### PR TITLE
fix: refresh quota during active work without scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `configure --apply` now binds `prefix+shift+r` to the force-refresh action
   when that key is free, while preserving an existing user-owned binding.
   `configure --uninstall` removes only the plugin action binding.
-- Grok turn completion now invokes a silent, provider-only refresh through its
-  official hook system. The refresh remains debounced to avoid request storms,
-  while manual refresh continues to bypass the debounce.
+- Grok now invokes a silent, provider-only refresh directly from `PostToolUse`
+  during long-running turns, with turn-end hooks covering final, failed, and
+  cancelled replies. It no longer routes these refreshes through a Herdr action,
+  and remains debounced to avoid request storms.
 - Quota-only refreshes no longer read every agent pane before publishing. They
   preserve the last topic token, update the sidebar as soon as quota collection
   finishes, and leave full topic extraction to agent lifecycle events.
@@ -55,6 +56,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   in one pass and reload Herdr automatically. They also repair legacy
   collectors that pointed at a different cache directory while preserving any
   previous user statusLine backup.
+- Metadata publication now skips panes whose viewport is in scrollback, so a
+  Herdr repaint cannot pull the user back to the bottom. The next refresh after
+  returning to the bottom catches the sidebar up.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   interaction. Existing custom status lines are still chained unchanged.
 - A pane that exits between `herdr agent list` and the metadata report no
   longer aborts the whole publish, so the remaining live panes still update.
-  This was reachable in normal use, because `pane.exited` itself triggers a
-  publish.
 - Closed a race in the Codex app-server watchdog that could signal an unrelated
   process after the child had been reaped and its pid recycled. The watchdog
   and the request thread now share the child and terminate it at most once.
@@ -39,6 +37,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Focus changes now use a dedicated provider-only, 60-second-debounced refresh.
   This path never reads pane content or refreshes topics, and metadata writes
   remain suppressed while the selected pane is in scrollback.
+- Agent detection and status events now refresh and read topics only for the
+  affected provider. Pane exit no longer starts a refresh after its metadata
+  consumer is already gone; incomplete event payloads still fall back to all
+  providers.
 - `configure --apply` now binds `prefix+shift+r` to the force-refresh action
   when that key is free, while preserving an existing user-owned binding.
   `configure --uninstall` removes only the plugin action binding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   an agent's own status line cannot synchronously call back into Herdr or move
   the terminal viewport. Metadata reports are skipped when every displayed
   token is unchanged.
-- Focus changes no longer trigger quota collection, which prevents returning to
-  a pane from moving its terminal viewport. External quota resets are still
-  picked up by agent lifecycle events or the **Refresh agent quota** action.
+- Focus changes now use a dedicated provider-only, 60-second-debounced refresh.
+  This path never reads pane content or refreshes topics, and metadata writes
+  remain suppressed while the selected pane is in scrollback.
 - `configure --apply` now binds `prefix+shift+r` to the force-refresh action
   when that key is free, while preserving an existing user-owned binding.
   `configure --uninstall` removes only the plugin action binding.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ herdr plugin action invoke herdr-agent-quota.configure
 That is the complete Herdr setup. The first command builds and enables the
 plugin. The second action consistently uses Herdr's plugin state, applies the
 sidebar rows, installs or repairs the reversible Claude and Agy statusLine
-collectors, installs the Grok turn hook, and reloads Herdr's config. You can run
+collectors, installs the Grok response hook, and reloads Herdr's config. You can run
 it again safely from Herdr's action menu as **Install / repair agent quota**.
 Use **Refresh agent quota** for a one-shot refresh, or
 press `prefix+shift+r` after configuration. The shortcut force-fetches Codex
@@ -119,9 +119,12 @@ through plugin actions so all collectors use the same Herdr state directory.
 The setup preserves Herdr's native state dot and plane/tab label. It only adds
 the provider, usage, and topic tokens, so the original Herdr agent indicator is
 not removed. Uninstall removes the plugin-owned rows and restores previous
-Claude and Agy statusLine commands. Setup also installs a silent global Grok `Stop`
-hook that schedules a debounced quota sync after completed, failed, or cancelled
-turns; uninstall removes only that plugin-owned hook file.
+Claude and Agy statusLine commands. Setup also installs a silent global Grok hook:
+`PostToolUse` refreshes during long-running turns, while `Stop`, `StopFailure`, and
+`StopCancelled` cover final, failed, and cancelled replies. The hook runs the
+collector directly rather than invoking a Herdr action, and uninstall removes
+only that plugin-owned hook file. Restart existing Grok sessions once after setup
+so they load the new global hook.
 
 ## Supported CLIs
 
