### PR TITLE
Stop Claude focus event feedback loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and the request thread now share the child and terminate it at most once.
 - A failed cache rename no longer leaves its scratch file behind.
 
-- Throttled the Claude statusLine hook's sidebar publish to once every 30
-  seconds. Claude re-runs its statusLine command constantly, and the hook was
-  spawning six `herdr` subprocesses per tick — including a `report-metadata`
-  aimed at the pane Claude was painting into — taking most of a second, to
-  re-send percentages that change a few times an hour.
+- Removed the `pane.focused` refresh subscription and all Herdr calls from the
+  Claude statusLine hook. Together they could create a focus/metadata feedback
+  loop that repeatedly repainted and scrolled Claude panes under Herdr 0.8.
 
 ### Changed
 

--- a/docs/plans/herdr-agent-quota-implementation.md
+++ b/docs/plans/herdr-agent-quota-implementation.md
@@ -199,14 +199,15 @@ herdr-agent-quota agy-statusline
 Declare one-shot startup and event hooks in `herdr-plugin.toml`:
 
 - Startup: `refresh --provider all`.
-- Events: `pane.agent_detected`, `pane.agent_status_changed`, `pane.focused`, and
-  `pane.exited`.
+- Events: `pane.agent_detected`, `pane.agent_status_changed`, and `pane.exited`.
 - Manual action: force refresh all providers.
 
 Use a state-file timestamp and a cross-process lock to coalesce non-forced provider
 refreshes occurring within 60 seconds. A manual refresh bypasses the timestamp but
 still takes the lock. Do not subscribe to raw output or `pane.updated`; those events
-are too frequent for quota checks.
+are too frequent for quota checks. Do not subscribe to `pane.focused`: the refresh
+reads and reports pane metadata through Herdr, and Herdr 0.8 can emit more focus
+events for those commands, creating an event feedback loop.
 
 ### Snapshot model
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -32,11 +32,6 @@ on = "pane.agent_status_changed"
 command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" event"]
 
 [[events]]
