### PR TITLE
feat: add one-step manual quota refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Focus changes no longer trigger quota collection, which prevents returning to
   a pane from moving its terminal viewport. External quota resets are still
   picked up by agent lifecycle events or the **Refresh agent quota** action.
+- `configure --apply` now binds `prefix+shift+r` to the force-refresh action
+  when that key is free, while preserving an existing user-owned binding.
+  `configure --uninstall` removes only the plugin action binding.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,17 @@ That is the complete Herdr setup. `herdr plugin link .` builds the Rust binary
 and registers the startup/event hooks. `configure --apply` makes an idempotent
 per-window sidebar edit and installs a reversible Claude Code `statusLine`
 wrapper. You can run the same setup from Herdr's action menu with **Configure
-agent quota sidebar**. Use **Refresh agent quota** for a one-shot refresh.
+agent quota sidebar**. Use **Refresh agent quota** for a one-shot refresh, or
+press `prefix+shift+r` after configuration. The shortcut force-fetches Codex
+and Grok, then republishes the latest Claude and Agy statusLine snapshots. Run
+the same action from a shell with:
+
+```sh
+herdr plugin action invoke herdr-agent-quota.refresh
+```
+
+Herdr plugin v1 does not currently let plugins add buttons to the native agent
+group header, so the shortcut is the closest stable one-step entry point.
 
 Preview the changes without writing anything:
 

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use std::fs;
 use std::path::PathBuf;