@@ -129,7 +132,7 @@ turns; uninstall removes only that plugin-owned hook file.
 | --- | --- | --- | --- |
 | Claude Code `2.1.233` | `5h` + `week` | Official `statusLine` JSON: `rate_limits.five_hour` and `seven_day` | The configure action installs and chains it automatically |
 | OpenAI Codex `0.147.0` | `week` | One-shot local `codex app-server --stdio`, `account/rateLimits/read` | ChatGPT subscription login; API-key mode is shown as unavailable |
-| Grok CLI / Grok Build `1.0.4` | `week` | Local `~/.grok/auth.json` and the billing contract used by the official CLI | The configure action installs a silent per-turn refresh hook |
+| Grok CLI / Grok Build `1.0.4` | `week` | Local `~/.grok/auth.json` and the billing contract used by the official CLI | The configure action installs a silent active-response hook |
 | Agy / Antigravity CLI `1.1.13` | `5h` + `week` | Official `statusLine` JSON `quota` object (`gemini-*` and `3p-*` pools) | The configure action installs and chains it automatically |
 
 Versions above were checked on the development machine on 2026-08-15. The
@@ -248,6 +251,7 @@ weekly value instead of clearing the sidebar.
 | Claude or Agy is `N/A` | Start a conversation so the native `statusLine` emits JSON; then refresh. |
 | Claude briefly changes while switching panes | The cached value is retained; run one prompt or a manual refresh if no snapshot exists yet. |
 | Agy has no quota | Run **Install / repair agent quota**, start one Agy turn, then manually refresh. |
+| A running Grok goal stays stale | Run **Install / repair agent quota**, then restart that Grok session once so it loads the updated global hook. |
 | The topic is blank or old | Send a prompt in that pane; topic extraction runs on agent events and needs recent output. |
 | Existing Claude statusLine is not changed | Run `configure --check`; the plugin refuses unsafe non-command settings instead of overwriting them. |
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ herdr plugin action invoke herdr-agent-quota.refresh
 
 Herdr plugin v1 does not currently let plugins add buttons to the native agent
 group header, so the shortcut is the closest stable one-step entry point.
+Selecting a pane also runs a provider-only refresh, debounced to once per
+minute. That path does not read terminal content, and a pane currently viewing
+scrollback receives no metadata write until it returns to the bottom.
 
 Preview the changes without writing anything:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,7 +75,7 @@ herdr plugin action invoke herdr-agent-quota.configure
 
 以上就是完整配置流程。第一条命令构建并启用插件；第二个 action 会统一使用
 Herdr 的插件 state 目录，批量写入 sidebar 行、安装或修复可恢复的 Claude/Agy
-statusLine 采集器、安装 Grok turn hook，并自动 reload 配置。之后可随时在 Herdr
+statusLine 采集器、安装 Grok 回复 hook，并自动 reload 配置。之后可随时在 Herdr
 action 菜单执行 **Install / repair agent quota**，重复执行也是安全的。需要手动
 刷新时执行 **Refresh agent quota**。
 
@@ -106,7 +106,7 @@ usage、topic 三类 token，不会覆盖官方 agent 指示。卸载 action 会
 | --- | --- | --- | --- |
 | Claude Code `2.1.233` | `5h` + `week` | 官方 `statusLine` JSON：`rate_limits.five_hour`、`seven_day` | 配置 action 自动安装并串联原命令 |
 | OpenAI Codex `0.147.0` | `week` | 一次性的 `codex app-server --stdio`，调用 `account/rateLimits/read` | 使用 ChatGPT 订阅登录；API key 模式显示为不可用 |
-| Grok CLI / Grok Build `1.0.3` | `week` | `~/.grok/auth.json` 和官方 CLI 使用的额度接口 | 登录 Grok CLI；不会读取 xAI team/API 账单 |
+| Grok CLI / Grok Build `1.0.4` | `week` | `~/.grok/auth.json` 和官方 CLI 使用的额度接口 | 配置 action 安装运行中与回合结束 hook |
 | Agy / Antigravity CLI `1.1.13` | `5h` + `week` | 官方 `statusLine` JSON 的 `quota`（`gemini-*`、`3p-*`） | 配置 action 自动安装并串联原命令 |
 
 上面的版本是 2026-08-15 在开发机上实际检查的版本。解析器按照供应商的
