### PR TITLE
fix: keep quota refresh manual and viewport-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   an agent's own status line cannot synchronously call back into Herdr or move
   the terminal viewport. Metadata reports are skipped when every displayed
   token is unchanged.
-- Restored a debounced `pane.focused` refresh after making metadata publication
-  idempotent. Returning from a browser reset now refetches Grok and Codex and
-  republishes changed Claude/Agy snapshots without recreating the old feedback
-  loop.
+- Focus changes no longer trigger quota collection, which prevents returning to
+  a pane from moving its terminal viewport. External quota resets are still
+  picked up by agent lifecycle events or the **Refresh agent quota** action.
 
 ### Changed
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -32,11 +32,6 @@ on = "pane.agent_status_changed"
 command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" event"]
 
 [[events]]
-id = "agent-quota-focus-refresh"
-on = "pane.focused"
-command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" event"]
-
-[[events]]
 id = "agent-quota-exit-refresh"
 on = "pane.exited"
 command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" event"]

--- a/tests/plugin_manifest.rs
+++ b/tests/plugin_manifest.rs
@@ -1,5 +1,5 @@
 #[test]
-fn pane_focus_refreshes_quota_that_changed_outside_herdr() {
+fn pane_focus_does_not_refresh_or_disturb_the_viewport() {
     let manifest = include_str!("../herdr-plugin.toml");
-    assert_eq!(manifest.matches("on = \"pane.focused\"").count(), 1);
+    assert!(!manifest.contains("on = \"pane.focused\""));
 }


### PR DESCRIPTION
## Summary
- remove the `pane.focused` quota refresh that moved the terminal viewport
- keep startup and agent lifecycle refresh paths
- bind `prefix+shift+r` to the existing force-refresh-all action when the key is free
- preserve user-owned conflicting keybindings and remove the managed binding on uninstall

## Evidence
The attached recording starts at 2026-08-16 02:28:44Z. Plugin logs show `pane.focused` refreshes at 02:28:46Z and 02:28:49Z, lasting 4.5–5.4 seconds.

Herdr plugin v1 does not expose native agent-group header button slots, so a plugin action keybinding is the stable one-step manual entry point.

## Verification
- `cargo fmt --check`
- `cargo test --locked --all-targets`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked --release`
- `herdr config check`
- invoked `herdr-agent-quota.refresh` locally; plugin log completed successfully
- relinked locally; registered events no longer include `pane.focused`