### PR TITLE
fix: make quota refresh silent and configuration reversible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `configure --apply` now binds `prefix+shift+r` to the force-refresh action
   when that key is free, while preserving an existing user-owned binding.
   `configure --uninstall` removes only the plugin action binding.
+- Grok turn completion now invokes a silent, provider-only refresh through its
+  official hook system. The refresh remains debounced to avoid request storms,
+  while manual refresh continues to bypass the debounce.
+- Quota-only refreshes no longer read every agent pane before publishing. They
+  preserve the last topic token, update the sidebar as soon as quota collection
+  finishes, and leave full topic extraction to agent lifecycle events.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Quota-only refreshes no longer read every agent pane before publishing. They
   preserve the last topic token, update the sidebar as soon as quota collection
   finishes, and leave full topic extraction to agent lifecycle events.
+- Agy's statusLine collector is now installed, repaired, chained, and removed
+  by the same configuration lifecycle as Claude's, and remains silent when no
+  user-owned status line existed.
+- Configuration actions now install or uninstall all plugin-owned integrations
+  in one pass and reload Herdr automatically. They also repair legacy
+  collectors that pointed at a different cache directory while preserving any
+  previous user statusLine backup.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ Preview the changes without writing anything:
 The setup preserves Herdr's native state dot and plane/tab label. It only adds
 the provider, usage, and topic tokens, so the original Herdr agent indicator is
 not removed. `configure --uninstall` removes the plugin-owned row and restores
-the previous Claude statusLine.
+the previous Claude statusLine. It also installs a silent global Grok `Stop`
+hook that schedules a debounced quota sync after completed, failed, or cancelled
+turns; uninstall removes only that plugin-owned hook file.
 
 ## Supported CLIs
 
@@ -115,7 +117,7 @@ the previous Claude statusLine.
 | --- | --- | --- | --- |
 | Claude Code `2.1.233` | `5h` + `week` | Official `statusLine` JSON: `rate_limits.five_hour` and `seven_day` | `configure --apply` chains an existing `statusLine` command |
 | OpenAI Codex `0.147.0` | `week` | One-shot local `codex app-server --stdio`, `account/rateLimits/read` | ChatGPT subscription login; API-key mode is shown as unavailable |
-| Grok CLI / Grok Build `1.0.3` | `week` | Local `~/.grok/auth.json` and the billing contract used by the official CLI | Log in to Grok CLI; no xAI team/API billing is queried |
+| Grok CLI / Grok Build `1.0.4` | `week` | Local `~/.grok/auth.json` and the billing contract used by the official CLI | `configure --apply` installs a silent per-turn refresh hook |
 | Agy / Antigravity CLI `1.1.13` | `5h` + `week` | Official `statusLine` JSON `quota` object (`gemini-*` and `3p-*` pools) | Set the native `/statusline` command once (below) |
 
 Versions above were checked on the development machine on 2026-08-15. The

--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ latest user prompt rather than an AI-generated status.*
 - **Never lies to you** — a failed refresh keeps the last good number instead
   of flashing `unavailable`, and API-key auth is never shown as a subscription
   quota.
-- **Fully reversible** — one command sets it up, one command puts your config
+- **Fully reversible** — one action sets it up, one action puts your config
   back exactly as it was.
 