@@ -194,7 +194,9 @@ Herdr plugin v1 只支持文本 token，不能由插件向原生 Agent renderer 
   ChatGPT 订阅额度。
 - **Grok：** 在内存中读取本地 `~/.grok/auth.json` 登录 key，访问 Grok CLI
   使用的周额度接口。只有明确标记为 weekly 的响应才会接受。这是
-  SuperGrok 订阅额度，不是 xAI 开发者/API team 账单。
+  SuperGrok 订阅额度，不是 xAI 开发者/API team 账单。`PostToolUse` 会在
+  长任务的工具调用之间刷新，`Stop`/`StopFailure`/`StopCancelled` 覆盖最终、
+  失败和取消的回复；hook 直接运行采集器，不经过 Herdr action。
 - **Claude Code：** 使用官方
   [`statusLine` JSON hook](https://code.claude.com/docs/en/statusline) 提供
   5 小时和 7 天额度。原有 statusLine 会被备份、串联，并可由
@@ -219,6 +221,7 @@ Grok CLI 的额度接口属于 CLI 内部契约，不是 xAI 面向开发者的�
 | Claude 或 Agy 显示 `N/A` | 发起一次对话，让原生 `statusLine` 产生 JSON，然后刷新。 |
 | 切换 pane 时 Claude 短暂变化 | 已有缓存会保留；如果还没有快照，发送一次 prompt 或手动刷新。 |
 | Agy 没有额度 | 执行 **Install / repair agent quota**，完成一次 Agy 对话后再手动刷新。 |
+| 运行中的 Grok goal 额度不更新 | 执行 **Install / repair agent quota** 后重启一次该 Grok session，让它加载新的全局 hook。 |
 | 话题为空或没有更新 | 在该 pane 发送 prompt；话题提取依赖 agent 事件和最近输出。 |
 | 原有 Claude statusLine 没有被修改 | 执行 `configure --check`；对于不能安全串联的配置，插件会拒绝覆盖。 |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,6 +79,10 @@ statusLine 采集器、安装 Grok 回复 hook，并自动 reload 配置。之�
 action 菜单执行 **Install / repair agent quota**，重复执行也是安全的。需要手动
 刷新时执行 **Refresh agent quota**。
 
+选中一个 pane 时也会触发该 provider 的额度刷新，60 秒内自动合并重复请求。
+这条路径不会读取终端内容；如果 pane 正在查看 scrollback，则暂缓 metadata
+写入，回到底部后再补上，避免刷新把 viewport 拉走。
+
 只查看配置变更、不写入文件：
 
 ```sh

--- a/docs/plans/herdr-agent-quota-implementation.md
+++ b/docs/plans/herdr-agent-quota-implementation.md
@@ -200,7 +200,9 @@ herdr-agent-quota agy-statusline
 Declare one-shot startup and event hooks in `herdr-plugin.toml`:
 
 - Startup: `refresh --provider all`.
-- Events: `pane.agent_detected`, `pane.agent_status_changed`, and `pane.exited`.
+- Events: `pane.agent_detected` and `pane.agent_status_changed`; refresh and read
+  topics only for the provider named by the event, falling back to all providers
+  when the event payload does not identify one.
 - Focus: refresh only the selected provider, without reading pane content.
 - Manual action: force refresh all providers.
 

--- a/docs/plans/herdr-agent-quota-implementation.md
+++ b/docs/plans/herdr-agent-quota-implementation.md
@@ -201,14 +201,15 @@ Declare one-shot startup and event hooks in `herdr-plugin.toml`:
 
 - Startup: `refresh --provider all`.
 - Events: `pane.agent_detected`, `pane.agent_status_changed`, and `pane.exited`.
+- Focus: refresh only the selected provider, without reading pane content.
 - Manual action: force refresh all providers.
 
 Use a state-file timestamp and a cross-process lock to coalesce non-forced provider
 refreshes occurring within 60 seconds. A manual refresh bypasses the timestamp but
 still takes the lock. Do not subscribe to raw output or `pane.updated`; those events
-are too frequent for quota checks. Do not subscribe to `pane.focused`: the refresh
-reads and reports pane metadata through Herdr, and Herdr 0.8 can emit more focus
-events for those commands, creating an event feedback loop.
+are too frequent for quota checks. The `pane.focused` path must stay provider-only,
+must not read pane content, and must skip metadata reports while the pane is in
+scrollback so it cannot recreate the original viewport feedback loop.
 
 ### Snapshot model
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -41,6 +41,11 @@ id = "agent-quota-exit-refresh"
 on = "pane.exited"
 command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" event"]
 
+[[events]]
+id = "focused-agent-quota-refresh"
+on = "pane.focused"
+command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" focus"]
+
 [[panes]]
 id = "dashboard"
 title = "Agent quota"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -37,11 +37,6 @@ on = "pane.agent_status_changed"
 command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" event"]
 
 [[events]]
-id = "agent-quota-exit-refresh"
-on = "pane.exited"
-command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" event"]
-
-[[events]]
 id = "focused-agent-quota-refresh"
 on = "pane.focused"
 command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" focus"]

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -17,11 +17,6 @@ title = "Refresh agent quota"
 command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" refresh --provider all --force"]
 
 [[actions]]
-id = "refresh-grok"
-title = "Sync Grok quota after turn"
-command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" refresh --provider grok"]
-
-[[actions]]
 id = "configure"
 title = "Install / repair agent quota"
 command = ["sh", "-c", "\"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" configure --apply && herdr server reload-config"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,7 @@ pub enum Command {
         json: bool,
     },
     Event,
+    Focus,
     Dashboard,
     Configure {
         #[arg(long, conflicts_with_all = ["apply", "uninstall"])]

--- a/src/configure/grok.rs
+++ b/src/configure/grok.rs
@@ -1,10 +1,12 @@
+use crate::cache::CacheStore;
 use anyhow::{Context, Result};
 use serde_json::json;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 const HOOK_FILE: &str = "herdr-agent-quota.json";
-const REFRESH_ACTION: &str = "herdr-agent-quota.refresh-grok";
+const LEGACY_REFRESH_ACTION: &str = "herdr-agent-quota.refresh-grok";
+const MANAGED_BY: &str = "herdr-agent-quota";
 
 pub fn check() -> Result<()> {
     let path = hook_path()?;
@@ -12,7 +14,7 @@ pub fn check() -> Result<()> {
         println!("Grok quota hook is already installed: {}", path.display());
     } else {
         println!(
-            "Grok quota hook preview for {}: refresh after each turn",
+            "Grok quota hook preview for {}: refresh during active turns and after final replies",
             path.display()
         );
     }
@@ -20,21 +22,23 @@ pub fn check() -> Result<()> {
 }
 
 pub fn apply() -> Result<()> {
-    apply_at(&hook_path()?)
+    let cache = CacheStore::from_env()?;
+    let executable = std::env::current_exe().context("resolve plugin executable")?;
+    apply_at(&hook_path()?, cache.root(), &executable)
 }
 
 pub fn uninstall() -> Result<()> {
     uninstall_at(&hook_path()?)
 }
 
-pub fn apply_at(path: &Path) -> Result<()> {
-    let desired = hook_document();
+pub fn apply_at(path: &Path, state: &Path, executable: &Path) -> Result<()> {
+    let desired = hook_document(state, executable);
     if path.exists() {
         let current = fs::read_to_string(path).context("read Grok quota hook")?;
         if current == desired {
             return Ok(());
         }
-        if !current.contains(REFRESH_ACTION) {
+        if !current.contains(LEGACY_REFRESH_ACTION) && !current.contains(MANAGED_BY) {
             anyhow::bail!(
                 "refusing to replace user-owned Grok hook file {}",
                 path.display()
@@ -48,7 +52,7 @@ pub fn apply_at(path: &Path) -> Result<()> {
     fs::write(&temporary, desired).context("write Grok quota hook")?;
     fs::rename(&temporary, path).context("replace Grok quota hook")?;
     println!(
-        "Installed silent Grok turn refresh hook at {}",
+        "Installed silent Grok active-response refresh hook at {}",
         path.display()
     );
     Ok(())
@@ -71,11 +75,18 @@ fn hook_path() -> Result<PathBuf> {
 }
 
 fn is_managed_hook(path: &Path) -> bool {
-    fs::read_to_string(path).is_ok_and(|contents| contents.contains(REFRESH_ACTION))
+    fs::read_to_string(path).is_ok_and(|contents| {
+        contents.contains(LEGACY_REFRESH_ACTION)
+            || (contents.contains(MANAGED_BY) && contents.contains("refresh --provider grok"))
+    })
 }
 
-fn hook_document() -> String {
-    let command = format!("herdr plugin action invoke {REFRESH_ACTION} >/dev/null 2>&1");
+fn hook_document(state: &Path, executable: &Path) -> String {
+    let command = format!(
+        "HERDR_PLUGIN_STATE_DIR={} {} refresh --provider grok >/dev/null 2>&1",
+        shell_quote(state),
+        shell_quote(executable)
+    );
     let handler = json!({
         "hooks": [{
             "type": "command",
@@ -85,11 +96,17 @@ fn hook_document() -> String {
     });
     serde_json::to_string_pretty(&json!({
         "hooks": {
+            "PostToolUse": [handler.clone()],
             "Stop": [handler.clone()],
             "StopFailure": [handler.clone()],
             "StopCancelled": [handler]
-        }
+        },
+        "managedBy": MANAGED_BY
     }))
     .expect("serialize static Grok hook")
         + "\n"
+}
+
+fn shell_quote(path: &Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
 }

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -50,6 +50,28 @@ pub fn list_agent_panes() -> Result<Vec<AgentPane>> {
     Ok(panes)
 }
 
+pub fn current_agent_provider() -> Result<Option<Provider>> {
+    if let Some(agent) = std::env::var_os("HERDR_FOCUSED_PANE_AGENT") {
+        if let Ok(provider) = agent.to_string_lossy().parse::<Provider>() {
+            return Ok(Some(provider));
+        }
+    }
+    let executable = std::env::var_os("HERDR_BIN_PATH").unwrap_or_else(|| "herdr".into());
+    let output = Command::new(executable)
+        .args(["pane", "current"])
+        .output()
+        .context("read focused Herdr pane")?;
+    if !output.status.success() {
+        anyhow::bail!("Herdr pane current failed with {}", output.status);
+    }
+    let value: Value =
+        serde_json::from_slice(&output.stdout).context("parse focused Herdr pane")?;
+    Ok(value
+        .pointer("/result/pane/agent")
+        .and_then(Value::as_str)
+        .and_then(|agent| agent.parse::<Provider>().ok()))
+}
+
 pub fn list_agent_panes_with_topics() -> Result<Vec<AgentPane>> {
     let executable = std::env::var_os("HERDR_BIN_PATH").unwrap_or_else(|| "herdr".into());
     let mut panes = list_agent_panes()?;

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -133,6 +133,12 @@ pub fn publish_tokens(
         if metadata_matches(&pane.tokens, &desired) {
             continue;
         }
+        // Herdr versions that repaint metadata can snap a terminal viewport
+        // back to the bottom. Never mutate pane metadata while the user is
+        // reading scrollback; the next refresh after they return catches up.
+        if pane_is_scrolled(&executable, &pane.pane_id) {
+            continue;
+        }
         reported += 1;
         let mut command = Command::new(&executable);
         command
@@ -167,6 +173,26 @@ pub fn publish_tokens(
         );
     }
     Ok(())
+}
+
+fn pane_is_scrolled(executable: &std::ffi::OsStr, pane_id: &str) -> bool {
+    let Ok(output) = Command::new(executable)
+        .args(["pane", "get", pane_id])
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    serde_json::from_slice::<Value>(&output.stdout)
+        .ok()
+        .and_then(|value| {
+            value
+                .pointer("/result/pane/scroll/offset_from_bottom")
+                .and_then(Value::as_u64)
+        })
+        .is_some_and(|offset| offset > 0)
 }
 
 fn desired_tokens(values: &MetadataTokens, topic: &str) -> BTreeMap<String, String> {

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -72,9 +72,10 @@ pub fn current_agent_provider() -> Result<Option<Provider>> {
         .and_then(|agent| agent.parse::<Provider>().ok()))
 }
 
-pub fn list_agent_panes_with_topics() -> Result<Vec<AgentPane>> {
+pub fn list_agent_panes_with_topics(providers: &[Provider]) -> Result<Vec<AgentPane>> {
     let executable = std::env::var_os("HERDR_BIN_PATH").unwrap_or_else(|| "herdr".into());
     let mut panes = list_agent_panes()?;
+    panes.retain(|pane| providers.contains(&pane.provider));
     for pane in &mut panes {
         pane.topic = read_pane_topic(&executable, pane).unwrap_or_default();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ fn main() -> Result<()> {
             json,
         } => herdr_agent_quota::refresh::run(&provider.providers(), force, json),
         Command::Event => herdr_agent_quota::refresh::event(),
+        Command::Focus => herdr_agent_quota::refresh::focus(),
         Command::Dashboard => herdr_agent_quota::dashboard::run(),
         Command::Configure {
             check,

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -7,6 +7,7 @@ use crate::presentation::MetadataTokens;
 use crate::providers::{codex, grok};
 use anyhow::Result;
 use serde::Serialize;
+use serde_json::Value;
 
 #[derive(Debug, Serialize)]
 pub struct ProviderOutcome {
@@ -39,7 +40,10 @@ fn run_internal(
 }
 
 pub fn event() -> Result<()> {
-    run_internal(&Provider::ALL, false, false, true)
+    let providers = event_provider()
+        .map(|provider| vec![provider])
+        .unwrap_or_else(|| Provider::ALL.to_vec());
+    run_internal(&providers, false, false, true)
 }
 
 pub fn focus() -> Result<()> {
@@ -108,7 +112,7 @@ fn refresh_locked(
 
 fn publish(cache: &CacheStore, providers: &[Provider], refresh_topics: bool) -> Result<()> {
     let panes = if refresh_topics {
-        list_agent_panes_with_topics()
+        list_agent_panes_with_topics(providers)
     } else {
         list_agent_panes()
     }
@@ -122,6 +126,23 @@ fn publish(cache: &CacheStore, providers: &[Provider], refresh_topics: bool) -> 
         }
     }
     publish_tokens(&panes, &tokens, CacheStore::now_millis())
+}
+
+fn event_provider() -> Option<Provider> {
+    let input = std::env::var("HERDR_PLUGIN_EVENT_JSON").ok()?;
+    let value: Value = serde_json::from_str(&input).ok()?;
+    find_agent(&value).and_then(|agent| agent.parse::<Provider>().ok())
+}
+
+fn find_agent(value: &Value) -> Option<&str> {
+    match value {
+        Value::Object(map) => map
+            .get("agent")
+            .and_then(Value::as_str)
+            .or_else(|| map.values().find_map(find_agent)),
+        Value::Array(values) => values.iter().find_map(find_agent),
+        _ => None,
+    }
 }
 
 fn tokens_for_provider(

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -1,5 +1,7 @@
 use crate::cache::CacheStore;
-use crate::herdr::{list_agent_panes, list_agent_panes_with_topics, publish_tokens};
+use crate::herdr::{
+    current_agent_provider, list_agent_panes, list_agent_panes_with_topics, publish_tokens,
+};
 use crate::model::Provider;
 use crate::presentation::MetadataTokens;
 use crate::providers::{codex, grok};
@@ -38,6 +40,13 @@ fn run_internal(
 
 pub fn event() -> Result<()> {
     run_internal(&Provider::ALL, false, false, true)
+}
+
+pub fn focus() -> Result<()> {
+    let Some(provider) = current_agent_provider()? else {
+        return Ok(());
+    };
+    run(&[provider], false, false)
 }
 
 fn refresh_locked(

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -251,6 +251,58 @@ fn focus_refreshes_only_the_selected_provider_without_reading_the_pane() {
 }
 
 #[test]
+fn agent_event_refreshes_and_reads_topics_only_for_its_provider() {
+    let state = tempdir().unwrap();
+    let log = state.path().join("herdr.log");
+    let codex_log = state.path().join("codex.log");
+    let herdr = state.path().join("herdr");
+    let codex = state.path().join("codex");
+    fs::write(
+        &herdr,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1 $2\" = \"agent list\" ]; then\n  printf '%s\\n' '{}'\nelif [ \"$1 $2\" = \"pane get\" ]; then\n  printf '%s\\n' '{}'\nfi\n",
+            log.display(),
+            r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1"},{"agent":"grok","pane_id":"w1:p2"}]}}"#,
+            r#"{"result":{"pane":{"scroll":{"offset_from_bottom":0}}}}"#,
+        ),
+    )
+    .unwrap();
+    fs::write(
+        &codex,
+        format!("#!/bin/sh\nprintf called > '{}'\n", codex_log.display()),
+    )
+    .unwrap();
+    for executable in [&herdr, &codex] {
+        let mut permissions = fs::metadata(executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(executable, permissions).unwrap();
+    }
+    run_claude_collector(
+        state.path(),
+        &herdr,
+        include_bytes!("fixtures/claude/statusline-both.json"),
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_herdr-agent-quota"))
+        .arg("event")
+        .env("HERDR_PLUGIN_STATE_DIR", state.path())
+        .env("HERDR_BIN_PATH", &herdr)
+        .env("CODEX_BIN_PATH", &codex)
+        .env("GROK_HOME", state.path().join("missing-grok-home"))
+        .env(
+            "HERDR_PLUGIN_EVENT_JSON",
+            r#"{"event":{"pane":{"agent":"claude","pane_id":"w1:p1"}}}"#,
+        )
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(!codex_log.exists());
+    let calls = fs::read_to_string(log).unwrap();
+    assert!(calls.contains("pane read w1:p1"));
+    assert!(!calls.contains("pane read w1:p2"));
+}
+
+#[test]
 fn claude_collector_does_not_republish_unchanged_quota() {
     let state = tempdir().unwrap();
     let (herdr_stub, herdr_log) = install_herdr_stub(

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -183,6 +183,36 @@ fn claude_cache_is_published_by_refresh_event() {
 }
 
 #[test]
+fn quota_refresh_does_not_report_metadata_to_a_scrolled_pane() {
+    let state = tempdir().unwrap();
+    let log = state.path().join("herdr.log");
+    let herdr = state.path().join("herdr");
+    fs::write(
+        &herdr,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1 $2\" = \"agent list\" ]; then\n  printf '%s\\n' '{}'\nelif [ \"$1 $2\" = \"pane get\" ]; then\n  printf '%s\\n' '{}'\nfi\n",
+            log.display(),
+            r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1"}]}}"#,
+            r#"{"result":{"pane":{"scroll":{"offset_from_bottom":12}}}}"#,
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&herdr).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&herdr, permissions).unwrap();
+
+    run_claude_collector(
+        state.path(),
+        &herdr,
+        include_bytes!("fixtures/claude/statusline-both.json"),
+    );
+    run_claude_refresh(state.path(), &herdr);
+    let calls = fs::read_to_string(log).unwrap();
+    assert!(calls.contains("pane get w1:p1"));
+    assert!(!calls.contains("pane report-metadata"));
+}
+
+#[test]
 fn claude_collector_does_not_republish_unchanged_quota() {
     let state = tempdir().unwrap();
     let (herdr_stub, herdr_log) = install_herdr_stub(

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -213,6 +213,44 @@ fn quota_refresh_does_not_report_metadata_to_a_scrolled_pane() {
 }
 
 #[test]
+fn focus_refreshes_only_the_selected_provider_without_reading_the_pane() {
+    let state = tempdir().unwrap();
+    let log = state.path().join("herdr.log");
+    let herdr = state.path().join("herdr");
+    fs::write(
+        &herdr,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1 $2\" = \"pane current\" ]; then\n  printf '%s\\n' '{}'\nelif [ \"$1 $2\" = \"agent list\" ]; then\n  printf '%s\\n' '{}'\nelif [ \"$1 $2\" = \"pane get\" ]; then\n  printf '%s\\n' '{}'\nfi\n",
+            log.display(),
+            r#"{"result":{"pane":{"agent":"claude","pane_id":"w1:p1"}}}"#,
+            r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1"}]}}"#,
+            r#"{"result":{"pane":{"scroll":{"offset_from_bottom":0}}}}"#,
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&herdr).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&herdr, permissions).unwrap();
+    run_claude_collector(
+        state.path(),
+        &herdr,
+        include_bytes!("fixtures/claude/statusline-both.json"),
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_herdr-agent-quota"))
+        .arg("focus")
+        .env("HERDR_PLUGIN_STATE_DIR", state.path())
+        .env("HERDR_BIN_PATH", &herdr)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let calls = fs::read_to_string(log).unwrap();
+    assert!(calls.contains("pane current"));
+    assert!(!calls.contains("pane read"));
+    assert!(calls.contains("pane report-metadata w1:p1"));
+}
+
+#[test]
 fn claude_collector_does_not_republish_unchanged_quota() {
     let state = tempdir().unwrap();
     let (herdr_stub, herdr_log) = install_herdr_stub(

--- a/tests/grok_hook_config.rs
+++ b/tests/grok_hook_config.rs
@@ -6,16 +6,22 @@ use tempfile::tempdir;
 fn grok_turn_hook_refreshes_quota_silently_and_is_reversible() {
     let directory = tempdir().unwrap();
     let path = directory.path().join("herdr-agent-quota.json");
+    let state = directory.path().join("state");
+    let executable = directory.path().join("herdr-agent-quota");
 
-    apply_at(&path).unwrap();
+    apply_at(&path, &state, &executable).unwrap();
     let installed = fs::read_to_string(&path).unwrap();
+    assert!(installed.contains("\"PostToolUse\""));
     assert!(installed.contains("\"Stop\""));
     assert!(installed.contains("\"StopFailure\""));
     assert!(installed.contains("\"StopCancelled\""));
-    assert!(installed.contains("herdr-agent-quota.refresh-grok"));
+    assert!(installed.contains("refresh --provider grok"));
+    assert!(installed.contains(state.to_str().unwrap()));
+    assert!(!installed.contains("plugin action invoke"));
+    assert!(!installed.contains("--force"));
     assert!(installed.contains(">/dev/null 2>&1"));
 
-    apply_at(&path).unwrap();
+    apply_at(&path, &state, &executable).unwrap();
     assert_eq!(fs::read_to_string(&path).unwrap(), installed);
 
     uninstall_at(&path).unwrap();

--- a/tests/plugin_manifest.rs
+++ b/tests/plugin_manifest.rs
@@ -12,3 +12,9 @@ fn plugin_exposes_one_click_configure_and_uninstall_actions() {
     assert!(manifest.contains("id = \"uninstall\""));
     assert!(manifest.contains("configure --uninstall"));
 }
+
+#[test]
+fn grok_runtime_refresh_does_not_go_through_a_plugin_action() {
+    let manifest = include_str!("../herdr-plugin.toml");
+    assert!(!manifest.contains("id = \"refresh-grok\""));
+}

--- a/tests/plugin_manifest.rs
+++ b/tests/plugin_manifest.rs
@@ -1,7 +1,12 @@
 #[test]
-fn pane_focus_does_not_refresh_or_disturb_the_viewport() {
+fn pane_focus_uses_the_quota_only_focus_path() {
     let manifest = include_str!("../herdr-plugin.toml");
-    assert!(!manifest.contains("on = \"pane.focused\""));
+    let hook = manifest
+        .split("[[events]]")
+        .find(|event| event.contains("on = \"pane.focused\""))
+        .unwrap();
+    assert!(hook.contains(" focus\"]"));
+    assert!(!hook.contains(" event\"]"));
 }
 
 #[test]

--- a/tests/plugin_manifest.rs
+++ b/tests/plugin_manifest.rs
@@ -23,3 +23,9 @@ fn grok_runtime_refresh_does_not_go_through_a_plugin_action() {
     let manifest = include_str!("../herdr-plugin.toml");
     assert!(!manifest.contains("id = \"refresh-grok\""));
 }
+
+#[test]
+fn exited_panes_do_not_trigger_a_quota_refresh() {
+    let manifest = include_str!("../herdr-plugin.toml");
+    assert!(!manifest.contains("on = \"pane.exited\""));
+}


### PR DESCRIPTION
## What changed\n\n- refresh Grok from PostToolUse during long-running turns\n- retain Stop, StopFailure, and StopCancelled for final, failed, and cancelled replies\n- run the Grok collector directly instead of routing through a Herdr plugin action\n- refresh only the selected provider when pane focus changes, with a 60-second debounce\n- keep the focus path quota-only: no pane content reads and no topic refresh\n- skip metadata publication while a pane is reading scrollback\n- refresh only the affected provider on agent detection/status events and read topics only from that provider's panes\n- remove the redundant pane.exited refresh; incomplete event payloads still fall back to all providers\n- migrate the previous plugin-owned Grok hook in place\n\n## Root cause\n\nA Grok goal can perform many model/tool rounds inside one user turn. Stop only fires when that whole turn genuinely completes, so quota stayed stale throughout long-running work. The hook also invoked a Herdr action, coupling collection to the action UI lifecycle. Earlier pane-focus handling used the full event path, including pane reads. Metadata repainting could pull a pane out of scrollback. Agent lifecycle events also refreshed and read panes for every provider even when only one provider changed, while pane.exited refreshed after its metadata consumer was gone.\n\n## User impact\n\nGrok quota refreshes during active work and again when the turn ends. Selecting a pane refreshes only that provider and coalesces repeated focus changes for 60 seconds. The focus path never reads terminal content. A pane with offset_from_bottom greater than zero is never sent quota metadata and catches up after returning to the bottom. Agent status changes no longer query unrelated providers. Existing Grok sessions need one restart after configuration to load the new global hook.\n\n## Validation\n\n- cargo test --all-targets\n- cargo clippy --all-targets -- -D warnings\n- cargo build --release\n- local plugin list confirms only pane.agent_detected, pane.agent_status_changed, and pane.focused are registered\n- local configure action installed PostToolUse plus turn-end hooks\n- installed Grok hook command contains no plugin action invocation\n- regression tests prove provider-scoped event refreshes, focus without pane reads, and scrollback-safe metadata publication