-use toml_edit::{Array, DocumentMut, InlineTable, Item, Table, Value};
+use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Item, Table, Value};
 
 const QUOTA_ROW_MARKERS: [&str; 18] = [
     "$quota_badge",
@@ -25,6 +25,8 @@ const QUOTA_ROW_MARKERS: [&str; 18] = [
 ];
 const ROW_GAP_MARKER: &str = "herdr-agent-quota";
 const PROVIDER_STYLE_MARKER: &str = "herdr-agent-quota-provider";
+const REFRESH_KEY: &str = "prefix+shift+r";
+const REFRESH_ACTION: &str = "herdr-agent-quota.refresh";
 const QUOTA_SAFE_COLOR: &str = "#84b084";
 const QUOTA_WARNING_COLOR: &str = "#cdaa65";
 const QUOTA_DANGER_COLOR: &str = "#ca6470";
@@ -116,6 +118,7 @@ pub fn add_quota_row(input: &str) -> Result<String> {
             .parse::<DocumentMut>()
             .context("parse Herdr TOML config")?
     };
+    add_refresh_keybinding(&mut document)?;
     let agents = ensure_table(&mut document, &["ui", "sidebar", "agents"])?;
     if !agents.contains_key("row_gap") {
         let mut row_gap = Value::from(1);
@@ -155,6 +158,7 @@ pub fn remove_quota_row(input: &str) -> Result<String> {
     let mut document = input
         .parse::<DocumentMut>()
         .context("parse Herdr TOML config")?;
+    remove_refresh_keybinding(&mut document);
     let Some(agents) = document
         .get_mut("ui")
         .and_then(Item::as_table_mut)
@@ -163,7 +167,7 @@ pub fn remove_quota_row(input: &str) -> Result<String> {
         .and_then(|sidebar| sidebar.get_mut("agents"))
         .and_then(Item::as_table_mut)
     else {
-        return Ok(input.to_string());
+        return Ok(document.to_string());
     };
     remove_managed_provider_rows(agents);
     if let Some(rows) = agents.get_mut("rows").and_then(Item::as_array_mut) {
@@ -194,6 +198,61 @@ pub fn remove_quota_row(input: &str) -> Result<String> {
         agents.remove("row_gap");
     }
     Ok(document.to_string())
+}
+
+fn add_refresh_keybinding(document: &mut DocumentMut) -> Result<()> {
+    let keys = ensure_table(document, &["keys"])?;
+    let commands = keys
+        .entry("command")
+        .or_insert(Item::ArrayOfTables(ArrayOfTables::new()))
+        .as_array_of_tables_mut()
+        .context("Herdr keys.command must be an array of tables")?;
+    if commands
+        .iter()
+        .any(|command| command.get("command").and_then(Item::as_str) == Some(REFRESH_ACTION))
+        || commands
+            .iter()
+            .any(|command| command.get("key").and_then(Item::as_str) == Some(REFRESH_KEY))
+    {
+        return Ok(());
+    }
+
+    let mut command = Table::new();
+    command.insert("key", Item::Value(Value::from(REFRESH_KEY)));
+    command.insert("type", Item::Value(Value::from("plugin_action")));
+    command.insert("command", Item::Value(Value::from(REFRESH_ACTION)));
+    command.insert(
+        "description",
+        Item::Value(Value::from("refresh all agent quotas")),
+    );
+    commands.push(command);
+    Ok(())
+}
+
+fn remove_refresh_keybinding(document: &mut DocumentMut) {
+    let Some(keys) = document.get_mut("keys").and_then(Item::as_table_mut) else {
+        return;
+    };
+    let Some(commands) = keys
+        .get_mut("command")
+        .and_then(Item::as_array_of_tables_mut)
+    else {
+        return;
+    };
+    let mut retained = ArrayOfTables::new();
+    for command in commands.iter() {
+        if command.get("command").and_then(Item::as_str) != Some(REFRESH_ACTION) {
+            retained.push(command.clone());
+        }
+    }
+    if retained.is_empty() {
+        keys.remove("command");
+    } else {
+        keys["command"] = Item::ArrayOfTables(retained);
+    }
+    if keys.is_empty() {
+        document.remove("keys");
+    }
 }
 
 fn ensure_table<'a>(document: &'a mut DocumentMut, path: &[&str]) -> Result<&'a mut Table> {

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -51,7 +51,28 @@ fn run_claude_refresh(state: &Path, herdr: &Path) {
 fn sidebar_configuration_is_idempotent_and_reversible() {
     let original = "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n";
     let applied = add_quota_row(original).unwrap();
+    assert!(applied.contains("key = \"prefix+shift+r\""));
+    assert!(applied.contains("type = \"plugin_action\""));
+    assert!(applied.contains("command = \"herdr-agent-quota.refresh\""));
     assert_eq!(add_quota_row(&applied).unwrap(), applied);
+    assert_eq!(remove_quota_row(&applied).unwrap(), original);
+}
+
+#[test]
+fn sidebar_configuration_preserves_a_conflicting_refresh_key() {
+    let original = concat!(
+        "[[keys.command]]\n",
+        "key = \"prefix+shift+r\"\n",
+        "type = \"shell\"\n",
+        "command = \"echo user-owned\"\n",
+        "description = \"user refresh\"\n\n",
+        "[ui.sidebar.agents]\n",
+        "rows = [[\"state_icon\", \"agent\"]]\n"
+    );
+    let applied = add_quota_row(original).unwrap();
+    assert_eq!(applied.matches("key = \"prefix+shift+r\"").count(), 1);
+    assert!(applied.contains("command = \"echo user-owned\""));
+    assert!(!applied.contains("command = \"herdr-agent-quota.refresh\""));
     assert_eq!(remove_quota_row(&applied).unwrap(), original);
 }
 


### PR DESCRIPTION
## Summary
- bind `prefix+shift+r` to the existing force-refresh-all plugin action during configuration
- skip the binding when the key is already user-owned
- remove the managed action binding during uninstall
- document the action-menu and CLI invocation paths and the Herdr plugin UI limitation

## Behavior
The action force-fetches Codex and Grok and republishes the latest Claude/Agy statusLine snapshots. It is explicit and does not restore the viewport-moving `pane.focused` hook removed in #6.

## Verification
- `cargo fmt --check`
- `cargo test --locked --all-targets`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo build --locked --release`
- `herdr config check`
- invoked `herdr-agent-quota.refresh` locally; plugin log completed successfully