### PR TITLE
fix: stop agent events from repainting every pane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,97 @@
+# AGENTS.md
+
+Notes for agents working on `herdr-agent-quota`. Read this before touching
+anything that talks to Herdr.
+
+## The rule that matters most: reading or writing a pane is not free
+
+This plugin's whole job is to put quota numbers in Herdr's sidebar. Every
+Herdr call it makes to do that lands on a pane that a human is actively
+watching. Two calls are visible to the user:
+
+- `herdr pane read <id>` — makes Herdr repaint that pane. The agent's TUI
+  redraws its whole frame, which the user sees as the terminal scrolling up
+  and then snapping back to the bottom.
+- `herdr pane report-metadata <id>` — same repaint risk when the tokens
+  actually change.
+
+Neither is detectable from `pane get`: `offset_from_bottom` and
+`max_offset_from_bottom` stay `0` throughout, because full-screen agent TUIs
+have no Herdr scrollback. The viewport never moves. What moves is the agent's
+own repaint. **Do not conclude "no scroll happened" from the scroll offsets.**
+
+Concretely, this means:
+
+1. **Never read every pane of a provider.** An event names one pane; read only
+   that one. Fanning out across panes multiplies the repaints by the number of
+   panes the user has open for that agent.
+2. **Publish once per invocation.** Two `publish` passes in a row means each
+   pane can take two metadata writes for one user action.
+3. **Keep `metadata_matches` honest** (`src/herdr.rs`). It is the only thing
+   stopping a no-op refresh from repainting every pane. If you add a token,
+   add it to `METADATA_TOKEN_NAMES` too, or the comparison silently stops
+   covering it and every refresh becomes a write.
+4. **Preserve, don't clear.** When a topic read fails or finds nothing, keep
+   the previously published topic. Clearing it churns the token and triggers
+   a write on the next refresh, which triggers a repaint.
+
+## Event paths, and what each is allowed to do
+
+| Entry point | Fired by | Allowed to read panes? |
+|---|---|---|
+| `refresh` | startup, manual action, Grok hooks | No |
+| `event` | `pane.agent_detected`, `pane.agent_status_changed` | Only the pane named in `HERDR_PLUGIN_EVENT_JSON` |
+| `focus` | `pane.focused` | No |
+
+`pane.agent_status_changed` fires **twice per turn** (idle→working on submit,
+working→idle on completion). Anything `event` does, the user pays for twice
+every time they press Enter. Budget accordingly.
+
+## Event payload shapes
+
+`HERDR_PLUGIN_EVENT_JSON` is nested and not uniform across events. `pane.focused`
+carries no `agent` at all, which is why `focus` has to call `herdr pane current`:
+
+```json
+{"event":"pane_focused","data":{"type":"pane_focused","pane_id":"w1:p9","workspace_id":"w1"}}
+```
+
+`find_agent` and `find_pane_id` in `src/refresh.rs` walk the tree rather than
+assuming a fixed path. Keep them tolerant — the shapes differ per event and are
+not part of a stable contract.
+
+## Debugging a "the panes are scrolling" report
+
+Bisect from the outside in. Each step needs the user to reproduce once, so do
+them in this order and don't skip ahead:
+
+1. `herdr plugin disable herdr-agent-quota` **and** remove the `statusLine`
+   entry from `~/.claude/settings.json`, then **restart the agent pane**.
+   `herdr plugin disable` alone is not enough — Claude Code runs the statusLine
+   command itself, independent of Herdr, and reads the setting at startup.
+2. Restore the statusLine only. Scrolls → the statusLine hook is at fault.
+3. Re-enable the plugin, then remove event hooks from `herdr-plugin.toml` one
+   at a time, reloading with `herdr plugin disable && herdr plugin enable`
+   (needed to re-read the manifest; `herdr server reload-config` does not).
+
+To capture a real event payload, temporarily point a hook at
+`sh -c "printf '%s' \"$HERDR_PLUGIN_EVENT_JSON\" > /tmp/ev.json; exec <real command>"`
+so the plugin keeps working while you collect the shape.
+
+Beware of instrumenting with a polling probe: polling `herdr pane read` at
+several Hz is itself a repaint source and will contaminate whatever the user
+reports while it runs.
+
+## Verifying
+
+```
+cargo fmt
+cargo test
+cargo clippy --release
+```
+
+Reloading the plugin after a rebuild:
+
+```
+herdr plugin disable herdr-agent-quota && herdr plugin enable herdr-agent-quota
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Agent events no longer repaint every pane of a provider. Reading a pane makes
+  Herdr repaint it, which the user sees as the agent's terminal scrolling up and
+  snapping back to the bottom, once on agent detection and twice per turn
+  thereafter. An event now reads only the pane it names and publishes once
+  instead of twice; the remaining panes keep the topic they last published.
+- A failed or empty topic read now preserves the last published topic instead of
+  clearing it, so it no longer churns the token and forces a write on the next
+  refresh.
+
 - Agent topics now come only from the latest user prompt in pane output. Native
   `Thinking`/`Executing` titles and other AI status text are no longer published
   as the user's topic, including Grok's `❯` prompt format.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -72,14 +72,14 @@ pub fn current_agent_provider() -> Result<Option<Provider>> {
         .and_then(|agent| agent.parse::<Provider>().ok()))
 }
 
-pub fn list_agent_panes_with_topics(providers: &[Provider]) -> Result<Vec<AgentPane>> {
+// Reading a pane makes Herdr repaint it, which visibly scrolls the agent's
+// terminal. Only the pane that fired the event is worth that cost; every other
+// pane keeps the topic it last published.
+pub fn refresh_pane_topic(pane: &mut AgentPane) {
     let executable = std::env::var_os("HERDR_BIN_PATH").unwrap_or_else(|| "herdr".into());
-    let mut panes = list_agent_panes()?;
-    panes.retain(|pane| providers.contains(&pane.provider));
-    for pane in &mut panes {
-        pane.topic = read_pane_topic(&executable, pane).unwrap_or_default();
+    if let Some(topic) = read_pane_topic(&executable, pane) {
+        pane.topic = topic;
     }
-    Ok(panes)
 }
 
 fn collect_agent_panes(value: &Value, panes: &mut Vec<AgentPane>) {

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -1,7 +1,5 @@
 use crate::cache::CacheStore;
-use crate::herdr::{
-    current_agent_provider, list_agent_panes, list_agent_panes_with_topics, publish_tokens,
-};
+use crate::herdr::{current_agent_provider, list_agent_panes, publish_tokens, refresh_pane_topic};
 use crate::model::Provider;
 use crate::presentation::MetadataTokens;
 use crate::providers::{codex, grok};
@@ -18,21 +16,18 @@ pub struct ProviderOutcome {
 }
 
 pub fn run(providers: &[Provider], force: bool, json: bool) -> Result<()> {
-    run_internal(providers, force, json, false)
+    run_internal(providers, force, json, None)
 }
 
 fn run_internal(
     providers: &[Provider],
     force: bool,
     json: bool,
-    refresh_topics: bool,
+    topic_pane: Option<&str>,
 ) -> Result<()> {
     let cache = CacheStore::from_env()?;
     let outcomes = cache.with_lock(|| refresh_locked(&cache, providers, force))?;
-    publish(&cache, providers, false)?;
-    if refresh_topics {
-        publish(&cache, providers, true)?;
-    }
+    publish(&cache, providers, topic_pane)?;
     if json {
         println!("{}", serde_json::to_string_pretty(&outcomes)?);
     }
@@ -40,10 +35,15 @@ fn run_internal(
 }
 
 pub fn event() -> Result<()> {
-    let providers = event_provider()
+    let event = event_json();
+    let providers = event
+        .as_ref()
+        .and_then(find_agent)
+        .and_then(|agent| agent.parse::<Provider>().ok())
         .map(|provider| vec![provider])
         .unwrap_or_else(|| Provider::ALL.to_vec());
-    run_internal(&providers, false, false, true)
+    let topic_pane = event.as_ref().and_then(find_pane_id);
+    run_internal(&providers, false, false, topic_pane)
 }
 
 pub fn focus() -> Result<()> {
@@ -110,13 +110,15 @@ fn refresh_locked(
     Ok(outcomes)
 }
 
-fn publish(cache: &CacheStore, providers: &[Provider], refresh_topics: bool) -> Result<()> {
-    let panes = if refresh_topics {
-        list_agent_panes_with_topics(providers)
-    } else {
-        list_agent_panes()
+fn publish(cache: &CacheStore, providers: &[Provider], topic_pane: Option<&str>) -> Result<()> {
+    let mut panes = list_agent_panes().unwrap_or_default();
+    if let Some(pane) = topic_pane.and_then(|pane_id| {
+        panes
+            .iter_mut()
+            .find(|pane| pane.pane_id == pane_id && providers.contains(&pane.provider))
+    }) {
+        refresh_pane_topic(pane);
     }
-    .unwrap_or_default();
     let mut tokens = Vec::new();
     let now = CacheStore::now_unix();
     for provider in providers {
@@ -128,21 +130,30 @@ fn publish(cache: &CacheStore, providers: &[Provider], refresh_topics: bool) -> 
     publish_tokens(&panes, &tokens, CacheStore::now_millis())
 }
 
-fn event_provider() -> Option<Provider> {
+fn event_json() -> Option<Value> {
     let input = std::env::var("HERDR_PLUGIN_EVENT_JSON").ok()?;
-    let value: Value = serde_json::from_str(&input).ok()?;
-    find_agent(&value).and_then(|agent| agent.parse::<Provider>().ok())
+    serde_json::from_str(&input).ok()
+}
+
+// Event payloads are nested and their shape differs per event, so look the
+// field up anywhere in the tree rather than at a fixed path.
+fn find_field<'a>(value: &'a Value, names: &[&str]) -> Option<&'a str> {
+    match value {
+        Value::Object(map) => names
+            .iter()
+            .find_map(|name| map.get(*name).and_then(Value::as_str))
+            .or_else(|| map.values().find_map(|child| find_field(child, names))),
+        Value::Array(values) => values.iter().find_map(|child| find_field(child, names)),
+        _ => None,
+    }
 }
 
 fn find_agent(value: &Value) -> Option<&str> {
-    match value {
-        Value::Object(map) => map
-            .get("agent")
-            .and_then(Value::as_str)
-            .or_else(|| map.values().find_map(find_agent)),
-        Value::Array(values) => values.iter().find_map(find_agent),
-        _ => None,
-    }
+    find_field(value, &["agent"])
+}
+
+fn find_pane_id(value: &Value) -> Option<&str> {
+    find_field(value, &["pane_id", "paneId"])
 }
 
 fn tokens_for_provider(
@@ -175,5 +186,26 @@ mod tests {
     fn missing_snapshot_does_not_overwrite_sidebar_with_unavailable() {
         let values = tokens_for_provider(None, 1);
         assert!(values.is_none());
+    }
+
+    // Reading a pane repaints it, which visibly scrolls the agent's terminal.
+    // An event must name exactly one pane to read, so the other panes of the
+    // same provider are left alone.
+    #[test]
+    fn event_payload_names_the_single_pane_whose_topic_may_be_read() {
+        let value: Value = serde_json::from_str(
+            r#"{"event":"pane_agent_status_changed",
+                "data":{"pane_id":"w1:p2","agent":"grok","status":"working"}}"#,
+        )
+        .unwrap();
+        assert_eq!(find_pane_id(&value), Some("w1:p2"));
+        assert_eq!(find_agent(&value), Some("grok"));
+    }
+
+    #[test]
+    fn an_event_without_a_pane_reads_no_pane_at_all() {
+        let value: Value =
+            serde_json::from_str(r#"{"event":"x","data":{"agent":"claude"}}"#).unwrap();
+        assert_eq!(find_pane_id(&value), None);
     }
 }


### PR DESCRIPTION
## Symptom

Every time the user pressed Enter in an agent pane, that pane and every other
pane of the same agent scrolled up and then snapped back to the bottom. Entering
a new agent pane scrolled once as well.

## Root cause

`herdr pane read` makes Herdr repaint the pane, and the agent's TUI redraws its
whole frame. The event path did that for **every pane of the provider**, then
published metadata **twice** (once preserving topics, once refreshing them).
`pane.agent_status_changed` fires twice per turn (idle→working, working→idle),
so a single keypress cost N pane reads and up to 2N metadata writes.

The failure is invisible to `herdr pane get`: `offset_from_bottom` and
`max_offset_from_bottom` stay `0` throughout, because full-screen agent TUIs have
no Herdr scrollback. The viewport never moves — the repaint does. The existing
`pane_is_scrolled` guard only skips panes with `offset > 0`, so it never applied.

## What changed

- An event now reads only the pane it names (`find_pane_id` over
  `HERDR_PLUGIN_EVENT_JSON`) and publishes once. Other panes keep the topic they
  last published — their prompt did not change, so reading them was pure waste.
- A failed or empty topic read preserves the last published topic instead of
  clearing it. Clearing churned the token and forced another write, and therefore
  another repaint, on the next refresh.
- `find_agent` and the new `find_pane_id` share one tolerant tree walk.

Writes per turn, with two panes of one agent open:

| | pane reads | metadata writes |
|---|---|---|
| before | 4 | up to 8 |
| after | 2 | up to 2 |

No feature is dropped: the sidebar topic row still tracks the latest prompt.

## Bisect notes (AGENTS.md / CLAUDE.md)

`herdr plugin disable` alone does **not** exonerate the plugin — Claude Code runs
the statusLine command itself and reads the setting at startup, so the
`~/.claude/settings.json` entry must be removed and the pane restarted too. This
cost a round of misattribution during diagnosis and is now written down, along
with the warning that a polling probe is itself a repaint source.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets --release` clean, 73 tests pass
- Bisected live against the reporter's session: disabling the plugin + statusLine
  stopped the scrolling; restoring the statusLine alone did not bring it back;
  re-enabling the plugin did; removing the `pane.agent_status_changed` hook
  stopped the per-turn case and left only the agent-detection case — both routed
  through the same `event` path fixed here.

⚠️ `find_pane_id` was verified against a real `pane.focused` payload
(`{"data":{"pane_id":"w1:p9",...}}`). The `pane.agent_status_changed` payload was
not captured, so its exact shape is inferred; the lookup walks the tree rather
than assuming a path. If the sidebar topic row stops tracking the latest prompt,
that inference is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)