### PR TITLE
fix: refresh quotas silently and catch external resets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and the request thread now share the child and terminate it at most once.
 - A failed cache rename no longer leaves its scratch file behind.
 
-- Removed the `pane.focused` refresh subscription and all Herdr calls from the
-  Claude statusLine hook. Together they could create a focus/metadata feedback
-  loop that repeatedly repainted and scrolled Claude panes under Herdr 0.8.
+- Removed the `pane.focused` refresh subscription, which could create a
+  focus/metadata feedback loop that repeatedly repainted and scrolled Claude
+  panes under Herdr 0.8. The Claude statusLine hook now republishes fresh quota
+  metadata through a 30-second marker so the sidebar does not stay blank.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and the request thread now share the child and terminate it at most once.
 - A failed cache rename no longer leaves its scratch file behind.
 
-- Removed the `pane.focused` refresh subscription, which could create a
-  focus/metadata feedback loop that repeatedly repainted and scrolled Claude
-  panes under Herdr 0.8. The Claude statusLine hook now republishes fresh quota
-  metadata through a 30-second marker so the sidebar does not stay blank.
+- Claude and Agy statusLine hooks now only update the local cache, so repainting
+  an agent's own status line cannot synchronously call back into Herdr or move
+  the terminal viewport. Metadata reports are skipped when every displayed
+  token is unchanged.
+- Restored a debounced `pane.focused` refresh after making metadata publication
+  idempotent. Returning from a browser reset now refetches Grok and Codex and
+  republishes changed Claude/Agy snapshots without recreating the old feedback
+  loop.
 
 ### Changed
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -32,6 +32,11 @@ on = "pane.agent_status_changed"
 command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" event"]
 
 [[events]]