-Install it in three commands ([quick start](#quick-start)):
+Install the plugin, then apply every reversible integration in one action
+([quick start](#quick-start)):
 
 ```sh
-herdr plugin link .
-./target/release/herdr-agent-quota configure --apply
-herdr server reload-config
+herdr plugin link . --enabled
+herdr plugin action invoke herdr-agent-quota.configure
 ```
 
 The screenshot is a real local Herdr session. The values and topic text are
@@ -77,16 +77,16 @@ Requirements: Herdr `0.8.0+`, Rust `1.95+`, macOS or Linux, and at least one
 supported CLI. From this repository:
 
 ```sh
-herdr plugin link .
-./target/release/herdr-agent-quota configure --apply
-herdr server reload-config
+herdr plugin link . --enabled
+herdr plugin action invoke herdr-agent-quota.configure
 ```
 
-That is the complete Herdr setup. `herdr plugin link .` builds the Rust binary
-and registers the startup/event hooks. `configure --apply` makes an idempotent
-per-window sidebar edit and installs a reversible Claude Code `statusLine`
-wrapper. You can run the same setup from Herdr's action menu with **Configure
-agent quota sidebar**. Use **Refresh agent quota** for a one-shot refresh, or
+That is the complete Herdr setup. The first command builds and enables the
+plugin. The second action consistently uses Herdr's plugin state, applies the
+sidebar rows, installs or repairs the reversible Claude and Agy statusLine
+collectors, installs the Grok turn hook, and reloads Herdr's config. You can run
+it again safely from Herdr's action menu as **Install / repair agent quota**.
+Use **Refresh agent quota** for a one-shot refresh, or
 press `prefix+shift+r` after configuration. The shortcut force-fetches Codex
 and Grok, then republishes the latest Claude and Agy statusLine snapshots. Run
 the same action from a shell with:
@@ -104,10 +104,22 @@ Preview the changes without writing anything:
 ./target/release/herdr-agent-quota configure --check
 ```
 
+Remove every plugin-owned config edit and restore previous Claude/Agy
+statusLine commands with the one-click **Uninstall agent quota configuration**
+action, or invoke it from a shell:
+
+```sh
+herdr plugin action invoke herdr-agent-quota.uninstall
+```
+
+After that action finishes, `herdr plugin unlink herdr-agent-quota` can remove
+the local plugin registration too. Configuration writes intentionally run
+through plugin actions so all collectors use the same Herdr state directory.
+
 The setup preserves Herdr's native state dot and plane/tab label. It only adds
 the provider, usage, and topic tokens, so the original Herdr agent indicator is
-not removed. `configure --uninstall` removes the plugin-owned row and restores
-the previous Claude statusLine. It also installs a silent global Grok `Stop`
+not removed. Uninstall removes the plugin-owned rows and restores previous
+Claude and Agy statusLine commands. Setup also installs a silent global Grok `Stop`
 hook that schedules a debounced quota sync after completed, failed, or cancelled
 turns; uninstall removes only that plugin-owned hook file.
 
@@ -115,10 +127,10 @@ turns; uninstall removes only that plugin-owned hook file.
 
 | CLI | Sidebar windows | Local collection path | Extra setup |
 | --- | --- | --- | --- |
-| Claude Code `2.1.233` | `5h` + `week` | Official `statusLine` JSON: `rate_limits.five_hour` and `seven_day` | `configure --apply` chains an existing `statusLine` command |
+| Claude Code `2.1.233` | `5h` + `week` | Official `statusLine` JSON: `rate_limits.five_hour` and `seven_day` | The configure action installs and chains it automatically |
 | OpenAI Codex `0.147.0` | `week` | One-shot local `codex app-server --stdio`, `account/rateLimits/read` | ChatGPT subscription login; API-key mode is shown as unavailable |
-| Grok CLI / Grok Build `1.0.4` | `week` | Local `~/.grok/auth.json` and the billing contract used by the official CLI | `configure --apply` installs a silent per-turn refresh hook |
-| Agy / Antigravity CLI `1.1.13` | `5h` + `week` | Official `statusLine` JSON `quota` object (`gemini-*` and `3p-*` pools) | Set the native `/statusline` command once (below) |
+| Grok CLI / Grok Build `1.0.4` | `week` | Local `~/.grok/auth.json` and the billing contract used by the official CLI | The configure action installs a silent per-turn refresh hook |
+| Agy / Antigravity CLI `1.1.13` | `5h` + `week` | Official `statusLine` JSON `quota` object (`gemini-*` and `3p-*` pools) | The configure action installs and chains it automatically |
 
 Versions above were checked on the development machine on 2026-08-15. The
 parser follows the provider fields rather than hard-coding these version
@@ -135,18 +147,14 @@ A failed refresh never replaces a successful cached value with `unavailable`;
 a provider without any successful snapshot is shown as `N/A` until its first
 usable event.
 
-## Agy / Antigravity setup
+## Agy / Antigravity collection
 
 Agy sends its quota snapshot to the plugin through its native one-shot
-`statusLine` hook. Set the command in Agy once:
-
-```text
-/statusline /absolute/path/to/herdr-agent-quota/target/release/herdr-agent-quota agy-statusline
-```
-
-The hook reads JSON from stdin, writes only sanitized percentages to the local
-plugin cache, and exits. It is not a resident process and does not use browser
-cookies or a private API.
+`statusLine` hook. The configure action installs it automatically, backs up and
+chains an existing command, and restores that command on uninstall. The plugin
+collector itself emits no status-line text: it reads JSON from stdin, writes
+only sanitized percentages to the local plugin cache, and exits. It is not a
+resident process and does not use browser cookies or a private API.
 
 ## What the sidebar rows mean
 
@@ -218,7 +226,7 @@ such as `Thinking` or `Executing`. It does not show the working directory.
   developer/API-team billing.
 - **Claude Code:** the official [`statusLine` JSON hook](https://code.claude.com/docs/en/statusline)
   supplies the five-hour and seven-day values. A previous statusLine command is
-  backed up, chained, and restored by `configure --uninstall`.
+  backed up, chained, and restored by the uninstall action.
 - **Agy/Antigravity:** the official [`/usage` and statusline docs](https://antigravity.google/docs/cli/commands/usage?app=antigravity-ide)
   supply Gemini and third-party pools. When both pools exist, the sidebar uses
   the lowest remaining percentage so the single Agy row is conservative.
@@ -239,7 +247,7 @@ weekly value instead of clearing the sidebar.
 | The rows do not appear | Run `herdr server reload-config`, then **Refresh agent quota**. |
 | Claude or Agy is `N/A` | Start a conversation so the native `statusLine` emits JSON; then refresh. |
 | Claude briefly changes while switching panes | The cached value is retained; run one prompt or a manual refresh if no snapshot exists yet. |
-| Agy has no quota | Confirm the native `/statusline` command points to the built `agy-statusline` hook. |
+| Agy has no quota | Run **Install / repair agent quota**, start one Agy turn, then manually refresh. |
 | The topic is blank or old | Send a prompt in that pane; topic extraction runs on agent events and needs recent output. |
 | Existing Claude statusLine is not changed | Run `configure --check`; the plugin refuses unsafe non-command settings instead of overwriting them. |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,14 +30,13 @@ Codex、Grok 显示周额度；每张 agent 卡片的话题来自用户最后一
   也不会写入或刷新凭证。
 - **不会给你错的数** —— 刷新失败时保留上一次的有效数值，而不是闪成
   `unavailable`；API key 登录也不会被当成订阅额度显示。
-- **完全可回滚** —— 一条命令装好，一条命令原样还原你的配置。
+- **完全可回滚** —— 一个 action 装好，一个 action 原样还原你的配置。
 
-三条命令即可安装（[快速开始](#快速开始)）：
+链接插件后，用一个 action 批量安装所有可恢复的集成（[快速开始](#快速开始)）：
 
 ```sh
-herdr plugin link .
-./target/release/herdr-agent-quota configure --apply
-herdr server reload-config
+herdr plugin link . --enabled
+herdr plugin action invoke herdr-agent-quota.configure
 ```
 
 截图是真实的 Herdr 本地会话。其中的额度和话题来自当时的会话，
@@ -70,18 +69,15 @@ herdr server reload-config
 CLI。在仓库目录执行：
 
 ```sh
-herdr plugin link .
-./target/release/herdr-agent-quota configure --apply
-herdr server reload-config
+herdr plugin link . --enabled
+herdr plugin action invoke herdr-agent-quota.configure
 ```
 
-以上就是完整的 Herdr 配置流程：
-
-- `herdr plugin link .` 构建 Rust 二进制并注册启动/事件钩子。
-- `configure --apply` 幂等地写入按额度窗口分行的 sidebar 配置，并安装可恢复的
-  Claude Code `statusLine` 包装器。
-- 也可以在 Herdr action 菜单中执行 **Configure agent quota sidebar**。
-- 需要手动刷新时执行 **Refresh agent quota**。
+以上就是完整配置流程。第一条命令构建并启用插件；第二个 action 会统一使用
+Herdr 的插件 state 目录，批量写入 sidebar 行、安装或修复可恢复的 Claude/Agy
+statusLine 采集器、安装 Grok turn hook，并自动 reload 配置。之后可随时在 Herdr
+action 菜单执行 **Install / repair agent quota**，重复执行也是安全的。需要手动
+刷新时执行 **Refresh agent quota**。
 
 只查看配置变更、不写入文件：
 
@@ -89,19 +85,29 @@ herdr server reload-config
 ./target/release/herdr-agent-quota configure --check
 ```
 
+要一次撤销所有插件配置并恢复原来的 Claude/Agy statusLine，可在 action 菜单
+执行 **Uninstall agent quota configuration**，或运行：
+
+```sh
+herdr plugin action invoke herdr-agent-quota.uninstall
+```
+
+action 完成后，如需连插件注册也删除，再执行
+`herdr plugin unlink herdr-agent-quota`。写配置刻意只通过插件 action 进行，
+避免采集器写到另一份缓存目录。
+
 插件会保留 Herdr 原生的状态圆点和 plane/tab 提示，只追加 provider、
-usage、topic 三类 token，不会覆盖官方 agent 指示。执行
-`configure --uninstall` 可以删除插件添加的行，并恢复原来的 Claude
-`statusLine`。
+usage、topic 三类 token，不会覆盖官方 agent 指示。卸载 action 会删除插件
+添加的行，并恢复原来的 Claude/Agy `statusLine`。
 
 ## 支持的 CLI
 
 | CLI | 侧栏显示 | 本地数据来源 | 额外配置 |
 | --- | --- | --- | --- |
-| Claude Code `2.1.233` | `5h` + `week` | 官方 `statusLine` JSON：`rate_limits.five_hour`、`seven_day` | `configure --apply` 会串联已有 `statusLine` 命令 |
+| Claude Code `2.1.233` | `5h` + `week` | 官方 `statusLine` JSON：`rate_limits.five_hour`、`seven_day` | 配置 action 自动安装并串联原命令 |
 | OpenAI Codex `0.147.0` | `week` | 一次性的 `codex app-server --stdio`，调用 `account/rateLimits/read` | 使用 ChatGPT 订阅登录；API key 模式显示为不可用 |
 | Grok CLI / Grok Build `1.0.3` | `week` | `~/.grok/auth.json` 和官方 CLI 使用的额度接口 | 登录 Grok CLI；不会读取 xAI team/API 账单 |
-| Agy / Antigravity CLI `1.1.13` | `5h` + `week` | 官方 `statusLine` JSON 的 `quota`（`gemini-*`、`3p-*`） | 需要一次性设置原生 `/statusline` 命令 |
+| Agy / Antigravity CLI `1.1.13` | `5h` + `week` | 官方 `statusLine` JSON 的 `quota`（`gemini-*`、`3p-*`） | 配置 action 自动安装并串联原命令 |
 
 上面的版本是 2026-08-15 在开发机上实际检查的版本。解析器按照供应商的
 字段工作，不会把这些版本号写死；兼容的新版本可以继续使用。
@@ -121,17 +127,13 @@ Codex 和 Grok 提供周额度；Claude Code 和 Agy 提供 5 小时额度与周
 刷新失败时，插件会保留上一次成功的缓存值，不会把旧值清空为
 `unavailable`。从未成功采集过的 provider 才会显示 `N/A`。
 
-## Agy / Antigravity 配置
+## Agy / Antigravity 采集
 
-Agy 通过原生的一次性 `statusLine` hook 把额度 JSON 传给插件。在 Agy 中
-设置一次：
-
-```text
-/statusline /absolute/path/to/herdr-agent-quota/target/release/herdr-agent-quota agy-statusline
-```
-
-该 hook 从 stdin 读取 JSON，只把脱敏后的百分比写入本地插件缓存，然后退出。
-它不是常驻进程，也不使用浏览器 Cookie 或私有 API。
+Agy 通过原生的一次性 `statusLine` hook 把额度 JSON 传给插件。配置 action
+会自动安装它；如果用户原来已有 statusLine 命令，会先备份并串联，卸载时恢复。
+插件自己的采集器不输出任何 status-line 文本，只从 stdin 读取 JSON，把脱敏后的
+百分比写入本地插件缓存，然后退出。它不是常驻进程，也不使用浏览器 Cookie 或
+私有 API。
 
 ## 侧栏布局
 
@@ -196,7 +198,7 @@ Herdr plugin v1 只支持文本 token，不能由插件向原生 Agent renderer 
 - **Claude Code：** 使用官方
   [`statusLine` JSON hook](https://code.claude.com/docs/en/statusline) 提供
   5 小时和 7 天额度。原有 statusLine 会被备份、串联，并可由
-  `configure --uninstall` 恢复。
+  卸载 action 恢复。
 - **Agy/Antigravity：** 使用官方
   [`/usage` 和 statusline 文档](https://antigravity.google/docs/cli/commands/usage?app=antigravity-ide)
   中的 Gemini 和第三方额度池。两个额度池同时存在时，取较低的剩余百分比，
@@ -216,7 +218,7 @@ Grok CLI 的额度接口属于 CLI 内部契约，不是 xAI 面向开发者的�
 | 侧栏没有新增行 | 执行 `herdr server reload-config`，再运行 **Refresh agent quota**。 |
 | Claude 或 Agy 显示 `N/A` | 发起一次对话，让原生 `statusLine` 产生 JSON，然后刷新。 |
 | 切换 pane 时 Claude 短暂变化 | 已有缓存会保留；如果还没有快照，发送一次 prompt 或手动刷新。 |
-| Agy 没有额度 | 确认原生 `/statusline` 命令指向编译好的 `agy-statusline` hook。 |
+| Agy 没有额度 | 执行 **Install / repair agent quota**，完成一次 Agy 对话后再手动刷新。 |
 | 话题为空或没有更新 | 在该 pane 发送 prompt；话题提取依赖 agent 事件和最近输出。 |
 | 原有 Claude statusLine 没有被修改 | 执行 `configure --check`；对于不能安全串联的配置，插件会拒绝覆盖。 |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,8 +14,10 @@ Useful context when judging impact:
 - **Reads** `~/.grok/auth.json` (login key only), Claude Code and Agy
   statusLine JSON on stdin, and the local `codex app-server` JSON-RPC socket.
 - **Writes** sanitized percentages to Herdr's plugin state directory,
-  `~/.config/herdr/config.toml`, and `~/.claude/settings.json`. The last two
-  are backed up and restored by `configure --uninstall`.
+  `~/.config/herdr/config.toml`, `~/.claude/settings.json`,
+  `~/.gemini/antigravity-cli/settings.json`, and one plugin-owned file under
+  `~/.grok/hooks`. User-owned statusLine values are backed up and restored by
+  the uninstall action; the Grok hook file is never shared with user content.
 - **Sends** one authenticated request to the Grok CLI billing endpoint. This is
   the only outbound network call in the project. No usage data is uploaded
   anywhere.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -23,8 +23,13 @@ command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quo
 
 [[actions]]
 id = "configure"
-title = "Configure agent quota sidebar"
-command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" configure --apply"]
+title = "Install / repair agent quota"
+command = ["sh", "-c", "\"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" configure --apply && herdr server reload-config"]
+
+[[actions]]
+id = "uninstall"
+title = "Uninstall agent quota configuration"
+command = ["sh", "-c", "\"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" configure --uninstall && herdr server reload-config"]
 
 [[events]]
 id = "agent-quota-refresh"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -17,6 +17,11 @@ title = "Refresh agent quota"
 command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" refresh --provider all --force"]
 
 [[actions]]
+id = "refresh-grok"
+title = "Sync Grok quota after turn"
+command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" refresh --provider grok"]
+
+[[actions]]
 id = "configure"
 title = "Configure agent quota sidebar"
 command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" configure --apply"]

--- a/scripts/agy-statusline.sh
+++ b/scripts/agy-statusline.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-set -eu
-
-script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-exec "$script_dir/../target/release/herdr-agent-quota" agy-statusline

--- a/src/configure/agy.rs
+++ b/src/configure/agy.rs
@@ -1,23 +1,79 @@
+use super::statusline::{settings_path, Adapter};
 use crate::cache::CacheStore;
-use crate::presentation::dashboard_summary;
 use crate::providers::agy::run_statusline;
-use anyhow::Result;
-use std::io::Read;
+use anyhow::{Context, Result};
+use std::io::{Read, Write};
+use std::path::Path;
+use std::process::{Command, Stdio};
 
-/// Consume one Agy statusLine JSON payload and update the local snapshot.
-///
-/// Agy's native `/statusline` command is user-configured, so this hook is
-/// intentionally one-shot: it never starts a background process or contacts
-/// an external API.
+const CONFIG: Adapter = Adapter {
+    label: "Agy",
+    subcommand: "agy-statusline",
+    backup_file: "agy-statusline.original.json",
+};
+
+pub fn check() -> Result<()> {
+    CONFIG.check(&settings_path(
+        "AGY_SETTINGS_FILE",
+        ".gemini/antigravity-cli/settings.json",
+    )?)
+}
+
+pub fn apply() -> Result<()> {
+    let cache = CacheStore::from_env()?;
+    let executable = std::env::current_exe().context("resolve plugin executable")?;
+    apply_at(
+        &settings_path("AGY_SETTINGS_FILE", ".gemini/antigravity-cli/settings.json")?,
+        cache.root(),
+        &executable,
+    )
+}
+
+pub fn uninstall() -> Result<()> {
+    let cache = CacheStore::from_env()?;
+    uninstall_at(
+        &settings_path("AGY_SETTINGS_FILE", ".gemini/antigravity-cli/settings.json")?,
+        cache.root(),
+    )
+}
+
+pub fn apply_at(settings: &Path, state: &Path, executable: &Path) -> Result<()> {
+    CONFIG.apply(settings, state, executable)
+}
+
+pub fn uninstall_at(settings: &Path, state: &Path) -> Result<()> {
+    CONFIG.uninstall(settings, state)
+}
+
+/// Consume one Agy statusLine payload, cache quota silently, then preserve a
+/// user-owned statusLine command when one existed before installation.
 pub fn run_statusline_hook() -> Result<()> {
     let mut input = Vec::new();
     std::io::stdin().read_to_end(&mut input)?;
-    let Ok(snapshot) = run_statusline(&input) else {
+    if let Ok(snapshot) = run_statusline(&input) {
+        if let Ok(cache) = CacheStore::from_env() {
+            let _ = cache.save(&snapshot);
+        }
+    }
+    let cache = CacheStore::from_env()?;
+    let Some(command) = CONFIG.previous_command(cache.root())? else {
         return Ok(());
     };
-    let cache = CacheStore::from_env()?;
-    cache.save(&snapshot)?;
-    let now = CacheStore::now_unix();
-    println!("Agy | {}", dashboard_summary(&snapshot, now));
+    let mut child = Command::new("sh")
+        .args(["-c", &command])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .context("run previous Agy statusLine")?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(&input)?;
+    }
+    let output = child.wait_with_output()?;
+    std::io::stdout().write_all(&output.stdout)?;
+    std::io::stdout().flush()?;
+    if !output.status.success() {
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
     Ok(())
 }

--- a/src/configure/claude.rs
+++ b/src/configure/claude.rs
@@ -1,123 +1,60 @@
+use super::statusline::{settings_path, Adapter};
 use crate::cache::CacheStore;
 use crate::providers::claude::run_statusline;
 use anyhow::{Context, Result};
-use serde_json::{json, Value};
-use std::fs;
 use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Command, Stdio};
 
-const BACKUP_FILE: &str = "claude-statusline.original.json";
+const CONFIG: Adapter = Adapter {
+    label: "Claude",
+    subcommand: "claude-statusline",
+    backup_file: "claude-statusline.original.json",
+};
 
 pub fn check() -> Result<()> {
-    let path = settings_path()?;
-    let settings = read_settings(&path)?;
-    if is_installed(settings.get("statusLine")) {
-        println!(
-            "Claude statusLine wrapper is already installed: {}",
-            path.display()
-        );
-    } else {
-        println!(
-            "Claude statusLine preview for {}: install a reversible quota wrapper",
-            path.display()
-        );
-    }
-    Ok(())
+    CONFIG.check(&settings_path(
+        "CLAUDE_SETTINGS_FILE",
+        ".claude/settings.json",
+    )?)
 }
 
 pub fn apply() -> Result<()> {
-    let path = settings_path()?;
-    let mut settings = read_settings(&path)?;
-    if is_installed(settings.get("statusLine")) {
-        return Ok(());
-    }
-    if !can_chain_statusline(settings.get("statusLine")) {
-        anyhow::bail!(
-            "existing Claude statusLine has no safely chainable command; refusing to replace it"
-        );
-    }
     let cache = CacheStore::from_env()?;
-    cache.ensure()?;
-    let backup = cache.root().join(BACKUP_FILE);
-    if !backup.exists() {
-        let original = settings.get("statusLine").cloned().unwrap_or(Value::Null);
-        fs::write(&backup, serde_json::to_vec_pretty(&original)?)
-            .context("write Claude statusLine backup")?;
-    }
     let executable = std::env::current_exe().context("resolve plugin executable")?;
-    let wrapper_command = format!(
-        "HERDR_PLUGIN_STATE_DIR={} {} claude-statusline",
-        shell_quote(cache.root()),
-        shell_quote(&executable)
-    );
-    let status_line = settings
-        .get_mut("statusLine")
-        .and_then(Value::as_object_mut)
-        .map(|object| {
-            object.insert("type".to_string(), Value::String("command".to_string()));
-            object.insert(
-                "command".to_string(),
-                Value::String(wrapper_command.clone()),
-            );
-            Value::Object(object.clone())
-        })
-        .unwrap_or_else(|| {
-            json!({
-                "type": "command",
-                "command": wrapper_command,
-            })
-        });
-    settings["statusLine"] = status_line;
-    write_settings(&path, &settings)
+    apply_at(
+        &settings_path("CLAUDE_SETTINGS_FILE", ".claude/settings.json")?,
+        cache.root(),
+        &executable,
+    )
 }
 
 pub fn uninstall() -> Result<()> {
-    let path = settings_path()?;
-    if !path.exists() {
-        return Ok(());
-    }
-    let mut settings = read_settings(&path)?;
-    if !is_installed(settings.get("statusLine")) {
-        return Ok(());
-    }
     let cache = CacheStore::from_env()?;
-    let backup = cache.root().join(BACKUP_FILE);
-    let original: Value = if backup.exists() {
-        serde_json::from_slice(&fs::read(&backup)?)?
-    } else {
-        Value::Null
-    };
-    if original.is_null() {
-        settings
-            .as_object_mut()
-            .context("Claude settings must be an object")?
-            .remove("statusLine");
-    } else {
-        settings["statusLine"] = original;
-    }
-    write_settings(&path, &settings)?;
-    if backup.exists() {
-        fs::remove_file(backup).context("remove Claude statusLine backup")?;
-    }
-    Ok(())
+    uninstall_at(
+        &settings_path("CLAUDE_SETTINGS_FILE", ".claude/settings.json")?,
+        cache.root(),
+    )
+}
+
+pub fn apply_at(settings: &Path, state: &Path, executable: &Path) -> Result<()> {
+    CONFIG.apply(settings, state, executable)
+}
+
+pub fn uninstall_at(settings: &Path, state: &Path) -> Result<()> {
+    CONFIG.uninstall(settings, state)
 }
 
 pub fn run_statusline_hook() -> Result<()> {
     let mut input = Vec::new();
     std::io::stdin().read_to_end(&mut input)?;
-    let snapshot = run_statusline(&input).ok();
-    if let Some(snapshot) = &snapshot {
+    if let Ok(snapshot) = run_statusline(&input) {
         if let Ok(cache) = CacheStore::from_env() {
-            // Keep this hook local and fast while Claude is painting its
-            // status line. Herdr events publish the cached snapshot.
-            let _ = cache.save(snapshot);
+            let _ = cache.save(&snapshot);
         }
     }
-    // This hook exists to collect quota for Herdr. If the user did not have a
-    // statusLine before installation, keep stdout empty so Claude has no
-    // plugin-owned line to repaint after every interaction.
-    let Some(command) = previous_statusline_command()? else {
+    let cache = CacheStore::from_env()?;
+    let Some(command) = CONFIG.previous_command(cache.root())? else {
         return Ok(());
     };
     let mut child = Command::new("sh")
@@ -137,135 +74,4 @@ pub fn run_statusline_hook() -> Result<()> {
         std::process::exit(output.status.code().unwrap_or(1));
     }
     Ok(())
-}
-
-fn can_chain_statusline(status_line: Option<&Value>) -> bool {
-    match status_line {
-        None | Some(Value::Null) | Some(Value::String(_)) => true,
-        Some(Value::Object(map)) => map
-            .get("command")
-            .and_then(Value::as_str)
-            .is_some_and(|command| !command.trim().is_empty()),
-        Some(_) => false,
-    }
-}
-
-fn previous_statusline_command() -> Result<Option<String>> {
-    let cache = CacheStore::from_env()?;
-    let backup = cache.root().join(BACKUP_FILE);
-    if !backup.exists() {
-        return Ok(None);
-    }
-    let value: Value = serde_json::from_slice(&fs::read(backup)?)?;
-    Ok(match value {
-        Value::String(command) => Some(command),
-        Value::Object(map) => map
-            .get("command")
-            .and_then(Value::as_str)
-            .map(str::to_string),
-        _ => None,
-    })
-}
-
-fn settings_path() -> Result<PathBuf> {
-    if let Some(path) = std::env::var_os("CLAUDE_SETTINGS_FILE") {
-        return Ok(PathBuf::from(path));
-    }
-    let home = std::env::var_os("HOME").context("HOME is not set")?;
-    Ok(PathBuf::from(home).join(".claude/settings.json"))
-}
-
-fn read_settings(path: &Path) -> Result<Value> {
-    if !path.exists() {
-        return Ok(json!({}));
-    }
-    let value: Value = serde_json::from_slice(&fs::read(path).context("read Claude settings")?)
-        .context("parse Claude settings")?;
-    if !value.is_object() {
-        anyhow::bail!("Claude settings must be a JSON object")
-    }
-    Ok(value)
-}
-
-fn write_settings(path: &Path, settings: &Value) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).context("create Claude settings directory")?;
-    }
-    let temporary = path.with_extension("json.herdr-agent-quota.tmp");
-    fs::write(&temporary, serde_json::to_vec_pretty(settings)?)?;
-    fs::rename(temporary, path).context("replace Claude settings")
-}
-
-fn is_installed(status_line: Option<&Value>) -> bool {
-    status_line
-        .and_then(|value| value.get("command"))
-        .and_then(Value::as_str)
-        .map(|command| {
-            command.contains("herdr-agent-quota") && command.contains("claude-statusline")
-        })
-        .unwrap_or(false)
-}
-
-fn shell_quote(path: &Path) -> String {
-    format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::tempdir;
-
-    #[test]
-    fn detects_wrapper_without_touching_other_statusline_shapes() {
-        assert!(is_installed(Some(&json!({
-            "type": "command",
-            "command": "/tmp/herdr-agent-quota claude-statusline"
-        }))));
-        assert!(!is_installed(Some(&json!("echo original"))));
-    }
-
-    #[test]
-    fn settings_round_trip_preserves_unrelated_keys() {
-        let directory = tempdir().unwrap();
-        let path = directory.path().join("settings.json");
-        fs::write(&path, r#"{"theme":"dark","statusLine":"echo old"}"#).unwrap();
-        let mut settings = read_settings(&path).unwrap();
-        settings["statusLine"] =
-            json!({"type":"command","command":"/tmp/herdr-agent-quota claude-statusline"});
-        write_settings(&path, &settings).unwrap();
-        let saved = read_settings(&path).unwrap();
-        assert_eq!(saved["theme"], "dark");
-        assert!(is_installed(saved.get("statusLine")));
-    }
-
-    #[test]
-    fn wrapper_replacement_keeps_existing_statusline_options() {
-        let directory = tempdir().unwrap();
-        let path = directory.path().join("settings.json");
-        fs::write(
-            &path,
-            r#"{"statusLine":{"type":"command","command":"echo old","refreshInterval":5}}"#,
-        )
-        .unwrap();
-        let mut settings = read_settings(&path).unwrap();
-        let object = settings["statusLine"].as_object_mut().unwrap();
-        object.insert(
-            "command".to_string(),
-            Value::String("/tmp/herdr-agent-quota claude-statusline".to_string()),
-        );
-        write_settings(&path, &settings).unwrap();
-        let saved = read_settings(&path).unwrap();
-        assert_eq!(saved["statusLine"]["refreshInterval"], 5);
-    }
-
-    #[test]
-    fn refuses_statusline_shapes_that_cannot_be_chained() {
-        assert!(can_chain_statusline(Some(&json!("echo old"))));
-        assert!(can_chain_statusline(Some(&json!({
-            "type": "command",
-            "command": "echo old"
-        }))));
-        assert!(!can_chain_statusline(Some(&json!({"type": "prompt"}))));
-        assert!(!can_chain_statusline(Some(&json!(["echo old"]))));
-    }
 }

--- a/src/configure/grok.rs
+++ b/src/configure/grok.rs
@@ -1,0 +1,95 @@
+use anyhow::{Context, Result};
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const HOOK_FILE: &str = "herdr-agent-quota.json";
+const REFRESH_ACTION: &str = "herdr-agent-quota.refresh-grok";
+
+pub fn check() -> Result<()> {
+    let path = hook_path()?;
+    if is_managed_hook(&path) {
+        println!("Grok quota hook is already installed: {}", path.display());
+    } else {
+        println!(
+            "Grok quota hook preview for {}: refresh after each turn",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+pub fn apply() -> Result<()> {
+    apply_at(&hook_path()?)
+}
+
+pub fn uninstall() -> Result<()> {
+    uninstall_at(&hook_path()?)
+}
+
+pub fn apply_at(path: &Path) -> Result<()> {
+    let desired = hook_document();
+    if path.exists() {
+        let current = fs::read_to_string(path).context("read Grok quota hook")?;
+        if current == desired {
+            return Ok(());
+        }
+        if !current.contains(REFRESH_ACTION) {
+            anyhow::bail!(
+                "refusing to replace user-owned Grok hook file {}",
+                path.display()
+            );
+        }
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).context("create Grok hooks directory")?;
+    }
+    let temporary = path.with_extension("json.herdr-agent-quota.tmp");
+    fs::write(&temporary, desired).context("write Grok quota hook")?;
+    fs::rename(&temporary, path).context("replace Grok quota hook")?;
+    println!(
+        "Installed silent Grok turn refresh hook at {}",
+        path.display()
+    );
+    Ok(())
+}
+
+pub fn uninstall_at(path: &Path) -> Result<()> {
+    if is_managed_hook(path) {
+        fs::remove_file(path).context("remove Grok quota hook")?;
+        println!("Removed Grok quota hook from {}", path.display());
+    }
+    Ok(())
+}
+
+fn hook_path() -> Result<PathBuf> {
+    if let Some(home) = std::env::var_os("GROK_HOME") {
+        return Ok(PathBuf::from(home).join("hooks").join(HOOK_FILE));
+    }
+    let home = std::env::var_os("HOME").context("HOME is not set")?;
+    Ok(PathBuf::from(home).join(".grok/hooks").join(HOOK_FILE))
+}
+
+fn is_managed_hook(path: &Path) -> bool {
+    fs::read_to_string(path).is_ok_and(|contents| contents.contains(REFRESH_ACTION))
+}
+
+fn hook_document() -> String {
+    let command = format!("herdr plugin action invoke {REFRESH_ACTION} >/dev/null 2>&1");
+    let handler = json!({
+        "hooks": [{
+            "type": "command",
+            "command": command,
+            "timeout": 3
+        }]
+    });
+    serde_json::to_string_pretty(&json!({
+        "hooks": {
+            "Stop": [handler.clone()],
+            "StopFailure": [handler.clone()],
+            "StopCancelled": [handler]
+        }
+    }))
+    .expect("serialize static Grok hook")
+        + "\n"
+}

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -2,22 +2,31 @@ pub mod agy;
 pub mod claude;
 pub mod grok;
 pub mod herdr;
+mod statusline;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 /// `--check` is also the no-flag default, so it needs no branch of its own.
 pub fn run(_check: bool, apply: bool, uninstall: bool) -> Result<()> {
+    if apply || uninstall {
+        std::env::var_os("HERDR_PLUGIN_STATE_DIR").context(
+            "configuration writes must run through Herdr so every collector uses the same cache; invoke herdr-agent-quota.configure or herdr-agent-quota.uninstall",
+        )?;
+    }
     if uninstall {
         grok::uninstall()?;
+        agy::uninstall()?;
         claude::uninstall()?;
         herdr::uninstall()?;
     } else if apply {
         herdr::apply()?;
         claude::apply()?;
+        agy::apply()?;
         grok::apply()?;
     } else {
         herdr::check()?;
         claude::check()?;
+        agy::check()?;
         grok::check()?;
     }
     Ok(())

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -1,5 +1,6 @@
 pub mod agy;
 pub mod claude;
+pub mod grok;
 pub mod herdr;
 
 use anyhow::Result;
@@ -7,14 +8,17 @@ use anyhow::Result;
 /// `--check` is also the no-flag default, so it needs no branch of its own.
 pub fn run(_check: bool, apply: bool, uninstall: bool) -> Result<()> {
     if uninstall {
+        grok::uninstall()?;
         claude::uninstall()?;
         herdr::uninstall()?;
     } else if apply {
         herdr::apply()?;
         claude::apply()?;
+        grok::apply()?;
     } else {
         herdr::check()?;
         claude::check()?;
+        grok::check()?;
     }
     Ok(())
 }

--- a/src/configure/statusline.rs
+++ b/src/configure/statusline.rs
@@ -1,0 +1,196 @@
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub(crate) struct Adapter {
+    pub label: &'static str,
+    pub subcommand: &'static str,
+    pub backup_file: &'static str,
+}
+
+impl Adapter {
+    pub fn check(&self, path: &Path) -> Result<()> {
+        let settings = read_settings(path, self.label)?;
+        if self.is_installed(settings.get("statusLine")) {
+            println!(
+                "{} statusLine collector is installed: {}",
+                self.label,
+                path.display()
+            );
+        } else {
+            println!(
+                "{} statusLine preview for {}: install a reversible, silent quota collector",
+                self.label,
+                path.display()
+            );
+        }
+        Ok(())
+    }
+
+    pub fn apply(&self, path: &Path, state: &Path, executable: &Path) -> Result<()> {
+        let mut settings = read_settings(path, self.label)?;
+        let installed = self.is_installed(settings.get("statusLine"));
+        if !installed && !can_chain_statusline(settings.get("statusLine")) {
+            anyhow::bail!(
+                "existing {} statusLine has no safely chainable command; refusing to replace it",
+                self.label
+            );
+        }
+        fs::create_dir_all(state).context("create plugin state directory")?;
+        let backup = state.join(self.backup_file);
+        if !backup.exists() {
+            let original = if installed {
+                self.previous_backup_from_wrapper(settings.get("statusLine"))?
+                    .unwrap_or(Value::Null)
+            } else {
+                settings.get("statusLine").cloned().unwrap_or(Value::Null)
+            };
+            fs::write(&backup, serde_json::to_vec_pretty(&original)?)
+                .with_context(|| format!("write {} statusLine backup", self.label))?;
+        }
+        let wrapper_command = format!(
+            "HERDR_PLUGIN_STATE_DIR={} {} {}",
+            shell_quote(state),
+            shell_quote(executable),
+            self.subcommand
+        );
+        let status_line = settings
+            .get_mut("statusLine")
+            .and_then(Value::as_object_mut)
+            .map(|object| {
+                object.insert("type".to_string(), Value::String("command".to_string()));
+                object.insert(
+                    "command".to_string(),
+                    Value::String(wrapper_command.clone()),
+                );
+                Value::Object(object.clone())
+            })
+            .unwrap_or_else(|| json!({"type": "command", "command": wrapper_command}));
+        settings["statusLine"] = status_line;
+        write_settings(path, &settings, self.label)
+    }
+
+    pub fn uninstall(&self, path: &Path, state: &Path) -> Result<()> {
+        if !path.exists() {
+            return Ok(());
+        }
+        let mut settings = read_settings(path, self.label)?;
+        if !self.is_installed(settings.get("statusLine")) {
+            return Ok(());
+        }
+        let backup = state.join(self.backup_file);
+        let original: Value = if backup.exists() {
+            serde_json::from_slice(&fs::read(&backup)?)?
+        } else {
+            Value::Null
+        };
+        if original.is_null() {
+            settings
+                .as_object_mut()
+                .with_context(|| format!("{} settings must be an object", self.label))?
+                .remove("statusLine");
+        } else {
+            settings["statusLine"] = original;
+        }
+        write_settings(path, &settings, self.label)?;
+        if backup.exists() {
+            fs::remove_file(backup)
+                .with_context(|| format!("remove {} statusLine backup", self.label))?;
+        }
+        Ok(())
+    }
+
+    pub fn previous_command(&self, state: &Path) -> Result<Option<String>> {
+        let backup = state.join(self.backup_file);
+        if !backup.exists() {
+            return Ok(None);
+        }
+        let value: Value = serde_json::from_slice(&fs::read(backup)?)?;
+        Ok(match value {
+            Value::String(command) => Some(command),
+            Value::Object(map) => map
+                .get("command")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            _ => None,
+        })
+    }
+
+    fn is_installed(&self, status_line: Option<&Value>) -> bool {
+        status_line
+            .and_then(|value| value.get("command"))
+            .and_then(Value::as_str)
+            .is_some_and(|command| {
+                command.contains(self.subcommand)
+                    && (command.contains("herdr-agent-quota")
+                        || command.contains("agy-statusline.sh"))
+            })
+    }
+
+    fn previous_backup_from_wrapper(&self, status_line: Option<&Value>) -> Result<Option<Value>> {
+        let Some(command) = status_line
+            .and_then(|value| value.get("command"))
+            .and_then(Value::as_str)
+        else {
+            return Ok(None);
+        };
+        let Some(rest) = command.strip_prefix("HERDR_PLUGIN_STATE_DIR='") else {
+            return Ok(None);
+        };
+        let Some((old_state, _)) = rest.split_once("' ") else {
+            return Ok(None);
+        };
+        let backup = Path::new(old_state).join(self.backup_file);
+        if !backup.exists() {
+            return Ok(None);
+        }
+        let value = serde_json::from_slice(&fs::read(backup)?)?;
+        Ok(Some(value))
+    }
+}
+
+fn can_chain_statusline(status_line: Option<&Value>) -> bool {
+    match status_line {
+        None | Some(Value::Null) | Some(Value::String(_)) => true,
+        Some(Value::Object(map)) => map
+            .get("command")
+            .and_then(Value::as_str)
+            .is_some_and(|command| !command.trim().is_empty()),
+        Some(_) => false,
+    }
+}
+
+pub(crate) fn settings_path(environment: &str, relative: &str) -> Result<PathBuf> {
+    if let Some(path) = std::env::var_os(environment) {
+        return Ok(PathBuf::from(path));
+    }
+    let home = std::env::var_os("HOME").context("HOME is not set")?;
+    Ok(PathBuf::from(home).join(relative))
+}
+
+fn read_settings(path: &Path, label: &str) -> Result<Value> {
+    if !path.exists() {
+        return Ok(json!({}));
+    }
+    let value: Value =
+        serde_json::from_slice(&fs::read(path).with_context(|| format!("read {label} settings"))?)
+            .with_context(|| format!("parse {label} settings"))?;
+    if !value.is_object() {
+        anyhow::bail!("{label} settings must be a JSON object")
+    }
+    Ok(value)
+}
+
+fn write_settings(path: &Path, settings: &Value, label: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {label} settings directory"))?;
+    }
+    let temporary = path.with_extension("json.herdr-agent-quota.tmp");
+    fs::write(&temporary, serde_json::to_vec_pretty(settings)?)?;
+    fs::rename(temporary, path).with_context(|| format!("replace {label} settings"))
+}
+
+fn shell_quote(path: &Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
+}

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -47,6 +47,12 @@ pub fn list_agent_panes() -> Result<Vec<AgentPane>> {
     collect_agent_panes(&value, &mut panes);
     panes.sort_by(|left, right| left.pane_id.cmp(&right.pane_id));
     panes.dedup_by(|left, right| left.pane_id == right.pane_id);
+    Ok(panes)
+}
+
+pub fn list_agent_panes_with_topics() -> Result<Vec<AgentPane>> {
+    let executable = std::env::var_os("HERDR_BIN_PATH").unwrap_or_else(|| "herdr".into());
+    let mut panes = list_agent_panes()?;
     for pane in &mut panes {
         pane.topic = read_pane_topic(&executable, pane).unwrap_or_default();
     }
@@ -72,7 +78,7 @@ fn collect_agent_panes(value: &Value, panes: &mut Vec<AgentPane>) {
                 });
             if let (Some(pane_id), Some(kind)) = (pane_id, kind) {
                 if let Ok(provider) = kind.parse::<Provider>() {
-                    let tokens = map
+                    let tokens: BTreeMap<String, String> = map
                         .get("tokens")
                         .and_then(Value::as_object)
                         .into_iter()
@@ -83,13 +89,13 @@ fn collect_agent_panes(value: &Value, panes: &mut Vec<AgentPane>) {
                                 .map(|value| (name.clone(), value.to_string()))
                         })
                         .collect();
+                    let topic = tokens.get("quota_topic").cloned().unwrap_or_default();
                     panes.push(AgentPane {
                         pane_id: pane_id.to_string(),
                         provider,
-                        // Native terminal titles often describe the agent's
-                        // current action (for example "Thinking"), not the
-                        // user's request. Topic text comes only from prompts.
-                        topic: String::new(),
+                        // Preserve the last published topic during quota-only
+                        // refreshes. Agent events refresh it from pane output.
+                        topic,
                         tokens,
                     });
                 }
@@ -340,6 +346,18 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn quota_only_discovery_preserves_the_last_published_topic() {
+        let value = json!({"result": {"agents": [{
+            "pane_id": "w1:p1",
+            "agent": "grok",
+            "tokens": {"quota_topic": "latest task"}
+        }]}});
+        let mut panes = Vec::new();
+        collect_agent_panes(&value, &mut panes);
+        assert_eq!(panes[0].topic, "latest task");
     }
 
     #[test]

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -1,5 +1,5 @@
 use crate::cache::CacheStore;
-use crate::herdr::{list_agent_panes, publish_tokens};
+use crate::herdr::{list_agent_panes, list_agent_panes_with_topics, publish_tokens};
 use crate::model::Provider;
 use crate::presentation::MetadataTokens;
 use crate::providers::{codex, grok};
@@ -15,9 +15,21 @@ pub struct ProviderOutcome {
 }
 
 pub fn run(providers: &[Provider], force: bool, json: bool) -> Result<()> {
+    run_internal(providers, force, json, false)
+}
+
+fn run_internal(
+    providers: &[Provider],
+    force: bool,
+    json: bool,
+    refresh_topics: bool,
+) -> Result<()> {
     let cache = CacheStore::from_env()?;
     let outcomes = cache.with_lock(|| refresh_locked(&cache, providers, force))?;
-    publish(&cache, providers)?;
+    publish(&cache, providers, false)?;
+    if refresh_topics {
+        publish(&cache, providers, true)?;
+    }
     if json {
         println!("{}", serde_json::to_string_pretty(&outcomes)?);
     }
@@ -25,7 +37,7 @@ pub fn run(providers: &[Provider], force: bool, json: bool) -> Result<()> {
 }
 
 pub fn event() -> Result<()> {
-    run(&Provider::ALL, false, false)
+    run_internal(&Provider::ALL, false, false, true)
 }
 
 fn refresh_locked(
@@ -85,8 +97,13 @@ fn refresh_locked(
     Ok(outcomes)
 }
 
-fn publish(cache: &CacheStore, providers: &[Provider]) -> Result<()> {
-    let panes = list_agent_panes().unwrap_or_default();
+fn publish(cache: &CacheStore, providers: &[Provider], refresh_topics: bool) -> Result<()> {
+    let panes = if refresh_topics {
+        list_agent_panes_with_topics()
+    } else {
+        list_agent_panes()
+    }
+    .unwrap_or_default();
     let mut tokens = Vec::new();
     let now = CacheStore::now_unix();
     for provider in providers {

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -141,6 +141,27 @@ fn claude_collector_is_silent_without_a_previous_statusline() {
 }
 
 #[test]
+fn agy_collector_is_silent_without_a_previous_statusline() {
+    let state = tempdir().unwrap();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_herdr-agent-quota"))
+        .arg("agy-statusline")
+        .env("HERDR_PLUGIN_STATE_DIR", state.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(include_bytes!("fixtures/agy/statusline-both.json"))
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
 fn claude_cache_is_published_by_refresh_event() {
     let state = tempdir().unwrap();
     let (herdr_stub, herdr_log) = install_herdr_stub(

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -12,8 +12,9 @@ fn install_herdr_stub(state: &Path, agent_list: &str) -> (PathBuf, PathBuf) {
     fs::write(
         &executable,
         format!(
-            "#!/bin/sh\nif [ \"$1 $2\" = \"agent list\" ]; then\n  printf '%s\\n' '{}'\nelif [ \"$1 $2\" = \"pane read\" ]; then\n  exit 0\nelif [ \"$1 $2\" = \"pane report-metadata\" ]; then\n  printf '%s\\n' \"$*\" >> '{}'\nfi\n",
+            "#!/bin/sh\nif [ \"$1 $2\" = \"agent list\" ]; then\n  printf '%s\\n' '{}'\nelif [ \"$1 $2\" = \"pane read\" ]; then\n  printf '%s\\n' \"$*\" >> '{}'\nelif [ \"$1 $2\" = \"pane report-metadata\" ]; then\n  printf '%s\\n' \"$*\" >> '{}'\nfi\n",
             agent_list,
+            log.display(),
             log.display()
         ),
     )
@@ -155,6 +156,7 @@ fn claude_cache_is_published_by_refresh_event() {
 
     run_claude_refresh(state.path(), &herdr_stub);
     let report = fs::read_to_string(herdr_log).unwrap();
+    assert!(!report.contains("pane read"));
     assert!(report.contains("quota_5h=5h 42% reset"));
     assert!(report.contains("quota_week=week 73% reset"));
 }

--- a/tests/grok_hook_config.rs
+++ b/tests/grok_hook_config.rs
@@ -1,0 +1,33 @@
+use herdr_agent_quota::configure::grok::{apply_at, uninstall_at};
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn grok_turn_hook_refreshes_quota_silently_and_is_reversible() {
+    let directory = tempdir().unwrap();
+    let path = directory.path().join("herdr-agent-quota.json");
+
+    apply_at(&path).unwrap();
+    let installed = fs::read_to_string(&path).unwrap();
+    assert!(installed.contains("\"Stop\""));
+    assert!(installed.contains("\"StopFailure\""));
+    assert!(installed.contains("\"StopCancelled\""));
+    assert!(installed.contains("herdr-agent-quota.refresh-grok"));
+    assert!(installed.contains(">/dev/null 2>&1"));
+
+    apply_at(&path).unwrap();
+    assert_eq!(fs::read_to_string(&path).unwrap(), installed);
+
+    uninstall_at(&path).unwrap();
+    assert!(!path.exists());
+}
+
+#[test]
+fn grok_hook_uninstall_preserves_a_user_owned_file() {
+    let directory = tempdir().unwrap();
+    let path = directory.path().join("herdr-agent-quota.json");
+    fs::write(&path, "{\"hooks\":{\"Stop\":[]}}").unwrap();
+
+    uninstall_at(&path).unwrap();
+    assert!(path.exists());
+}

--- a/tests/plugin_manifest.rs
+++ b/tests/plugin_manifest.rs
@@ -3,3 +3,12 @@ fn pane_focus_does_not_refresh_or_disturb_the_viewport() {
     let manifest = include_str!("../herdr-plugin.toml");
     assert!(!manifest.contains("on = \"pane.focused\""));
 }
+
+#[test]
+fn plugin_exposes_one_click_configure_and_uninstall_actions() {
+    let manifest = include_str!("../herdr-plugin.toml");
+    assert!(manifest.contains("id = \"configure\""));
+    assert!(manifest.contains("configure --apply"));
+    assert!(manifest.contains("id = \"uninstall\""));
+    assert!(manifest.contains("configure --uninstall"));
+}

--- a/tests/statusline_config.rs
+++ b/tests/statusline_config.rs
@@ -1,0 +1,97 @@
+use herdr_agent_quota::configure::{agy, claude};
+use serde_json::Value;
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+#[test]
+fn agy_setup_is_idempotent_and_restores_the_previous_statusline() {
+    let directory = tempdir().unwrap();
+    let settings = directory.path().join("settings.json");
+    let state = directory.path().join("state");
+    let executable = directory.path().join("herdr-agent-quota");
+    fs::write(
+        &settings,
+        r#"{"theme":"dark","statusLine":{"type":"command","command":"echo old","refreshInterval":5}}"#,
+    )
+    .unwrap();
+
+    agy::apply_at(&settings, &state, &executable).unwrap();
+    let once = fs::read(&settings).unwrap();
+    agy::apply_at(&settings, &state, &executable).unwrap();
+    assert_eq!(fs::read(&settings).unwrap(), once);
+
+    let installed: Value = serde_json::from_slice(&once).unwrap();
+    assert_eq!(installed["theme"], "dark");
+    assert_eq!(installed["statusLine"]["refreshInterval"], 5);
+    let command = installed["statusLine"]["command"].as_str().unwrap();
+    assert!(command.contains("agy-statusline"));
+    assert!(command.contains(state.to_str().unwrap()));
+
+    agy::uninstall_at(&settings, &state).unwrap();
+    let restored: Value = serde_json::from_slice(&fs::read(&settings).unwrap()).unwrap();
+    assert_eq!(restored["statusLine"]["command"], "echo old");
+    assert_eq!(restored["statusLine"]["refreshInterval"], 5);
+}
+
+#[test]
+fn old_plugin_wrappers_are_repaired_without_becoming_the_backup() {
+    let directory = tempdir().unwrap();
+    let settings = directory.path().join("settings.json");
+    let state = directory.path().join("state");
+    let executable = directory.path().join("herdr-agent-quota");
+    fs::write(
+        &settings,
+        r#"{"statusLine":{"type":"command","command":"HERDR_PLUGIN_STATE_DIR='/wrong' '/old/herdr-agent-quota' claude-statusline"}}"#,
+    )
+    .unwrap();
+
+    claude::apply_at(&settings, &state, &executable).unwrap();
+    let installed: Value = serde_json::from_slice(&fs::read(&settings).unwrap()).unwrap();
+    let command = installed["statusLine"]["command"].as_str().unwrap();
+    assert!(command.contains(state.to_str().unwrap()));
+    assert!(!command.contains("/wrong"));
+
+    claude::uninstall_at(&settings, &state).unwrap();
+    let restored: Value = serde_json::from_slice(&fs::read(&settings).unwrap()).unwrap();
+    assert!(restored.get("statusLine").is_none());
+}
+
+#[test]
+fn repair_migrates_a_previous_backup_from_the_old_state_directory() {
+    let directory = tempdir().unwrap();
+    let settings = directory.path().join("settings.json");
+    let old_state = directory.path().join("old-state");
+    let state = directory.path().join("state");
+    let executable = directory.path().join("herdr-agent-quota");
+    fs::create_dir_all(&old_state).unwrap();
+    fs::write(
+        old_state.join("claude-statusline.original.json"),
+        r#"{"type":"command","command":"echo user-owned"}"#,
+    )
+    .unwrap();
+    fs::write(
+        &settings,
+        format!(
+            r#"{{"statusLine":{{"type":"command","command":"HERDR_PLUGIN_STATE_DIR='{}' '/old/herdr-agent-quota' claude-statusline"}}}}"#,
+            old_state.display()
+        ),
+    )
+    .unwrap();
+
+    claude::apply_at(&settings, &state, &executable).unwrap();
+    claude::uninstall_at(&settings, &state).unwrap();
+    let restored: Value = serde_json::from_slice(&fs::read(&settings).unwrap()).unwrap();
+    assert_eq!(restored["statusLine"]["command"], "echo user-owned");
+}
+
+#[test]
+fn direct_configuration_write_refuses_an_ambiguous_cache_directory() {
+    let output = Command::new(env!("CARGO_BIN_EXE_herdr-agent-quota"))
+        .args(["configure", "--apply"])
+        .env_remove("HERDR_PLUGIN_STATE_DIR")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("must run through Herdr"));
+}


### PR DESCRIPTION
## What changed

- refresh Grok quota silently after each completed, failed, or cancelled turn
- keep quota-only refreshes from reading panes, preserving terminal scroll position
- install a manual force-refresh action and prefix+shift+r binding
- install and repair Claude/Agy statusLine collectors through one shared reversible lifecycle
- add one-click install/repair and uninstall actions that reload Herdr automatically
- document the complete trigger model and remove the manual Agy wrapper setup

## Root causes

Grok quota could remain stale because Herdr status changes do not occur after every Grok turn. Quota refreshes also performed unnecessary pane reads, which could disturb the viewport. Claude/Agy collectors configured outside Herdr could write to a fallback cache directory, and Agy still required a manual visible statusLine command.

## User impact

Quota updates are silent and do not run on pane focus. Grok notices turn-level and provider-side resets on the next turn, while the force-refresh action remains available for immediate checks. Claude and Agy use their official statusLine payloads without adding plugin-owned status text. Existing user statusLine commands are chained and restored on uninstall; the existing Codex notify setting is untouched.

## Validation

- cargo test --all-targets
- cargo clippy --all-targets -- -D warnings
- cargo build --release
- local Herdr install/repair action and config reload succeeded
- local Claude/Agy commands now share the Herdr plugin state directory
- local Grok refresh completed without pane reads or scroll changes