-id = "agent-quota-focus-refresh"
-on = "pane.focused"
-command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" event"]
-
-[[events]]
 id = "agent-quota-exit-refresh"
 on = "pane.exited"
 command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" event"]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -97,22 +97,7 @@ impl CacheStore {
         now_unix: u64,
         interval_seconds: u64,
     ) -> Result<bool> {
-        self.should_debounce_key(provider.source(), now_unix, interval_seconds)
-    }
-
-    pub fn mark_refresh(&self, provider: Provider, now_unix: u64) -> Result<()> {
-        self.mark_key(provider.source(), now_unix)
-    }
-
-    /// Debounce anything that is not a provider refresh, such as the work the
-    /// Claude statusLine hook does on every tick.
-    pub fn should_debounce_key(
-        &self,
-        key: &str,
-        now_unix: u64,
-        interval_seconds: u64,
-    ) -> Result<bool> {
-        let Ok(contents) = fs::read_to_string(self.marker_path(key)) else {
+        let Ok(contents) = fs::read_to_string(self.refresh_marker_path(provider)) else {
             return Ok(false);
         };
         let Ok(last) = contents.trim().parse::<u64>() else {
@@ -121,9 +106,10 @@ impl CacheStore {
         Ok(now_unix.saturating_sub(last) < interval_seconds)
     }
 
-    pub fn mark_key(&self, key: &str, now_unix: u64) -> Result<()> {
+    pub fn mark_refresh(&self, provider: Provider, now_unix: u64) -> Result<()> {
         self.ensure()?;
-        fs::write(self.marker_path(key), now_unix.to_string()).context("write refresh marker")
+        fs::write(self.refresh_marker_path(provider), now_unix.to_string())
+            .context("write refresh marker")
     }
 
     pub fn now_unix() -> u64 {
@@ -144,8 +130,8 @@ impl CacheStore {
         self.root.join(format!("{}.json", provider.source()))
     }
 
-    fn marker_path(&self, key: &str) -> PathBuf {
-        self.root.join(format!("{key}.refresh"))
+    fn refresh_marker_path(&self, provider: Provider) -> PathBuf {
+        self.root.join(format!("{}.refresh", provider.source()))
     }
 }
 

--- a/src/configure/claude.rs
+++ b/src/configure/claude.rs
@@ -1,6 +1,5 @@
 use crate::cache::CacheStore;
-use crate::herdr::{list_agent_panes, publish_tokens};
-use crate::model::{MetadataTokens, Provider};
+use crate::model::Provider;
 use crate::providers::claude::run_statusline;
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -10,8 +9,6 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 const BACKUP_FILE: &str = "claude-statusline.original.json";
-const PUBLISH_MARKER: &str = "claude-statusline-publish";
-const PUBLISH_INTERVAL_SECONDS: u64 = 30;
 
 pub fn check() -> Result<()> {
     let path = settings_path()?;
@@ -113,11 +110,9 @@ pub fn run_statusline_hook() -> Result<()> {
     let snapshot = run_statusline(&input).ok();
     if let Some(snapshot) = &snapshot {
         if let Ok(cache) = CacheStore::from_env() {
-            // Saving is a single local file write, so it stays on every tick
-            // and keeps the cached quota current.
-            if cache.save(snapshot).is_ok() {
-                publish_throttled(&cache, snapshot);
-            }
+            // Keep the statusLine hook local and fast. Calling Herdr from this
+            // hook can feed pane events back into Claude while it is painting.
+            let _ = cache.save(snapshot);
         }
     }
     // Claude renders this hook's stdout as the status line. With nothing to
@@ -159,31 +154,6 @@ pub fn run_statusline_hook() -> Result<()> {
         std::process::exit(output.status.code().unwrap_or(1));
     }
     Ok(())
-}
-
-/// Push quota tokens to the sidebar, but at most once per interval.
-///
-/// Claude re-runs its statusLine command constantly, and this hook is that
-/// command. Publishing on every tick meant one `herdr agent list`, one
-/// `herdr pane read` per agent pane, and one `herdr pane report-metadata`
-/// aimed at the very pane Claude was painting into — six subprocesses and
-/// most of a second, several times a second, all to re-send percentages that
-/// change a few times an hour. Agent events publish on their own, so a stale
-/// window here costs nothing.
-fn publish_throttled(cache: &CacheStore, snapshot: &crate::model::ProviderSnapshot) {
-    let now = CacheStore::now_unix();
-    if cache
-        .should_debounce_key(PUBLISH_MARKER, now, PUBLISH_INTERVAL_SECONDS)
-        .unwrap_or(false)
-    {
-        return;
-    }
-    if cache.mark_key(PUBLISH_MARKER, now).is_err() {
-        return;
-    }
-    let panes = list_agent_panes().unwrap_or_default();
-    let tokens = [(Provider::Claude, MetadataTokens::from_snapshot(snapshot))];
-    let _ = publish_tokens(&panes, &tokens, CacheStore::now_millis());
 }
 
 fn can_chain_statusline(status_line: Option<&Value>) -> bool {

--- a/tests/plugin_manifest.rs
+++ b/tests/plugin_manifest.rs
@@ -1,0 +1,5 @@
+#[test]
+fn pane_focus_does_not_trigger_a_refresh_feedback_loop() {
+    let manifest = include_str!("../herdr-plugin.toml");
+    assert!(!manifest.contains("on = \"pane.focused\""));
+}


### PR DESCRIPTION
## What changed

- stop refreshing quota metadata on `pane.focused`
- make the Claude statusLine hook cache-only, with no synchronous Herdr subprocesses
- remove the now-unused generic debounce path
- add a manifest regression test that forbids the focus subscription

## Why

Herdr 0.8 can replay or emit bursts of focus events. The handler queried and
reported metadata for every pane, while Claude's statusLine hook also called
back into Herdr. That feedback path repeatedly repainted Claude panes and could
look like infinite terminal scrolling, especially with a multi-line statusline.

The remaining agent lifecycle events and manual refresh still publish cached
quota values, while Claude's high-frequency hook now performs only a local
cache write.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features --locked`
- `cargo build --release --locked`
- linked the updated plugin into Herdr 0.8.0 and verified no `pane.focused` hook is registered
- verified the Claude statusLine backup is empty and the wrapper emits its own single-line quota output