+id = "agent-quota-focus-refresh"
+on = "pane.focused"
+command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" event"]
+
+[[events]]
 id = "agent-quota-exit-refresh"
 on = "pane.exited"
 command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" event"]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -97,16 +97,7 @@ impl CacheStore {
         now_unix: u64,
         interval_seconds: u64,
     ) -> Result<bool> {
-        self.should_debounce_key(provider.source(), now_unix, interval_seconds)
-    }
-
-    pub fn should_debounce_key(
-        &self,
-        key: &str,
-        now_unix: u64,
-        interval_seconds: u64,
-    ) -> Result<bool> {
-        let Ok(contents) = fs::read_to_string(self.marker_path(key)) else {
+        let Ok(contents) = fs::read_to_string(self.refresh_marker_path(provider)) else {
             return Ok(false);
         };
         let Ok(last) = contents.trim().parse::<u64>() else {
@@ -116,12 +107,9 @@ impl CacheStore {
     }
 
     pub fn mark_refresh(&self, provider: Provider, now_unix: u64) -> Result<()> {
-        self.mark_key(provider.source(), now_unix)
-    }
-
-    pub fn mark_key(&self, key: &str, now_unix: u64) -> Result<()> {
         self.ensure()?;
-        fs::write(self.marker_path(key), now_unix.to_string()).context("write refresh marker")
+        fs::write(self.refresh_marker_path(provider), now_unix.to_string())
+            .context("write refresh marker")
     }
 
     pub fn now_unix() -> u64 {
@@ -142,8 +130,8 @@ impl CacheStore {
         self.root.join(format!("{}.json", provider.source()))
     }
 
-    fn marker_path(&self, key: &str) -> PathBuf {
-        self.root.join(format!("{key}.refresh"))
+    fn refresh_marker_path(&self, provider: Provider) -> PathBuf {
+        self.root.join(format!("{}.refresh", provider.source()))
     }
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -97,7 +97,16 @@ impl CacheStore {
         now_unix: u64,
         interval_seconds: u64,
     ) -> Result<bool> {
-        let Ok(contents) = fs::read_to_string(self.refresh_marker_path(provider)) else {
+        self.should_debounce_key(provider.source(), now_unix, interval_seconds)
+    }
+
+    pub fn should_debounce_key(
+        &self,
+        key: &str,
+        now_unix: u64,
+        interval_seconds: u64,
+    ) -> Result<bool> {
+        let Ok(contents) = fs::read_to_string(self.marker_path(key)) else {
             return Ok(false);
         };
         let Ok(last) = contents.trim().parse::<u64>() else {
@@ -107,9 +116,12 @@ impl CacheStore {
     }
 
     pub fn mark_refresh(&self, provider: Provider, now_unix: u64) -> Result<()> {
+        self.mark_key(provider.source(), now_unix)
+    }
+
+    pub fn mark_key(&self, key: &str, now_unix: u64) -> Result<()> {
         self.ensure()?;
-        fs::write(self.refresh_marker_path(provider), now_unix.to_string())
-            .context("write refresh marker")
+        fs::write(self.marker_path(key), now_unix.to_string()).context("write refresh marker")
     }
 
     pub fn now_unix() -> u64 {
@@ -130,8 +142,8 @@ impl CacheStore {
         self.root.join(format!("{}.json", provider.source()))
     }
 
-    fn refresh_marker_path(&self, provider: Provider) -> PathBuf {
-        self.root.join(format!("{}.refresh", provider.source()))
+    fn marker_path(&self, key: &str) -> PathBuf {
+        self.root.join(format!("{key}.refresh"))
     }
 }
 

--- a/src/configure/agy.rs
+++ b/src/configure/agy.rs
@@ -1,7 +1,5 @@
 use crate::cache::CacheStore;
-use crate::herdr::{list_agent_panes, publish_tokens};
-use crate::model::Provider;
-use crate::presentation::{dashboard_summary, MetadataTokens};
+use crate::presentation::dashboard_summary;
 use crate::providers::agy::run_statusline;
 use anyhow::Result;
 use std::io::Read;
@@ -19,10 +17,7 @@ pub fn run_statusline_hook() -> Result<()> {
     };
     let cache = CacheStore::from_env()?;
     cache.save(&snapshot)?;
-    let panes = list_agent_panes().unwrap_or_default();
     let now = CacheStore::now_unix();
-    let tokens = [(Provider::Agy, MetadataTokens::from_snapshot(&snapshot, now))];
-    let _ = publish_tokens(&panes, &tokens, CacheStore::now_millis());
     println!("Agy | {}", dashboard_summary(&snapshot, now));
     Ok(())
 }

--- a/src/configure/claude.rs
+++ b/src/configure/claude.rs
@@ -1,7 +1,4 @@
 use crate::cache::CacheStore;
-use crate::herdr::{list_agent_panes, publish_tokens};
-use crate::model::Provider;
-use crate::presentation::MetadataTokens;
 use crate::providers::claude::run_statusline;
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -11,8 +8,6 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 const BACKUP_FILE: &str = "claude-statusline.original.json";
-const PUBLISH_MARKER: &str = "claude-statusline-publish";
-const PUBLISH_INTERVAL_SECONDS: u64 = 30;
 
 pub fn check() -> Result<()> {
     let path = settings_path()?;
@@ -114,12 +109,9 @@ pub fn run_statusline_hook() -> Result<()> {
     let snapshot = run_statusline(&input).ok();
     if let Some(snapshot) = &snapshot {
         if let Ok(cache) = CacheStore::from_env() {
-            // Saving is a single local file write, so it stays on every tick
-            // and keeps the cached quota current. Publishing is throttled
-            // separately because Claude re-runs this command frequently.
-            if cache.save(snapshot).is_ok() {
-                publish_throttled(&cache, snapshot);
-            }
+            // Keep this hook local and fast while Claude is painting its
+            // status line. Herdr events publish the cached snapshot.
+            let _ = cache.save(snapshot);
         }
     }
     // This hook exists to collect quota for Herdr. If the user did not have a
@@ -145,27 +137,6 @@ pub fn run_statusline_hook() -> Result<()> {
         std::process::exit(output.status.code().unwrap_or(1));
     }
     Ok(())
-}
-
-/// Push fresh quota to Herdr often enough for a live pane, without spawning
-/// Herdr subprocesses on every Claude statusLine tick.
-fn publish_throttled(cache: &CacheStore, snapshot: &crate::model::ProviderSnapshot) {
-    let now = CacheStore::now_unix();
-    if cache
-        .should_debounce_key(PUBLISH_MARKER, now, PUBLISH_INTERVAL_SECONDS)
-        .unwrap_or(false)
-    {
-        return;
-    }
-    if cache.mark_key(PUBLISH_MARKER, now).is_err() {
-        return;
-    }
-    let panes = list_agent_panes().unwrap_or_default();
-    let tokens = [(
-        Provider::Claude,
-        MetadataTokens::from_snapshot(snapshot, now),
-    )];
-    let _ = publish_tokens(&panes, &tokens, CacheStore::now_millis());
 }
 
 fn can_chain_statusline(status_line: Option<&Value>) -> bool {

--- a/src/configure/claude.rs
+++ b/src/configure/claude.rs
@@ -1,4 +1,7 @@
 use crate::cache::CacheStore;
+use crate::herdr::{list_agent_panes, publish_tokens};
+use crate::model::Provider;
+use crate::presentation::MetadataTokens;
 use crate::providers::claude::run_statusline;
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -8,6 +11,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 const BACKUP_FILE: &str = "claude-statusline.original.json";
+const PUBLISH_MARKER: &str = "claude-statusline-publish";
+const PUBLISH_INTERVAL_SECONDS: u64 = 30;
 
 pub fn check() -> Result<()> {
     let path = settings_path()?;
@@ -109,9 +114,12 @@ pub fn run_statusline_hook() -> Result<()> {
     let snapshot = run_statusline(&input).ok();
     if let Some(snapshot) = &snapshot {
         if let Ok(cache) = CacheStore::from_env() {
-            // Keep the statusLine hook local and fast. Calling Herdr from this
-            // hook can feed pane events back into Claude while it is painting.
-            let _ = cache.save(snapshot);
+            // Saving is a single local file write, so it stays on every tick
+            // and keeps the cached quota current. Publishing is throttled
+            // separately because Claude re-runs this command frequently.
+            if cache.save(snapshot).is_ok() {
+                publish_throttled(&cache, snapshot);
+            }
         }
     }
     // This hook exists to collect quota for Herdr. If the user did not have a
@@ -137,6 +145,27 @@ pub fn run_statusline_hook() -> Result<()> {
         std::process::exit(output.status.code().unwrap_or(1));
     }
     Ok(())
+}
+
+/// Push fresh quota to Herdr often enough for a live pane, without spawning
+/// Herdr subprocesses on every Claude statusLine tick.
+fn publish_throttled(cache: &CacheStore, snapshot: &crate::model::ProviderSnapshot) {
+    let now = CacheStore::now_unix();
+    if cache
+        .should_debounce_key(PUBLISH_MARKER, now, PUBLISH_INTERVAL_SECONDS)
+        .unwrap_or(false)
+    {
+        return;
+    }
+    if cache.mark_key(PUBLISH_MARKER, now).is_err() {
+        return;
+    }
+    let panes = list_agent_panes().unwrap_or_default();
+    let tokens = [(
+        Provider::Claude,
+        MetadataTokens::from_snapshot(snapshot, now),
+    )];
+    let _ = publish_tokens(&panes, &tokens, CacheStore::now_millis());
 }
 
 fn can_chain_statusline(status_line: Option<&Value>) -> bool {

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -2,15 +2,35 @@ use crate::model::Provider;
 use crate::presentation::MetadataTokens;
 use anyhow::{Context, Result};
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::process::Command;
 
 const METADATA_TTL_MS: &str = "86400000";
+const METADATA_TOKEN_NAMES: [&str; 16] = [
+    "quota_badge",
+    "quota_state",
+    "quota_icon",
+    "quota_provider",
+    "quota_status",
+    "quota_summary",
+    "quota_5h",
+    "quota_5h_normal",
+    "quota_5h_warning",
+    "quota_5h_danger",
+    "quota_week",
+    "quota_week_normal",
+    "quota_week_warning",
+    "quota_week_danger",
+    "quota_topic",
+    "quota_error",
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentPane {
     pub pane_id: String,
     pub provider: Provider,
     pub topic: String,
+    pub tokens: BTreeMap<String, String>,
 }
 
 pub fn list_agent_panes() -> Result<Vec<AgentPane>> {
@@ -52,6 +72,17 @@ fn collect_agent_panes(value: &Value, panes: &mut Vec<AgentPane>) {
                 });
             if let (Some(pane_id), Some(kind)) = (pane_id, kind) {
                 if let Ok(provider) = kind.parse::<Provider>() {
+                    let tokens = map
+                        .get("tokens")
+                        .and_then(Value::as_object)
+                        .into_iter()
+                        .flat_map(|tokens| tokens.iter())
+                        .filter_map(|(name, value)| {
+                            value
+                                .as_str()
+                                .map(|value| (name.clone(), value.to_string()))
+                        })
+                        .collect();
                     panes.push(AgentPane {
                         pane_id: pane_id.to_string(),
                         provider,
@@ -59,6 +90,7 @@ fn collect_agent_panes(value: &Value, panes: &mut Vec<AgentPane>) {
                         // current action (for example "Thinking"), not the
                         // user's request. Topic text comes only from prompts.
                         topic: String::new(),
+                        tokens,
                     });
                 }
             }
@@ -90,9 +122,13 @@ pub fn publish_tokens(
         else {
             continue;
         };
+        let topic = truncate_topic(&pane.topic);
+        let desired = desired_tokens(values, &topic);
+        if metadata_matches(&pane.tokens, &desired) {
+            continue;
+        }
         reported += 1;
         let mut command = Command::new(&executable);
-        let topic = truncate_topic(&pane.topic);
         command
             .args([
                 "pane",
@@ -102,38 +138,13 @@ pub fn publish_tokens(
                 "herdr-agent-quota",
             ])
             .args(["--seq", &sequence.to_string()])
-            .args(["--ttl-ms", METADATA_TTL_MS])
-            .args(["--token", &format!("quota_badge={}", values.quota_badge)])
-            .args(["--token", &format!("quota_state={}", values.quota_state)])
-            .args(["--token", &format!("quota_icon={}", values.quota_icon)])
-            .args([
-                "--token",
-                &format!("quota_provider={}", values.quota_provider),
-            ])
-            .args(["--token", &format!("quota_status={}", values.quota_status)])
-            .args([
-                "--token",
-                &format!("quota_summary={}", values.quota_summary),
-            ]);
-        set_optional_token(&mut command, "quota_5h", &values.quota_5h);
-        set_severity_token(
-            &mut command,
-            "quota_5h",
-            &values.quota_5h,
-            values.quota_5h_severity,
-        );
-        set_optional_token(&mut command, "quota_week", &values.quota_week);
-        set_severity_token(
-            &mut command,
-            "quota_week",
-            &values.quota_week,
-            values.quota_week_severity,
-        );
-        set_optional_token(&mut command, "quota_topic", &topic);
-        if let Some(error) = &values.quota_error {
-            command.args(["--token", &format!("quota_error={error}")]);
-        } else {
-            command.args(["--clear-token", "quota_error"]);
+            .args(["--ttl-ms", METADATA_TTL_MS]);
+        for name in METADATA_TOKEN_NAMES {
+            if let Some(value) = desired.get(name) {
+                command.args(["--token", &format!("{name}={value}")]);
+            } else {
+                command.args(["--clear-token", name]);
+            }
         }
         let output = command.output().context("report quota metadata to Herdr")?;
         if !output.status.success() {
@@ -152,33 +163,70 @@ pub fn publish_tokens(
     Ok(())
 }
 
-fn set_severity_token(
-    command: &mut Command,
+fn desired_tokens(values: &MetadataTokens, topic: &str) -> BTreeMap<String, String> {
+    let mut tokens = BTreeMap::from([
+        ("quota_badge".to_string(), values.quota_badge.clone()),
+        ("quota_state".to_string(), values.quota_state.clone()),
+        ("quota_icon".to_string(), values.quota_icon.clone()),
+        ("quota_provider".to_string(), values.quota_provider.clone()),
+        ("quota_status".to_string(), values.quota_status.clone()),
+        ("quota_summary".to_string(), values.quota_summary.clone()),
+    ]);
+    insert_optional_token(&mut tokens, "quota_5h", &values.quota_5h);
+    insert_severity_token(
+        &mut tokens,
+        "quota_5h",
+        &values.quota_5h,
+        values.quota_5h_severity,
+    );
+    insert_optional_token(&mut tokens, "quota_week", &values.quota_week);
+    insert_severity_token(
+        &mut tokens,
+        "quota_week",
+        &values.quota_week,
+        values.quota_week_severity,
+    );
+    insert_optional_token(&mut tokens, "quota_topic", topic);
+    if let Some(error) = &values.quota_error {
+        tokens.insert("quota_error".to_string(), error.clone());
+    }
+    tokens
+}
+
+fn metadata_matches(
+    current: &BTreeMap<String, String>,
+    desired: &BTreeMap<String, String>,
+) -> bool {
+    METADATA_TOKEN_NAMES
+        .into_iter()
+        .all(|name| current.get(name) == desired.get(name))
+}
+
+fn insert_severity_token(
+    tokens: &mut BTreeMap<String, String>,
     base: &str,
     value: &str,
     severity: Option<crate::model::Severity>,
 ) {
-    let variants = ["normal", "warning", "danger"];
-    for variant in variants {
-        command.args(["--clear-token", &format!("{base}_{variant}")]);
-    }
     if value.trim().is_empty() {
         return;
     }
-    let variant = match severity.unwrap_or(crate::model::Severity::Unknown) {
+    let variant = severity_variant(severity);
+    tokens.insert(format!("{base}_{variant}"), value.to_string());
+}
+
+fn severity_variant(severity: Option<crate::model::Severity>) -> &'static str {
+    match severity.unwrap_or(crate::model::Severity::Unknown) {
         crate::model::Severity::Warning => "warning",
         crate::model::Severity::Danger => "danger",
         crate::model::Severity::Normal => "normal",
         crate::model::Severity::Unknown => "warning",
-    };
-    command.args(["--token", &format!("{base}_{variant}={value}")]);
+    }
 }
 
-fn set_optional_token(command: &mut Command, name: &str, value: &str) {
-    if value.trim().is_empty() {
-        command.args(["--clear-token", name]);
-    } else {
-        command.args(["--token", &format!("{name}={value}")]);
+fn insert_optional_token(tokens: &mut BTreeMap<String, String>, name: &str, value: &str) {
+    if !value.trim().is_empty() {
+        tokens.insert(name.to_string(), value.to_string());
     }
 }
 
@@ -282,11 +330,13 @@ mod tests {
                     pane_id: "w1:p1".to_string(),
                     provider: Provider::Codex,
                     topic: String::new(),
+                    tokens: BTreeMap::new(),
                 },
                 AgentPane {
                     pane_id: "w1:p2".to_string(),
                     provider: Provider::Claude,
                     topic: String::new(),
+                    tokens: BTreeMap::new(),
                 },
             ]
         );
@@ -318,23 +368,19 @@ mod tests {
 
     #[test]
     fn publishes_exactly_one_styled_variant_for_each_window() {
-        let mut command = Command::new("herdr");
-        set_severity_token(
-            &mut command,
+        let mut tokens = BTreeMap::new();
+        insert_severity_token(
+            &mut tokens,
             "quota_week",
             "week 25% reset 2d3h",
             Some(crate::model::Severity::Warning),
         );
-        let args = command
-            .get_args()
-            .map(|arg| arg.to_string_lossy().into_owned())
-            .collect::<Vec<_>>();
-        assert!(args.contains(&"quota_week_normal".to_string()));
-        assert!(args.contains(&"quota_week_warning".to_string()));
-        assert!(args.contains(&"quota_week_danger".to_string()));
-        assert!(args.contains(&"quota_week_warning=week 25% reset 2d3h".to_string()));
-        assert!(!args.iter().any(|arg| arg.starts_with("quota_week_normal=")));
-        assert!(!args.iter().any(|arg| arg.starts_with("quota_week_danger=")));
+        assert_eq!(
+            tokens.get("quota_week_warning").map(String::as_str),
+            Some("week 25% reset 2d3h")
+        );
+        assert!(!tokens.contains_key("quota_week_normal"));
+        assert!(!tokens.contains_key("quota_week_danger"));
     }
 
     #[test]

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -1,5 +1,7 @@
 use herdr_agent_quota::configure::herdr::{add_quota_row, remove_quota_row};
+use std::fs;
 use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
 use std::process::{Command, Stdio};
 use tempfile::tempdir;
 
@@ -72,4 +74,43 @@ fn claude_collector_is_silent_without_a_previous_statusline() {
     let output = child.wait_with_output().unwrap();
     assert!(output.status.success());
     assert!(output.stdout.is_empty());
+}
+
+#[test]
+fn claude_collector_publishes_fresh_quota_to_herdr() {
+    let state = tempdir().unwrap();
+    let herdr_log = state.path().join("herdr.log");
+    let herdr_stub = state.path().join("herdr");
+    fs::write(
+        &herdr_stub,
+        format!(
+            "#!/bin/sh\nif [ \"$1 $2\" = \"agent list\" ]; then\n  printf '%s\\n' '{{\"result\":{{\"agents\":[{{\"agent\":\"claude\",\"pane_id\":\"w1:p1\"}}]}}}}'\nelif [ \"$1 $2\" = \"pane read\" ]; then\n  exit 0\nelif [ \"$1 $2\" = \"pane report-metadata\" ]; then\n  printf '%s\\n' \"$*\" >> '{}'\nfi\n",
+            herdr_log.display()
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&herdr_stub).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&herdr_stub, permissions).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_herdr-agent-quota"))
+        .arg("claude-statusline")
+        .env("HERDR_PLUGIN_STATE_DIR", state.path())
+        .env("HERDR_BIN_PATH", &herdr_stub)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(include_bytes!("fixtures/claude/statusline-both.json"))
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+
+    let report = fs::read_to_string(herdr_log).unwrap();
+    assert!(report.contains("quota_5h=5h 42% reset"));
+    assert!(report.contains("quota_week=week 73% reset"));
 }

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -2,8 +2,50 @@ use herdr_agent_quota::configure::herdr::{add_quota_row, remove_quota_row};
 use std::fs;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tempfile::tempdir;
+
+fn install_herdr_stub(state: &Path, agent_list: &str) -> (PathBuf, PathBuf) {
+    let log = state.join("herdr.log");
+    let executable = state.join("herdr");
+    fs::write(
+        &executable,
+        format!(
+            "#!/bin/sh\nif [ \"$1 $2\" = \"agent list\" ]; then\n  printf '%s\\n' '{}'\nelif [ \"$1 $2\" = \"pane read\" ]; then\n  exit 0\nelif [ \"$1 $2\" = \"pane report-metadata\" ]; then\n  printf '%s\\n' \"$*\" >> '{}'\nfi\n",
+            agent_list,
+            log.display()
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&executable).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&executable, permissions).unwrap();
+    (executable, log)
+}
+
+fn run_claude_collector(state: &Path, herdr: &Path, input: &[u8]) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_herdr-agent-quota"))
+        .arg("claude-statusline")
+        .env("HERDR_PLUGIN_STATE_DIR", state)
+        .env("HERDR_BIN_PATH", herdr)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(input).unwrap();
+    assert!(child.wait_with_output().unwrap().status.success());
+}
+
+fn run_claude_refresh(state: &Path, herdr: &Path) {
+    let output = Command::new(env!("CARGO_BIN_EXE_herdr-agent-quota"))
+        .args(["refresh", "--provider", "claude", "--force"])
+        .env("HERDR_PLUGIN_STATE_DIR", state)
+        .env("HERDR_BIN_PATH", herdr)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+}
 
 #[test]
 fn sidebar_configuration_is_idempotent_and_reversible() {
@@ -77,40 +119,42 @@ fn claude_collector_is_silent_without_a_previous_statusline() {
 }
 
 #[test]
-fn claude_collector_publishes_fresh_quota_to_herdr() {
+fn claude_cache_is_published_by_refresh_event() {
     let state = tempdir().unwrap();
-    let herdr_log = state.path().join("herdr.log");
-    let herdr_stub = state.path().join("herdr");
-    fs::write(
+    let (herdr_stub, herdr_log) = install_herdr_stub(
+        state.path(),
+        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1"}]}}"#,
+    );
+    run_claude_collector(
+        state.path(),
         &herdr_stub,
-        format!(
-            "#!/bin/sh\nif [ \"$1 $2\" = \"agent list\" ]; then\n  printf '%s\\n' '{{\"result\":{{\"agents\":[{{\"agent\":\"claude\",\"pane_id\":\"w1:p1\"}}]}}}}'\nelif [ \"$1 $2\" = \"pane read\" ]; then\n  exit 0\nelif [ \"$1 $2\" = \"pane report-metadata\" ]; then\n  printf '%s\\n' \"$*\" >> '{}'\nfi\n",
-            herdr_log.display()
-        ),
-    )
-    .unwrap();
-    let mut permissions = fs::metadata(&herdr_stub).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&herdr_stub, permissions).unwrap();
+        include_bytes!("fixtures/claude/statusline-both.json"),
+    );
+    assert!(!herdr_log.exists());
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_herdr-agent-quota"))
-        .arg("claude-statusline")
-        .env("HERDR_PLUGIN_STATE_DIR", state.path())
-        .env("HERDR_BIN_PATH", &herdr_stub)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .unwrap();
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(include_bytes!("fixtures/claude/statusline-both.json"))
-        .unwrap();
-    let output = child.wait_with_output().unwrap();
-    assert!(output.status.success());
-
+    run_claude_refresh(state.path(), &herdr_stub);
     let report = fs::read_to_string(herdr_log).unwrap();
     assert!(report.contains("quota_5h=5h 42% reset"));
     assert!(report.contains("quota_week=week 73% reset"));
+}
+
+#[test]
+fn claude_collector_does_not_republish_unchanged_quota() {
+    let state = tempdir().unwrap();
+    let (herdr_stub, herdr_log) = install_herdr_stub(
+        state.path(),
+        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1","tokens":{"quota_badge":"[A]","quota_state":"?","quota_icon":"✦Cl","quota_provider":"Claude","quota_status":"N/A","quota_5h":"5h 42%","quota_5h_warning":"5h 42%","quota_week":"week 73%","quota_week_warning":"week 73%","quota_summary":"5h 42% · week 73%"}}]}}"#,
+    );
+
+    let input = br#"{
+        "rate_limits": {
+            "five_hour": {"used_percentage": 58.0},
+            "seven_day": {"used_percentage": 27.0}
+        }
+    }"#;
+    run_claude_collector(state.path(), &herdr_stub, input);
+    assert!(!herdr_log.exists());
+
+    run_claude_refresh(state.path(), &herdr_stub);
+    assert!(!herdr_log.exists());
 }

--- a/tests/plugin_manifest.rs
+++ b/tests/plugin_manifest.rs
@@ -1,5 +1,5 @@
 #[test]
-fn pane_focus_does_not_trigger_a_refresh_feedback_loop() {
+fn pane_focus_refreshes_quota_that_changed_outside_herdr() {
     let manifest = include_str!("../herdr-plugin.toml");
-    assert!(!manifest.contains("on = \"pane.focused\""));
+    assert_eq!(manifest.matches("on = \"pane.focused\"").count(), 1);
 }


### PR DESCRIPTION
## Summary
- Keep Claude and Agy statusLine hooks local: they only update the cache and never call back into Herdr while the agent is painting.
- Compare the full desired token set with each pane and skip unchanged report-metadata calls.
- Restore a debounced pane.focused refresh so returning from a browser reset refetches Grok/Codex and republishes changed Claude/Agy snapshots.
- Add integration coverage for silent collection, changed-token publication, unchanged-token suppression, and focus refresh registration.

## Root cause
Publishing directly from Claude statusLine fixed missing quota tokens but synchronously called Herdr from the pane Claude was repainting, which could move the viewport. Removing focus refresh avoided the old feedback loop but also left provider changes made outside Herdr, such as a Grok web reset, stale until another agent event or manual action.

## User impact
StatusLine collection is now silent. Identical quota data causes no metadata write, while changed quota is picked up when the user returns to Herdr. Upward quota changes and reset grants are accepted just like normal usage changes.

## Validation
- cargo fmt --all -- --check
- cargo test --all-targets --all-features --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo build --release --locked
- Local Grok force refresh changed the cached remaining quota from 20% to 99% after the web reset.
- Local Claude statusLine replay left pane revision, state sequence, and scroll offset unchanged.
- Two identical refreshes left the second pane revision unchanged.
