### PR TITLE
feat: unify active-turn quota polling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,16 +9,38 @@ This plugin's whole job is to put quota numbers in Herdr's sidebar. Every
 Herdr call it makes to do that lands on a pane that a human is actively
 watching. Two calls are visible to the user:
 
-- `herdr pane read <id>` — makes Herdr repaint that pane. The agent's TUI
-  redraws its whole frame, which the user sees as the terminal scrolling up
-  and then snapping back to the bottom.
-- `herdr pane report-metadata <id>` — same repaint risk when the tokens
-  actually change.
+- `herdr pane read <id> --source recent` (and `recent-unwrapped`) — rebuilds the
+  pane's wrapped scrollback. Measured at **4.45s per call** against 0.006s for
+  `--source visible`, and it repaints the pane: the agent's TUI redraws its whole
+  frame, which the user sees as the terminal scrolling up and snapping back to
+  the bottom. **One read, one scroll** — confirmed 1:1 by burst-reading a live
+  pane while the user watched (2 `recent` reads → 2 scrolls; 13 `visible` reads
+  → none).
+- `herdr pane report-metadata <id>` — repaint risk when the tokens actually
+  change, though it was never reproduced as a scroll on its own.
 
-Neither is detectable from `pane get`: `offset_from_bottom` and
+Use `--source visible` (or `detection`; both return the current screen). The
+prompt is on screen at the moment `idle->working` fires, which is exactly when
+the topic changes. Later in the turn it may have scrolled off — then extraction
+returns `None` and the caller must keep the topic it already published.
+
+| `--source` | cost | repaints |
+|---|---|---|
+| `visible` | 0.006s | no |
+| `detection` | 0.004s | no |
+| `recent` | 4.452s | **yes** |
+| `recent-unwrapped` | 4.448s | **yes** |
+
+None of this is detectable from `pane get`: `offset_from_bottom` and
 `max_offset_from_bottom` stay `0` throughout, because full-screen agent TUIs
 have no Herdr scrollback. The viewport never moves. What moves is the agent's
 own repaint. **Do not conclude "no scroll happened" from the scroll offsets.**
+
+Comparing a pane's content hash before and after a call does not work either:
+the repaint ends with the pane back exactly as it was, so the hashes match and
+the scroll is invisible to sampling. This produced a false "pane read is
+harmless" result during diagnosis. **A human has to watch the pane.** The only
+reliable instrument is a burst of N calls with the user counting scrolls.
 
 Concretely, this means:
 
@@ -39,13 +61,20 @@ Concretely, this means:
 
 | Entry point | Fired by | Allowed to read panes? |
 |---|---|---|
-| `refresh` | startup, manual action, Grok hooks | No |
+| `refresh` | startup, manual action | No |
 | `event` | `pane.agent_detected`, `pane.agent_status_changed` | Only the pane named in `HERDR_PLUGIN_EVENT_JSON` |
 | `focus` | `pane.focused` | No |
+| `watch` | detached from a working status event | No (agent metadata only) |
 
 `pane.agent_status_changed` fires **twice per turn** (idle→working on submit,
 working→idle on completion). Anything `event` does, the user pays for twice
 every time they press Enter. Budget accordingly.
+
+The working event starts one global `watch` pulse. It calls `herdr agent list`
+once per configured interval, refreshes every working provider in that pass,
+publishes without reading pane output, and exits after all agents settle. The
+interval defaults to 60 seconds and is bounded to 30 seconds–1 hour. Uninstall
+writes a stop marker so a detached watcher cannot survive a restore.
 
 ## Event payload shapes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Quota rows now show a compact `reset` ETA: minutes below one hour, hours and
   minutes below one day, and days plus hours for longer windows.
+- Active turns now start one short-lived global refresh watcher for Claude,
+  Codex, Grok, and Agy. It reads the working provider set once per poll,
+  publishes statusLine cache updates, keeps active fetches debounced, stops
+  when all agents settle, and performs final debounced passes per provider.
+  Polling defaults to 60 seconds and is configurable from 30 seconds to one
+  hour. `install.sh` and `uninstall.sh` provide a build/link/configure and
+  restore/unlink workflow for downloaded checkouts.
 
 ### Fixed
 
+- Topic extraction now reads the pane's visible screen instead of rebuilding its
+  wrapped scrollback. The old `--source recent` read took 4.45s and repainted the
+  pane once per call, which is what the user saw as scrolling; `--source visible`
+  costs 0.006s and repaints nothing. The prompt is on screen when a turn starts,
+  which is when the topic changes.
 - Agent events no longer repaint every pane of a provider. Reading a pane makes
   Herdr repaint it, which the user sees as the agent's terminal scrolling up and
   snapping back to the bottom, once on agent detection and twice per turn
@@ -21,6 +33,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - A failed or empty topic read now preserves the last published topic instead of
   clearing it, so it no longer churns the token and forces a write on the next
   refresh.
+- The legacy per-tool Grok response hook is no longer installed. Existing
+  plugin-owned copies are removed during configure because the single global
+  watcher now covers active and settled turns without spawning one command per
+  tool call.
 
 - Agent topics now come only from the latest user prompt in pane output. Native
   `Thinking`/`Executing` titles and other AI status text are no longer published

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,7 @@ for you) and Herdr `0.8.0+`.
 ```sh
 git clone https://github.com/levi-qiao/herdr-agent-quota
 cd herdr-agent-quota
-cargo build --release
-herdr plugin link .
+./install.sh
 ```
 
 ## Before opening a pull request
@@ -41,8 +40,11 @@ needs to say so explicitly in the pull request.
 4. **Every user-facing config edit is reversible.** `configure --apply` backs up
    what it replaces and `configure --uninstall` restores it. Both are
    idempotent.
-5. **No resident processes.** The statusLine hooks are one-shot, and the Codex
-   app-server subprocess is killed and reaped before the command returns.
+5. **No permanent resident processes.** StatusLine hooks are one-shot, the
+   Codex app-server subprocess is killed and reaped before the command returns,
+   and the active-turn refresh watcher is one bounded global worker. It polls
+   once per configured interval, exits when all turns settle, and has a safety
+   cap.
 
 ## Adding a provider
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,11 @@ latest user prompt rather than an AI-generated status.*
 - **Fully reversible** — one action sets it up, one action puts your config
   back exactly as it was.
 
-Install the plugin, then apply every reversible integration in one action
+For a downloaded checkout, one command applies every reversible integration
 ([quick start](#quick-start)):
 
 ```sh
-herdr plugin link . --enabled
-herdr plugin action invoke herdr-agent-quota.configure
+./install.sh
 ```
 
 The screenshot is a real local Herdr session. The values and topic text are
@@ -74,18 +73,34 @@ every provider adapter; only the window data differs.
 ## Quick start
 
 Requirements: Herdr `0.8.0+`, Rust `1.95+`, macOS or Linux, and at least one
-supported CLI. From this repository:
+supported CLI. If you downloaded this repository, the one-step installer does
+the build, link, enable, and reversible configuration for you:
+
+```sh
+./install.sh
+```
+
+To restore the previous sidebar/statusLine configuration and unlink the plugin:
+
+```sh
+./uninstall.sh
+```
+
+The scripts are idempotent. They leave the local quota snapshots in Herdr's
+plugin state directory; those contain no credentials and can be removed later
+if desired.
+
+The equivalent Herdr commands are:
 
 ```sh
 herdr plugin link . --enabled
 herdr plugin action invoke herdr-agent-quota.configure
 ```
 
-That is the complete Herdr setup. The first command builds and enables the
-plugin. The second action consistently uses Herdr's plugin state, applies the
+The configure action consistently uses Herdr's plugin state, applies the
 sidebar rows, installs or repairs the reversible Claude and Agy statusLine
-collectors, installs the Grok response hook, and reloads Herdr's config. You can run
-it again safely from Herdr's action menu as **Install / repair agent quota**.
+collectors, and reloads Herdr's config. You can
+run it again safely from Herdr's action menu as **Install / repair agent quota**.
 Use **Refresh agent quota** for a one-shot refresh, or
 press `prefix+shift+r` after configuration. The shortcut force-fetches Codex
 and Grok, then republishes the latest Claude and Agy statusLine snapshots. Run
@@ -98,8 +113,31 @@ herdr plugin action invoke herdr-agent-quota.refresh
 Herdr plugin v1 does not currently let plugins add buttons to the native agent
 group header, so the shortcut is the closest stable one-step entry point.
 Selecting a pane also runs a provider-only refresh, debounced to once per
-minute. That path does not read terminal content, and a pane currently viewing
-scrollback receives no metadata write until it returns to the bottom.
+minute. While any agent is working, one global background watcher polls the
+working provider set once per minute, publishes fresh cache values, and performs
+one final debounced pass when each provider settles. These pulses never read
+terminal content, and a pane currently viewing scrollback receives no metadata
+write until it returns to the bottom.
+
+The default poll interval is 60 seconds. To persist another value (30 seconds to
+one hour), pass it during installation:
+
+```sh
+./install.sh --watch-interval-seconds 300
+```
+
+Or update an existing installation with the same environment override:
+
+```sh
+HERDR_AGENT_QUOTA_WATCH_INTERVAL_SECONDS=300 \
+  herdr plugin action invoke herdr-agent-quota.configure
+```
+
+Each poll uses one global coordination lock and one `herdr agent list` call.
+Provider network fetches are independently capped at one per 60 seconds by the
+existing refresh markers, even if a shorter custom poll interval is requested.
+The watcher never sends prompts, starts a new login, refreshes credentials, or
+consumes model/chat tokens; a manual `--force` refresh is the explicit exception.
 
 Preview the changes without writing anything:
 
@@ -109,7 +147,8 @@ Preview the changes without writing anything:
 
 Remove every plugin-owned config edit and restore previous Claude/Agy
 statusLine commands with the one-click **Uninstall agent quota configuration**
-action, or invoke it from a shell:
+action, or invoke it from a shell (the `./uninstall.sh` wrapper above also
+unlinks the plugin):
 
 ```sh
 herdr plugin action invoke herdr-agent-quota.uninstall
@@ -122,12 +161,9 @@ through plugin actions so all collectors use the same Herdr state directory.
 The setup preserves Herdr's native state dot and plane/tab label. It only adds
 the provider, usage, and topic tokens, so the original Herdr agent indicator is
 not removed. Uninstall removes the plugin-owned rows and restores previous
-Claude and Agy statusLine commands. Setup also installs a silent global Grok hook:
-`PostToolUse` refreshes during long-running turns, while `Stop`, `StopFailure`, and
-`StopCancelled` cover final, failed, and cancelled replies. The hook runs the
-collector directly rather than invoking a Herdr action, and uninstall removes
-only that plugin-owned hook file. Restart existing Grok sessions once after setup
-so they load the new global hook.
+Claude and Agy statusLine commands. Older plugin-owned Grok response hooks are
+removed during configure; the single global watcher now covers Grok as well, so
+long turns no longer start one refresh command per tool call.
 
 ## Supported CLIs
 
@@ -135,7 +171,7 @@ so they load the new global hook.
 | --- | --- | --- | --- |
 | Claude Code `2.1.233` | `5h` + `week` | Official `statusLine` JSON: `rate_limits.five_hour` and `seven_day` | The configure action installs and chains it automatically |
 | OpenAI Codex `0.147.0` | `week` | One-shot local `codex app-server --stdio`, `account/rateLimits/read` | ChatGPT subscription login; API-key mode is shown as unavailable |
-| Grok CLI / Grok Build `1.0.4` | `week` | Local `~/.grok/auth.json` and the billing contract used by the official CLI | The configure action installs a silent active-response hook |
+| Grok CLI / Grok Build `1.0.4` | `week` | Local `~/.grok/auth.json` and the billing contract used by the official CLI | Covered by the unified watcher; no response hook is installed |
 | Agy / Antigravity CLI `1.1.13` | `5h` + `week` | Official `statusLine` JSON `quota` object (`gemini-*` and `3p-*` pools) | The configure action installs and chains it automatically |
 
 Versions above were checked on the development machine on 2026-08-15. The
@@ -145,9 +181,10 @@ strings, so newer compatible CLI releases can continue to work.
 The sidebar shows **percentage remaining** and the time until each reset, not
 token counts. Codex and Grok expose their weekly window. Claude Code and Agy
 expose both five-hour and weekly windows. Reset ETAs use minutes below one hour,
-hours and minutes below one day, and days plus hours above one day. They are
-recalculated on agent events or manual refresh; the sidebar does not run a
-resident minute-by-minute countdown.
+hours and minutes below one day, and days plus hours above one day. During a
+working turn, one short-lived global watcher polls once per configured interval,
+coalesces active fetches, and exits when all selected providers settle. The
+sidebar does not run a permanent daemon.
 
 A failed refresh never replaces a successful cached value with `unavailable`;
 a provider without any successful snapshot is shown as `N/A` until its first
@@ -229,13 +266,16 @@ such as `Thinking` or `Executing`. It does not show the working directory.
 - **Grok:** the local `~/.grok/auth.json` login key is read in memory and sent
   to the weekly billing endpoint used by the Grok CLI. The response is accepted
   only when it identifies a weekly period. This is SuperGrok usage, not xAI
-  developer/API-team billing.
+  developer/API-team billing. The unified watcher and the existing 60-second
+  debounce limit active requests; it never logs in or refreshes the key.
 - **Claude Code:** the official [`statusLine` JSON hook](https://code.claude.com/docs/en/statusline)
   supplies the five-hour and seven-day values. A previous statusLine command is
-  backed up, chained, and restored by the uninstall action.
+  backed up, chained, and restored by the uninstall action; the active-turn
+  watcher republishes each new snapshot without calling Herdr from that hook.
 - **Agy/Antigravity:** the official [`/usage` and statusline docs](https://antigravity.google/docs/cli/commands/usage?app=antigravity-ide)
   supply Gemini and third-party pools. When both pools exist, the sidebar uses
-  the lowest remaining percentage so the single Agy row is conservative.
+  the lowest remaining percentage so the single Agy row is conservative; its
+  statusLine cache is published by the same active-turn watcher.
 
 Snapshots and refresh markers stay in Herdr's plugin state directory. No usage
 data is uploaded, browser cookies or browser keychains are read, and provider
@@ -254,7 +294,7 @@ weekly value instead of clearing the sidebar.
 | Claude or Agy is `N/A` | Start a conversation so the native `statusLine` emits JSON; then refresh. |
 | Claude briefly changes while switching panes | The cached value is retained; run one prompt or a manual refresh if no snapshot exists yet. |
 | Agy has no quota | Run **Install / repair agent quota**, start one Agy turn, then manually refresh. |
-| A running Grok goal stays stale | Run **Install / repair agent quota**, then restart that Grok session once so it loads the updated global hook. |
+| A running Grok goal stays stale | Run **Install / repair agent quota**, then start the next turn; the unified watcher will pick up working sessions. |
 | The topic is blank or old | Send a prompt in that pane; topic extraction runs on agent events and needs recent output. |
 | Existing Claude statusLine is not changed | Run `configure --check`; the plugin refuses unsafe non-command settings instead of overwriting them. |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,11 +32,10 @@ Codex、Grok 显示周额度；每张 agent 卡片的话题来自用户最后一
   `unavailable`；API key 登录也不会被当成订阅额度显示。
 - **完全可回滚** —— 一个 action 装好，一个 action 原样还原你的配置。
 
-链接插件后，用一个 action 批量安装所有可恢复的集成（[快速开始](#快速开始)）：
+下载仓库后执行一个命令即可批量安装所有可恢复的集成（[快速开始](#快速开始)）：
 
 ```sh
-herdr plugin link . --enabled
-herdr plugin action invoke herdr-agent-quota.configure
+./install.sh
 ```
 
 截图是真实的 Herdr 本地会话。其中的额度和话题来自当时的会话，
@@ -66,22 +65,57 @@ herdr plugin action invoke herdr-agent-quota.configure
 ## 快速开始
 
 要求：Herdr `0.8.0+`、Rust `1.95+`、macOS 或 Linux，以及至少一个支持的
-CLI。在仓库目录执行：
+CLI。下载仓库后，在目录中执行下面的一键安装命令即可完成构建、链接、启用和
+可恢复配置：
+
+```sh
+./install.sh
+```
+
+恢复原来的 sidebar/statusLine 配置并解除插件链接：
+
+```sh
+./uninstall.sh
+```
+
+两个脚本都可以重复执行。卸载会保留 Herdr 插件 state 中的本地额度快照（不含
+凭证）；如需释放磁盘空间可再手动删除。
+
+等价的 Herdr 命令是：
 
 ```sh
 herdr plugin link . --enabled
 herdr plugin action invoke herdr-agent-quota.configure
 ```
 
-以上就是完整配置流程。第一条命令构建并启用插件；第二个 action 会统一使用
-Herdr 的插件 state 目录，批量写入 sidebar 行、安装或修复可恢复的 Claude/Agy
-statusLine 采集器、安装 Grok 回复 hook，并自动 reload 配置。之后可随时在 Herdr
-action 菜单执行 **Install / repair agent quota**，重复执行也是安全的。需要手动
-刷新时执行 **Refresh agent quota**。
+configure action 会统一使用 Herdr 的插件 state 目录，批量写入 sidebar 行、安装
+或修复可恢复的 Claude/Agy statusLine 采集器，并自动 reload 配置。之后可随时在
+Herdr action 菜单执行 **Install / repair agent quota**，重复
+执行也是安全的。需要手动刷新时执行 **Refresh agent quota**。
 
 选中一个 pane 时也会触发该 provider 的额度刷新，60 秒内自动合并重复请求。
-这条路径不会读取终端内容；如果 pane 正在查看 scrollback，则暂缓 metadata
-写入，回到底部后再补上，避免刷新把 viewport 拉走。
+进入 working 后，插件只启动一个全局短生命周期 watcher：每轮只调用一次
+`herdr agent list`，统一找出所有 working provider，再批量发布缓存并按相同去抖规则
+查询 Codex/Grok；每个 provider 结束时再按去抖规则补一次。
+这条路径不会读取终端内容；如果 pane 正在查看 scrollback，则暂缓 metadata 写入，
+回到底部后再补上，避免刷新把 viewport 拉走。默认轮询间隔为 60 秒，可在安装时自定义
+为 30 秒到 1 小时：
+
+```sh
+./install.sh --watch-interval-seconds 300
+```
+
+已有安装也可以这样更新间隔：
+
+```sh
+HERDR_AGENT_QUOTA_WATCH_INTERVAL_SECONDS=300 \
+  herdr plugin action invoke herdr-agent-quota.configure
+```
+
+每轮只使用一个全局协调锁和一次 `herdr agent list`。各 provider 的网络查询仍由
+原有刷新标记独立限制为每 60 秒最多一次，即使用户把轮询间隔设得更短也不会突破。
+watcher 不发送 prompt、不重新登录、不刷新凭证，也不会消耗模型/对话 token；只有用户
+明确执行手动 `--force` 刷新时才绕过这层去抖。
 
 只查看配置变更、不写入文件：
 
@@ -108,10 +142,10 @@ usage、topic 三类 token，不会覆盖官方 agent 指示。卸载 action 会
 
 | CLI | 侧栏显示 | 本地数据来源 | 额外配置 |
 | --- | --- | --- | --- |
-| Claude Code `2.1.233` | `5h` + `week` | 官方 `statusLine` JSON：`rate_limits.five_hour`、`seven_day` | 配置 action 自动安装并串联原命令 |
-| OpenAI Codex `0.147.0` | `week` | 一次性的 `codex app-server --stdio`，调用 `account/rateLimits/read` | 使用 ChatGPT 订阅登录；API key 模式显示为不可用 |
-| Grok CLI / Grok Build `1.0.4` | `week` | `~/.grok/auth.json` 和官方 CLI 使用的额度接口 | 配置 action 安装运行中与回合结束 hook |
-| Agy / Antigravity CLI `1.1.13` | `5h` + `week` | 官方 `statusLine` JSON 的 `quota`（`gemini-*`、`3p-*`） | 配置 action 自动安装并串联原命令 |
+| Claude Code `2.1.233` | `5h` + `week` | 官方 `statusLine` JSON：`rate_limits.five_hour`、`seven_day` | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
+| OpenAI Codex `0.147.0` | `week` | 一次性的 `codex app-server --stdio`，调用 `account/rateLimits/read` | 使用 ChatGPT 订阅登录；API key 模式显示为不可用；turn 中由统一 watcher 去抖查询 |
+| Grok CLI / Grok Build `1.0.4` | `week` | `~/.grok/auth.json` 和官方 CLI 使用的额度接口 | 由统一 watcher 处理，不再安装回复 hook |
+| Agy / Antigravity CLI `1.1.13` | `5h` + `week` | 官方 `statusLine` JSON 的 `quota`（`gemini-*`、`3p-*`） | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
 
 上面的版本是 2026-08-15 在开发机上实际检查的版本。解析器按照供应商的
 字段工作，不会把这些版本号写死；兼容的新版本可以继续使用。
@@ -127,7 +161,8 @@ usage、topic 三类 token，不会覆盖官方 agent 指示。卸载 action 会
 
 Codex 和 Grok 提供周额度；Claude Code 和 Agy 提供 5 小时额度与周额度。
 不到一小时显示分钟，不到一天显示小时和分钟，超过一天显示天和小时。
-侧栏数值在 agent 事件或手动刷新时重新计算，不是常驻的逐分钟跳动倒计时。
+侧栏数值在 agent 事件、working turn 的短生命周期刷新脉冲或手动刷新时重新计算，
+不是常驻的逐分钟跳动倒计时。
 刷新失败时，插件会保留上一次成功的缓存值，不会把旧值清空为
 `unavailable`。从未成功采集过的 provider 才会显示 `N/A`。
 
@@ -198,17 +233,16 @@ Herdr plugin v1 只支持文本 token，不能由插件向原生 Agent renderer 
   ChatGPT 订阅额度。
 - **Grok：** 在内存中读取本地 `~/.grok/auth.json` 登录 key，访问 Grok CLI
   使用的周额度接口。只有明确标记为 weekly 的响应才会接受。这是
-  SuperGrok 订阅额度，不是 xAI 开发者/API team 账单。`PostToolUse` 会在
-  长任务的工具调用之间刷新，`Stop`/`StopFailure`/`StopCancelled` 覆盖最终、
-  失败和取消的回复；hook 直接运行采集器，不经过 Herdr action。
+  SuperGrok 订阅额度，不是 xAI 开发者/API team 账单。统一 watcher 配合原有
+  60 秒去抖查询额度，不会反复登录、刷新登录 key，也不会消耗对话 token。
 - **Claude Code：** 使用官方
   [`statusLine` JSON hook](https://code.claude.com/docs/en/statusline) 提供
   5 小时和 7 天额度。原有 statusLine 会被备份、串联，并可由
-  卸载 action 恢复。
+  卸载 action 恢复；working turn 中由统一 watcher 发布新缓存。
 - **Agy/Antigravity：** 使用官方
   [`/usage` 和 statusline 文档](https://antigravity.google/docs/cli/commands/usage?app=antigravity-ide)
   中的 Gemini 和第三方额度池。两个额度池同时存在时，取较低的剩余百分比，
-  让单个 Agy 行保持保守。
+  让单个 Agy 行保持保守，working turn 中同样由统一 watcher 发布缓存。
 
 快照和刷新标记保存在 Herdr 插件状态目录中。插件不会上传使用数据，不读取
 浏览器 Cookie/Keychain，不刷新或写入 provider 凭据。provider 失败时保留
@@ -225,7 +259,7 @@ Grok CLI 的额度接口属于 CLI 内部契约，不是 xAI 面向开发者的�
 | Claude 或 Agy 显示 `N/A` | 发起一次对话，让原生 `statusLine` 产生 JSON，然后刷新。 |
 | 切换 pane 时 Claude 短暂变化 | 已有缓存会保留；如果还没有快照，发送一次 prompt 或手动刷新。 |
 | Agy 没有额度 | 执行 **Install / repair agent quota**，完成一次 Agy 对话后再手动刷新。 |
-| 运行中的 Grok goal 额度不更新 | 执行 **Install / repair agent quota** 后重启一次该 Grok session，让它加载新的全局 hook。 |
+| 任一运行中的 turn 额度不更新 | 执行 **Install / repair agent quota**，下一次 working turn 会自动启动统一 watcher，回合结束时还会按去抖规则补一次。 |
 | 话题为空或没有更新 | 在该 pane 发送 prompt；话题提取依赖 agent 事件和最近输出。 |
 | 原有 Claude statusLine 没有被修改 | 执行 `configure --check`；对于不能安全串联的配置，插件会拒绝覆盖。 |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,10 +14,11 @@ Useful context when judging impact:
 - **Reads** `~/.grok/auth.json` (login key only), Claude Code and Agy
   statusLine JSON on stdin, and the local `codex app-server` JSON-RPC socket.
 - **Writes** sanitized percentages to Herdr's plugin state directory,
-  `~/.config/herdr/config.toml`, `~/.claude/settings.json`,
-  `~/.gemini/antigravity-cli/settings.json`, and one plugin-owned file under
-  `~/.grok/hooks`. User-owned statusLine values are backed up and restored by
-  the uninstall action; the Grok hook file is never shared with user content.
+  `~/.config/herdr/config.toml`, `~/.claude/settings.json`, and
+  `~/.gemini/antigravity-cli/settings.json`. Active-turn coordination locks, a
+  configurable poll interval, and a temporary stop marker are also kept in
+  that plugin state directory. Older plugin-owned Grok hook files may be
+  removed during migration; user-owned hook content is never replaced.
 - **Sends** one authenticated request to the Grok CLI billing endpoint. This is
   the only outbound network call in the project. No usage data is uploaded
   anywhere.

--- a/docs/plans/herdr-agent-quota-implementation.md
+++ b/docs/plans/herdr-agent-quota-implementation.md
@@ -17,9 +17,11 @@ active local account's subscription quota in Herdr:
 - Herdr Agents sidebar: a readable provider/status row plus a quota row per agent.
 - Optional read-only terminal pane: expanded quota details and diagnostics.
 
-The plugin must be lightweight. It must not run a resident daemon. Refreshes are
-one-shot commands triggered by Herdr startup, selected agent lifecycle events, or
-the user. Between triggers, the last successful value remains visible indefinitely.
+The plugin must be lightweight. It must not run a permanent resident daemon.
+Refreshes are one-shot commands triggered by Herdr startup, selected agent
+lifecycle events, or the user; one bounded global watcher may run only while an
+agent is working. Between triggers, the last successful value remains visible
+indefinitely.
 
 ## 2. Frozen product decisions
 
@@ -55,7 +57,7 @@ the user. Between triggers, the last successful value remains visible indefinite
 - Multiple accounts for one provider.
 - xAI developer/API-team usage. Grok must show the SuperGrok weekly pool.
 - Browser Cookie, Keychain, or web-page scraping fallbacks.
-- A resident polling daemon, OS service, or scheduled job.
+- A permanent polling daemon, OS service, or scheduled job.
 - Resident minute-by-minute countdowns, `updated N minutes ago`, automatic stale
   transitions, alerts, notifications, or usage history.
 - Windows support.
@@ -175,10 +177,12 @@ Keep the public surface small:
 
 ```text
 herdr-agent-quota refresh [--provider codex|grok|claude|all] [--force] [--json]
+herdr-agent-quota watch [--provider codex|grok|claude|agy|all] [--interval-seconds N]
 herdr-agent-quota event
 herdr-agent-quota dashboard
 herdr-agent-quota configure --check
 herdr-agent-quota configure --apply
+herdr-agent-quota configure --apply --watch-interval-seconds N
 herdr-agent-quota configure --uninstall
 herdr-agent-quota claude-statusline
 herdr-agent-quota agy-statusline
@@ -186,7 +190,12 @@ herdr-agent-quota agy-statusline
 
 - `refresh`: fetch, normalize, cache, and publish quota tokens.
 - `event`: read `HERDR_PLUGIN_EVENT_JSON`, identify affected provider(s), debounce,
-  and call the same refresh service.
+  call the same refresh service, and start one global `watch` pulse for a
+  working turn.
+- `watch`: call `herdr agent list` once per configured interval, publish
+  statusLine cache changes and debounced active fetches for every working
+  provider, perform one final debounced pass when it settles, and exit after a safety
+  cap if Herdr becomes unavailable. It never reads pane output.
 - `dashboard`: render cached values and explicit unavailable reasons; pressing `r`
   may force a refresh, but the pane must not poll automatically.
 - `configure`: manage Herdr rows and the Claude statusLine wrapper.
@@ -207,9 +216,11 @@ Declare one-shot startup and event hooks in `herdr-plugin.toml`:
 - Manual action: force refresh all providers.
 
 Use a state-file timestamp and a cross-process lock to coalesce non-forced provider
-refreshes occurring within 60 seconds. A manual refresh bypasses the timestamp but
-still takes the lock. Do not subscribe to raw output or `pane.updated`; those events
-are too frequent for quota checks. The `pane.focused` path must stay provider-only,
+refreshes occurring within 60 seconds. The active-turn watcher uses one global
+coordination lock and a configurable 60-second poll interval (30 seconds to one
+hour); a manual refresh bypasses the timestamp but still takes the lock. Do not
+subscribe to raw output or `pane.updated`; those events are too frequent for quota
+checks. The `pane.focused` path must stay provider-only,
 must not read pane content, and must skip metadata reports while the pane is in
 scrollback so it cannot recreate the original viewport feedback loop.
 
@@ -455,8 +466,9 @@ Owner scope: `src/herdr.rs`, `src/refresh.rs`, event fixtures, manifest hooks.
 - Discover provider panes from v0.8 JSON output.
 - Map cached provider snapshots to the readable provider/status/summary tokens.
 - Report metadata to every matching pane without altering semantic state.
-- Implement startup, approved event hooks, force refresh, cross-process coalescing,
-  monotonic sequence values, and partial provider failure.
+- Implement startup, approved event hooks, bounded active-turn pulses, force
+  refresh, cross-process coalescing, monotonic sequence values, and partial
+  provider failure.
 
 Exit criterion: mocked Herdr commands prove exact argv/token values; a local Herdr
 smoke test shows different provider quotas on matching agent rows.
@@ -498,7 +510,8 @@ Depends on: packages 2–7.
   their values.
 - Verify startup and each declared Herdr event hook.
 - Kill/exit every short-lived child and confirm no `herdr-agent-quota`, Codex
-  app-server, or dashboard process remains after the relevant command ends.
+  app-server, dashboard, or settled-turn watcher remains after the relevant
+  command ends.
 - Inspect logs and fixtures for bearer tokens, refresh tokens, Cookies, emails, and
   account IDs.
 
@@ -518,7 +531,7 @@ Depends on: package 8 passing.
 - README first sentence:
   `Show Claude Code, Codex, Grok, and Agy subscription usage in Herdr's agent sidebar.`
 - Explain exact data sources, remaining-percentage semantics, single-account scope,
-  no-daemon behavior, retained old values, configuration, uninstall, and provider
+  bounded active-turn behavior, retained old values, configuration, uninstall, and provider
   failure messages.
 - Include a real screenshot with no private workspace or account data.
 - GitHub description:
@@ -572,7 +585,8 @@ The project is done only when all of the following are true:
 - With no further events, the last successful usage remains displayed unchanged.
 - A manual refresh updates all available providers and does not erase old successes
   when one provider fails.
-- No resident background service exists.
+- No permanent background service exists; one active-turn watcher is bounded and
+  stops when all selected providers' agents settle.
 - Config apply is previewable, idempotent, backed up, and precisely reversible.
 - Existing Claude statusLine behavior survives apply and uninstall.
 - No provider credential or browser Cookie is stored, logged, or committed.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -2,7 +2,7 @@ id = "herdr-agent-quota"
 name = "Herdr Agent Quota"
 version = "0.1.0"
 min_herdr_version = "0.8.0"
-description = "Never hit a quota limit mid-task: see Claude, Codex, Grok and Agy usage live in your Herdr sidebar. 5h and weekly percent remaining, updated on every agent event."
+description = "Never hit a quota limit mid-task: see Claude, Codex, Grok and Agy usage live in your Herdr sidebar. 5h and weekly percent remaining, refreshed throughout active turns."
 platforms = ["macos", "linux"]
 
 [[build]]

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Build, link, enable, and configure herdr-agent-quota in one step.
+#
+# Usage:
+#   ./install.sh
+#   ./install.sh --watch-interval-seconds 300
+#
+# The matching uninstall.sh first restores every configuration entry owned by
+# this plugin and only then unlinks it from Herdr.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+WATCH_INTERVAL_SECONDS=""
+
+while (($# > 0)); do
+  case "$1" in
+    --watch-interval-seconds)
+      (($# >= 2)) || { printf 'error: missing value for %s\n' "$1" >&2; exit 1; }
+      WATCH_INTERVAL_SECONDS="$2"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,8p' "$0"
+      exit 0
+      ;;
+    *)
+      printf 'error: unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v herdr >/dev/null 2>&1 || die "Herdr is not installed or not on PATH"
+command -v cargo >/dev/null 2>&1 || die "Rust/Cargo is not installed or not on PATH"
+
+printf '%s\n' '→ building herdr-agent-quota'
+cargo build --release --locked --manifest-path "$ROOT/Cargo.toml"
+
+printf '%s\n' '→ linking and enabling the Herdr plugin'
+herdr plugin link "$ROOT" --enabled
+
+printf '%s\n' '→ installing reversible sidebar and provider collectors'
+if [[ -n "$WATCH_INTERVAL_SECONDS" ]]; then
+  HERDR_AGENT_QUOTA_WATCH_INTERVAL_SECONDS="$WATCH_INTERVAL_SECONDS" \
+    herdr plugin action invoke herdr-agent-quota.configure
+else
+  herdr plugin action invoke herdr-agent-quota.configure
+fi
+
+printf '%s\n' 'Installed. Restart already-running agent sessions once so they load the refreshed hooks.'

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,9 +1,15 @@
 use crate::model::{Provider, ProviderSnapshot};
 use anyhow::{Context, Result};
 use directories::ProjectDirs;
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions, TryLockError};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const DEFAULT_WATCH_INTERVAL_SECONDS: u64 = 60;
+pub const MIN_WATCH_INTERVAL_SECONDS: u64 = 30;
+pub const MAX_WATCH_INTERVAL_SECONDS: u64 = 60 * 60;
+const WATCH_INTERVAL_ENV: &str = "HERDR_AGENT_QUOTA_WATCH_INTERVAL_SECONDS";
+const WATCH_INTERVAL_FILE: &str = "watch-interval-seconds";
 
 #[derive(Debug, Clone)]
 pub struct CacheStore {
@@ -91,6 +97,104 @@ impl CacheStore {
         }
     }
 
+    /// Try to claim a named long-running coordination lock.
+    ///
+    /// Active-turn refreshers are started by two Herdr events at the same
+    /// boundary (and there may be several working providers). A non-blocking
+    /// OS lock lets the first global watcher own the poll loop while later
+    /// starts exit immediately instead of creating duplicate pollers.
+    pub fn try_lock_named(&self, name: &str) -> Result<Option<File>> {
+        self.ensure()?;
+        let path = self.root.join(name);
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)
+            .with_context(|| format!("open {}", path.display()))?;
+        match file.try_lock() {
+            Ok(()) => Ok(Some(file)),
+            Err(TryLockError::WouldBlock) => Ok(None),
+            Err(error) => Err(error).with_context(|| format!("lock {}", path.display())),
+        }
+    }
+
+    pub fn stop_turn_watchers(&self) -> Result<()> {
+        self.ensure()?;
+        fs::write(
+            self.root.join("turn-watch.stop"),
+            Self::now_millis().to_string(),
+        )
+        .context("stop active-turn quota watchers")
+    }
+
+    pub fn clear_turn_watcher_stop(&self) -> Result<()> {
+        let path = self.root.join("turn-watch.stop");
+        match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error).context("clear active-turn watcher stop marker"),
+        }
+    }
+
+    pub fn turn_watchers_stopped_after(&self, started_millis: u64) -> Result<bool> {
+        let path = self.root.join("turn-watch.stop");
+        let Ok(value) = fs::read_to_string(path) else {
+            return Ok(false);
+        };
+        Ok(value
+            .trim()
+            .parse::<u64>()
+            .is_ok_and(|stopped| stopped >= started_millis))
+    }
+
+    /// Return the configured active-turn polling interval.
+    ///
+    /// An environment override is useful for one-off runs and installation
+    /// scripts; the state file is the persistent user setting. Invalid or
+    /// out-of-range values deliberately fall back to the safe default.
+    pub fn watch_interval_seconds(&self) -> u64 {
+        std::env::var(WATCH_INTERVAL_ENV)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .and_then(Self::valid_watch_interval)
+            .or_else(|| {
+                fs::read_to_string(self.watch_interval_path())
+                    .ok()
+                    .and_then(|value| value.trim().parse().ok())
+                    .and_then(Self::valid_watch_interval)
+            })
+            .unwrap_or(DEFAULT_WATCH_INTERVAL_SECONDS)
+    }
+
+    pub fn set_watch_interval_seconds(&self, seconds: u64) -> Result<()> {
+        Self::valid_watch_interval(seconds).with_context(|| {
+            format!(
+                "watch interval must be between {MIN_WATCH_INTERVAL_SECONDS} and {MAX_WATCH_INTERVAL_SECONDS} seconds"
+            )
+        })?;
+        self.ensure()?;
+        fs::write(self.watch_interval_path(), seconds.to_string())
+            .context("write active-turn watch interval")
+    }
+
+    pub fn clear_watch_interval(&self) -> Result<()> {
+        match fs::remove_file(self.watch_interval_path()) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error).context("remove active-turn watch interval"),
+        }
+    }
+
+    pub fn validate_watch_interval_seconds(seconds: u64) -> Result<u64> {
+        Self::valid_watch_interval(seconds).with_context(|| {
+            format!(
+                "watch interval must be between {MIN_WATCH_INTERVAL_SECONDS} and {MAX_WATCH_INTERVAL_SECONDS} seconds"
+            )
+        })
+    }
+
     pub fn should_debounce(
         &self,
         provider: Provider,
@@ -133,6 +237,16 @@ impl CacheStore {
     fn refresh_marker_path(&self, provider: Provider) -> PathBuf {
         self.root.join(format!("{}.refresh", provider.source()))
     }
+
+    fn watch_interval_path(&self) -> PathBuf {
+        self.root.join(WATCH_INTERVAL_FILE)
+    }
+
+    fn valid_watch_interval(seconds: u64) -> Option<u64> {
+        (MIN_WATCH_INTERVAL_SECONDS..=MAX_WATCH_INTERVAL_SECONDS)
+            .contains(&seconds)
+            .then_some(seconds)
+    }
 }
 
 #[cfg(test)]
@@ -171,5 +285,60 @@ mod tests {
         cache.mark_refresh(Provider::Codex, 100).unwrap();
         assert!(cache.should_debounce(Provider::Codex, 120, 60).unwrap());
         assert!(!cache.should_debounce(Provider::Codex, 161, 60).unwrap());
+    }
+
+    #[test]
+    fn named_turn_lock_is_non_blocking_and_exclusive() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let first = cache.try_lock_named("codex.turn.lock").unwrap();
+        assert!(first.is_some());
+        let second = cache.try_lock_named("codex.turn.lock").unwrap();
+        assert!(second.is_none());
+        drop(first);
+        assert!(cache.try_lock_named("codex.turn.lock").unwrap().is_some());
+    }
+
+    #[test]
+    fn watcher_stop_marker_is_reversible_for_reinstall() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache.stop_turn_watchers().unwrap();
+        assert!(cache
+            .turn_watchers_stopped_after(CacheStore::now_millis().saturating_sub(1))
+            .unwrap());
+        cache.clear_turn_watcher_stop().unwrap();
+        assert!(!cache
+            .turn_watchers_stopped_after(CacheStore::now_millis().saturating_sub(1))
+            .unwrap());
+    }
+
+    #[test]
+    fn watch_interval_defaults_and_persists_a_safe_custom_value() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        assert_eq!(
+            cache.watch_interval_seconds(),
+            DEFAULT_WATCH_INTERVAL_SECONDS
+        );
+        cache.set_watch_interval_seconds(300).unwrap();
+        assert_eq!(cache.watch_interval_seconds(), 300);
+        cache.clear_watch_interval().unwrap();
+        assert_eq!(
+            cache.watch_interval_seconds(),
+            DEFAULT_WATCH_INTERVAL_SECONDS
+        );
+    }
+
+    #[test]
+    fn watch_interval_rejects_values_that_are_too_short_or_long() {
+        assert!(
+            CacheStore::validate_watch_interval_seconds(MIN_WATCH_INTERVAL_SECONDS - 1).is_err()
+        );
+        assert!(
+            CacheStore::validate_watch_interval_seconds(MAX_WATCH_INTERVAL_SECONDS + 1).is_err()
+        );
+        assert!(CacheStore::validate_watch_interval_seconds(MIN_WATCH_INTERVAL_SECONDS).is_ok());
+        assert!(CacheStore::validate_watch_interval_seconds(MAX_WATCH_INTERVAL_SECONDS).is_ok());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,15 @@ pub enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Keep selected working providers' quotas fresh with one global poller.
+    /// This is started automatically by the Herdr status event hook.
+    Watch {
+        #[arg(long, default_value = "all")]
+        provider: ProviderSelection,
+        /// Override the configured poll interval for this run.
+        #[arg(long)]
+        interval_seconds: Option<u64>,
+    },
     Event,
     Focus,
     Dashboard,
@@ -32,6 +41,9 @@ pub enum Command {
         apply: bool,
         #[arg(long, conflicts_with_all = ["check", "apply"])]
         uninstall: bool,
+        /// Persist the active-turn poll interval while applying configuration.
+        #[arg(long, requires = "apply")]
+        watch_interval_seconds: Option<u64>,
     },
     ClaudeStatusline,
     AgyStatusline,

--- a/src/configure/grok.rs
+++ b/src/configure/grok.rs
@@ -1,6 +1,5 @@
 use crate::cache::CacheStore;
 use anyhow::{Context, Result};
-use serde_json::json;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -11,10 +10,13 @@ const MANAGED_BY: &str = "herdr-agent-quota";
 pub fn check() -> Result<()> {
     let path = hook_path()?;
     if is_managed_hook(&path) {
-        println!("Grok quota hook is already installed: {}", path.display());
+        println!(
+            "Legacy Grok quota hook will be removed; the unified active-turn watcher handles refreshes: {}",
+            path.display()
+        );
     } else {
         println!(
-            "Grok quota hook preview for {}: refresh during active turns and after final replies",
+            "No Grok response hook is needed; the unified active-turn watcher handles {}",
             path.display()
         );
     }
@@ -31,30 +33,13 @@ pub fn uninstall() -> Result<()> {
     uninstall_at(&hook_path()?)
 }
 
-pub fn apply_at(path: &Path, state: &Path, executable: &Path) -> Result<()> {
-    let desired = hook_document(state, executable);
-    if path.exists() {
-        let current = fs::read_to_string(path).context("read Grok quota hook")?;
-        if current == desired {
-            return Ok(());
-        }
-        if !current.contains(LEGACY_REFRESH_ACTION) && !current.contains(MANAGED_BY) {
-            anyhow::bail!(
-                "refusing to replace user-owned Grok hook file {}",
-                path.display()
-            );
-        }
+pub fn apply_at(path: &Path, _state: &Path, _executable: &Path) -> Result<()> {
+    // The unified watcher replaces the old per-tool Grok hook. Only remove a
+    // file that this plugin owns; a user's unrelated hook is never touched.
+    if is_managed_hook(path) {
+        fs::remove_file(path).context("remove legacy Grok quota hook")?;
+        println!("Removed legacy Grok quota hook from {}", path.display());
     }
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).context("create Grok hooks directory")?;
-    }
-    let temporary = path.with_extension("json.herdr-agent-quota.tmp");
-    fs::write(&temporary, desired).context("write Grok quota hook")?;
-    fs::rename(&temporary, path).context("replace Grok quota hook")?;
-    println!(
-        "Installed silent Grok active-response refresh hook at {}",
-        path.display()
-    );
     Ok(())
 }
 
@@ -79,34 +64,4 @@ fn is_managed_hook(path: &Path) -> bool {
         contents.contains(LEGACY_REFRESH_ACTION)
             || (contents.contains(MANAGED_BY) && contents.contains("refresh --provider grok"))
     })
-}
-
-fn hook_document(state: &Path, executable: &Path) -> String {
-    let command = format!(
-        "HERDR_PLUGIN_STATE_DIR={} {} refresh --provider grok >/dev/null 2>&1",
-        shell_quote(state),
-        shell_quote(executable)
-    );
-    let handler = json!({
-        "hooks": [{
-            "type": "command",
-            "command": command,
-            "timeout": 3
-        }]
-    });
-    serde_json::to_string_pretty(&json!({
-        "hooks": {
-            "PostToolUse": [handler.clone()],
-            "Stop": [handler.clone()],
-            "StopFailure": [handler.clone()],
-            "StopCancelled": [handler]
-        },
-        "managedBy": MANAGED_BY
-    }))
-    .expect("serialize static Grok hook")
-        + "\n"
-}
-
-fn shell_quote(path: &Path) -> String {
-    format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
 }

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Item, Table, Value};
 
 const QUOTA_ROW_MARKERS: [&str; 18] = [
@@ -27,6 +27,7 @@ const ROW_GAP_MARKER: &str = "herdr-agent-quota";
 const PROVIDER_STYLE_MARKER: &str = "herdr-agent-quota-provider";
 const REFRESH_KEY: &str = "prefix+shift+r";
 const REFRESH_ACTION: &str = "herdr-agent-quota.refresh";
+const CONFIG_PRESENCE_FILE: &str = "herdr-config.original.present";
 const QUOTA_SAFE_COLOR: &str = "#84b084";
 const QUOTA_WARNING_COLOR: &str = "#cdaa65";
 const QUOTA_DANGER_COLOR: &str = "#ca6470";
@@ -55,20 +56,14 @@ pub fn check() -> Result<()> {
 
 pub fn apply() -> Result<()> {
     let path = config_path()?;
+    let existed = path.exists();
     let original = fs::read_to_string(&path).unwrap_or_default();
     let updated = add_quota_row(&original)?;
     if updated == original {
         return Ok(());
     }
-    if !original.is_empty() {
-        if let Some(backup) = backup_path()? {
-            if let Some(parent) = backup.parent() {
-                fs::create_dir_all(parent).context("create plugin state directory")?;
-            }
-            if !backup.exists() {
-                fs::write(backup, &original).context("write Herdr config backup")?;
-            }
-        }
+    if let Some(backup) = backup_path()? {
+        write_backup(&backup, &original, existed)?;
     }
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).context("create Herdr config directory")?;
@@ -80,18 +75,31 @@ pub fn apply() -> Result<()> {
 
 pub fn uninstall() -> Result<()> {
     let path = config_path()?;
-    if !path.exists() {
-        return Ok(());
-    }
-    let original = fs::read_to_string(&path).context("read Herdr config")?;
-    let updated = remove_quota_row(&original)?;
-    if updated != original {
-        fs::write(&path, updated).context("remove quota sidebar row")?;
-        println!("Removed quota sidebar row from {}", path.display());
+    if path.exists() {
+        let original = fs::read_to_string(&path).context("read Herdr config")?;
+        let updated = reversible_backup(&original)?.unwrap_or(remove_quota_row(&original)?);
+        let originally_absent = backup_presence_path()?
+            .and_then(|path| fs::read_to_string(path).ok())
+            .is_some_and(|value| value.trim() == "absent");
+        if originally_absent && updated.is_empty() {
+            fs::remove_file(&path).context("remove empty Herdr config")?;
+            println!(
+                "Removed quota sidebar configuration from {}",
+                path.display()
+            );
+        } else if updated != original {
+            fs::write(&path, updated).context("remove quota sidebar row")?;
+            println!("Removed quota sidebar row from {}", path.display());
+        }
     }
     if let Some(backup) = backup_path()? {
         if backup.exists() {
             fs::remove_file(backup).context("remove Herdr config backup")?;
+        }
+        if let Some(presence) = backup_presence_path()? {
+            if presence.exists() {
+                fs::remove_file(presence).context("remove Herdr config backup marker")?;
+            }
         }
     }
     Ok(())
@@ -108,6 +116,40 @@ pub fn config_path() -> Result<PathBuf> {
 fn backup_path() -> Result<Option<PathBuf>> {
     let state = std::env::var_os("HERDR_PLUGIN_STATE_DIR");
     Ok(state.map(|directory| PathBuf::from(directory).join("herdr-config.original.toml")))
+}
+
+fn backup_presence_path() -> Result<Option<PathBuf>> {
+    Ok(std::env::var_os("HERDR_PLUGIN_STATE_DIR")
+        .map(PathBuf::from)
+        .map(|directory| directory.join(CONFIG_PRESENCE_FILE)))
+}
+
+fn write_backup(path: &Path, original: &str, existed: bool) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).context("create plugin state directory")?;
+    }
+    if !path.exists() {
+        fs::write(path, original).context("write Herdr config backup")?;
+        if let Some(marker) = backup_presence_path()? {
+            fs::write(marker, if existed { "present" } else { "absent" })
+                .context("write Herdr config backup marker")?;
+        }
+    }
+    Ok(())
+}
+
+fn reversible_backup(current: &str) -> Result<Option<String>> {
+    let Some(path) = backup_path()? else {
+        return Ok(None);
+    };
+    if !path.exists() {
+        return Ok(None);
+    }
+    let original = fs::read_to_string(&path).context("read Herdr config backup")?;
+    if add_quota_row(&original)? == current {
+        return Ok(Some(original));
+    }
+    Ok(None)
 }
 
 pub fn add_quota_row(input: &str) -> Result<String> {
@@ -154,6 +196,9 @@ pub fn add_quota_row(input: &str) -> Result<String> {
 pub fn remove_quota_row(input: &str) -> Result<String> {
     if input.trim().is_empty() {
         return Ok(input.to_string());
+    }
+    if add_quota_row("")?.as_str() == input {
+        return Ok(String::new());
     }
     let mut document = input
         .parse::<DocumentMut>()
@@ -565,5 +610,11 @@ claude = [["state_icon", "agent"]]
         let removed = remove_quota_row(&updated).unwrap();
         assert!(removed.contains("claude = [[\"state_icon\", \"agent\"]]"));
         assert!(!removed.contains("codex ="));
+    }
+
+    #[test]
+    fn empty_sidebar_configuration_round_trips_to_empty() {
+        let updated = add_quota_row("").unwrap();
+        assert_eq!(remove_quota_row(&updated).unwrap(), "");
     }
 }

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -4,21 +4,40 @@ pub mod grok;
 pub mod herdr;
 mod statusline;
 
+use crate::cache::CacheStore;
 use anyhow::{Context, Result};
 
 /// `--check` is also the no-flag default, so it needs no branch of its own.
-pub fn run(_check: bool, apply: bool, uninstall: bool) -> Result<()> {
+pub fn run(
+    _check: bool,
+    apply: bool,
+    uninstall: bool,
+    watch_interval_seconds: Option<u64>,
+) -> Result<()> {
     if apply || uninstall {
         std::env::var_os("HERDR_PLUGIN_STATE_DIR").context(
             "configuration writes must run through Herdr so every collector uses the same cache; invoke herdr-agent-quota.configure or herdr-agent-quota.uninstall",
         )?;
     }
     if uninstall {
+        let cache = CacheStore::from_env()?;
+        cache.stop_turn_watchers()?;
         grok::uninstall()?;
         agy::uninstall()?;
         claude::uninstall()?;
         herdr::uninstall()?;
+        cache.clear_watch_interval()?;
     } else if apply {
+        let cache = CacheStore::from_env()?;
+        cache.clear_turn_watcher_stop()?;
+        let interval = watch_interval_seconds.or_else(|| {
+            std::env::var("HERDR_AGENT_QUOTA_WATCH_INTERVAL_SECONDS")
+                .ok()
+                .and_then(|value| value.parse().ok())
+        });
+        if let Some(interval) = interval {
+            cache.set_watch_interval_seconds(interval)?;
+        }
         herdr::apply()?;
         claude::apply()?;
         agy::apply()?;

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -33,7 +33,42 @@ pub struct AgentPane {
     pub tokens: BTreeMap<String, String>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct AgentState {
+    pub panes: Vec<AgentPane>,
+    pub working_providers: Vec<Provider>,
+}
+
 pub fn list_agent_panes() -> Result<Vec<AgentPane>> {
+    Ok(list_agent_state()?.panes)
+}
+
+/// Read Herdr's agent inventory once and derive both panes and working
+/// providers from that same response. The active-turn watcher uses this
+/// combined view so one poll does not fan out into one `agent list` call per
+/// provider.
+pub fn list_agent_state() -> Result<AgentState> {
+    let value = list_agent_value()?;
+    let mut panes = Vec::new();
+    collect_agent_panes(&value, &mut panes);
+    panes.sort_by(|left, right| left.pane_id.cmp(&right.pane_id));
+    panes.dedup_by(|left, right| left.pane_id == right.pane_id);
+    Ok(AgentState {
+        panes,
+        working_providers: working_providers_from(&value),
+    })
+}
+
+/// Return whether at least one pane for a provider is currently working.
+///
+/// This provider-specific helper only asks Herdr for agent metadata; it never
+/// reads terminal output. The global watcher uses [`list_agent_state`] so all
+/// providers share one inventory call per poll.
+pub fn provider_has_working_agent(provider: Provider) -> Result<bool> {
+    Ok(list_agent_state()?.working_providers.contains(&provider))
+}
+
+fn list_agent_value() -> Result<Value> {
     let executable = std::env::var_os("HERDR_BIN_PATH").unwrap_or_else(|| "herdr".into());
     let output = Command::new(&executable)
         .args(["agent", "list"])
@@ -42,12 +77,7 @@ pub fn list_agent_panes() -> Result<Vec<AgentPane>> {
     if !output.status.success() {
         anyhow::bail!("Herdr agent list failed with {}", output.status);
     }
-    let value: Value = serde_json::from_slice(&output.stdout).context("parse Herdr agent list")?;
-    let mut panes = Vec::new();
-    collect_agent_panes(&value, &mut panes);
-    panes.sort_by(|left, right| left.pane_id.cmp(&right.pane_id));
-    panes.dedup_by(|left, right| left.pane_id == right.pane_id);
-    Ok(panes)
+    serde_json::from_slice(&output.stdout).context("parse Herdr agent list")
 }
 
 pub fn current_agent_provider() -> Result<Option<Provider>> {
@@ -130,6 +160,57 @@ fn collect_agent_panes(value: &Value, panes: &mut Vec<AgentPane>) {
         Value::Array(values) => {
             for child in values {
                 collect_agent_panes(child, panes);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn working_providers_from(value: &Value) -> Vec<Provider> {
+    let mut providers = Vec::new();
+    collect_working_providers(value, &mut providers);
+    providers.sort_by_key(|provider| {
+        Provider::ALL
+            .iter()
+            .position(|candidate| candidate == provider)
+    });
+    providers.dedup();
+    providers
+}
+
+fn collect_working_providers(value: &Value, providers: &mut Vec<Provider>) {
+    match value {
+        Value::Object(map) => {
+            let kind = map
+                .get("agent")
+                .and_then(Value::as_str)
+                .or_else(|| map.get("kind").and_then(Value::as_str))
+                .or_else(|| {
+                    map.get("agent_session")
+                        .and_then(Value::as_object)
+                        .and_then(|session| session.get("agent"))
+                        .and_then(Value::as_str)
+                });
+            let status = map
+                .get("agent_status")
+                .or_else(|| map.get("agentStatus"))
+                .or_else(|| map.get("status"))
+                .or_else(|| map.get("state"))
+                .and_then(Value::as_str);
+            if let (Some(kind), Some(status)) = (kind, status) {
+                if status.eq_ignore_ascii_case("working") {
+                    if let Ok(provider) = kind.parse::<Provider>() {
+                        providers.push(provider);
+                    }
+                }
+            }
+            for child in map.values() {
+                collect_working_providers(child, providers);
+            }
+        }
+        Value::Array(values) => {
+            for child in values {
+                collect_working_providers(child, providers);
             }
         }
         _ => {}
@@ -285,19 +366,21 @@ fn insert_optional_token(tokens: &mut BTreeMap<String, String>, name: &str, valu
     }
 }
 
+// `recent` rebuilds the pane's wrapped scrollback, which takes seconds and
+// repaints the pane: the agent's terminal visibly scrolls, once per read.
+// `visible` is the current screen only, costs microseconds, and repaints
+// nothing. The prompt is on screen at the moment idle->working fires, which is
+// exactly when the topic changes; later in the turn it may have scrolled off,
+// and then the caller keeps the topic it already published.
+fn topic_read_args(pane_id: &str) -> [&str; 7] {
+    [
+        "pane", "read", pane_id, "--source", "visible", "--format", "text",
+    ]
+}
+
 fn read_pane_topic(executable: &std::ffi::OsStr, pane: &AgentPane) -> Option<String> {
     let output = Command::new(executable)
-        .args([
-            "pane",
-            "read",
-            &pane.pane_id,
-            "--source",
-            "recent",
-            "--lines",
-            "160",
-            "--format",
-            "text",
-        ])
+        .args(topic_read_args(&pane.pane_id))
         .output()
         .ok()?;
     if !output.status.success() {
@@ -410,6 +493,25 @@ mod tests {
     }
 
     #[test]
+    fn working_agent_detection_handles_herdr_agent_list_shape() {
+        let value = json!({"result": {"agents": [
+            {"agent": "claude", "agent_status": "working"},
+            {"agent": "codex", "agent_status": "idle"}
+        ]}});
+        assert_eq!(working_providers_from(&value), vec![Provider::Claude]);
+    }
+
+    #[test]
+    fn one_agent_inventory_deduplicates_working_providers() {
+        let value = json!({"result": {"agents": [
+            {"agent": "codex", "agent_status": "working"},
+            {"agent_session": {"agent": "codex"}, "status": "working"},
+            {"agent": "claude", "agent_status": "idle"}
+        ]}});
+        assert_eq!(working_providers_from(&value), vec![Provider::Codex]);
+    }
+
+    #[test]
     fn extracts_latest_agy_prompt_instead_of_status_line() {
         let text = "> older\nHello\n> hi\nHello!\n> Accept-edits mode: file edits auto-approved\n";
         assert_eq!(extract_topic(text, Provider::Agy).as_deref(), Some("hi"));
@@ -457,6 +559,16 @@ mod tests {
             extract_topic(text, Provider::Grok).as_deref(),
             Some("/goal 你在 ti 工作区接手 L7")
         );
+    }
+
+    // `recent` and `recent-unwrapped` rebuild the pane's wrapped scrollback,
+    // which repaints it: one read, one visible scroll for the user.
+    #[test]
+    fn topic_reads_never_rebuild_a_pane_scrollback() {
+        let args = topic_read_args("w1:p1");
+        assert!(args.contains(&"visible"));
+        assert!(!args.contains(&"recent"));
+        assert!(!args.contains(&"recent-unwrapped"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,10 @@ fn main() -> Result<()> {
             force,
             json,
         } => herdr_agent_quota::refresh::run(&provider.providers(), force, json),
+        Command::Watch {
+            provider,
+            interval_seconds,
+        } => herdr_agent_quota::refresh::watch(&provider.providers(), interval_seconds),
         Command::Event => herdr_agent_quota::refresh::event(),
         Command::Focus => herdr_agent_quota::refresh::focus(),
         Command::Dashboard => herdr_agent_quota::dashboard::run(),
@@ -17,7 +21,8 @@ fn main() -> Result<()> {
             check,
             apply,
             uninstall,
-        } => herdr_agent_quota::configure::run(check, apply, uninstall),
+            watch_interval_seconds,
+        } => herdr_agent_quota::configure::run(check, apply, uninstall, watch_interval_seconds),
         Command::ClaudeStatusline => herdr_agent_quota::configure::claude::run_statusline_hook(),
         Command::AgyStatusline => herdr_agent_quota::configure::agy::run_statusline_hook(),
     }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -1,11 +1,23 @@
 use crate::cache::CacheStore;
-use crate::herdr::{current_agent_provider, list_agent_panes, publish_tokens, refresh_pane_topic};
+use crate::herdr::{
+    current_agent_provider, list_agent_panes, list_agent_state, publish_tokens, refresh_pane_topic,
+    AgentPane,
+};
 use crate::model::Provider;
 use crate::presentation::MetadataTokens;
 use crate::providers::{codex, grok};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::Serialize;
 use serde_json::Value;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
+const MAX_ACTIVE_TURN_WATCH: Duration = Duration::from_secs(60 * 60);
+const TURN_WATCH_LOCK: &str = "turn.lock";
 
 #[derive(Debug, Serialize)]
 pub struct ProviderOutcome {
@@ -19,6 +31,82 @@ pub fn run(providers: &[Provider], force: bool, json: bool) -> Result<()> {
     run_internal(providers, force, json, None)
 }
 
+/// Refresh selected providers until their agents leave the working state.
+///
+/// This command is normally launched detached by `event` and is deliberately
+/// quota-only: it never reads a pane. Claude/Agy statusLine hooks keep writing
+/// snapshots to the same cache, while Codex/Grok use their normal providers'
+/// fetchers. One global watcher reads Herdr's agent inventory once per poll
+/// and refreshes every selected provider that is working. The existing
+/// provider-level debounce remains the lower bound for network requests.
+pub fn watch(providers: &[Provider], interval_seconds: Option<u64>) -> Result<()> {
+    let cache = CacheStore::from_env()?;
+    let interval_seconds = interval_seconds
+        .map(CacheStore::validate_watch_interval_seconds)
+        .transpose()?
+        .unwrap_or_else(|| cache.watch_interval_seconds());
+    let Some(_lock) = cache.try_lock_named(TURN_WATCH_LOCK)? else {
+        return Ok(());
+    };
+
+    let started = Instant::now();
+    let started_millis = CacheStore::now_millis();
+    let interval = Duration::from_secs(interval_seconds);
+    let mut previous_active = Vec::new();
+    loop {
+        if cache.turn_watchers_stopped_after(started_millis)? {
+            break;
+        }
+        // A transient Herdr failure should not terminate a live watcher; the
+        // one-hour cap below still prevents an orphaned process. The next
+        // poll retries the single inventory call.
+        let Ok(state) = list_agent_state() else {
+            if started.elapsed() >= MAX_ACTIVE_TURN_WATCH {
+                break;
+            }
+            thread::sleep(interval);
+            continue;
+        };
+        let active = providers
+            .iter()
+            .copied()
+            .filter(|provider| state.working_providers.contains(provider))
+            .collect::<Vec<_>>();
+        let finishing = previous_active
+            .iter()
+            .copied()
+            .filter(|provider| !active.contains(provider))
+            .collect::<Vec<_>>();
+
+        // A provider can settle while another provider keeps working. Run one
+        // final debounced pass for providers that just transitioned to idle,
+        // then continue polling the remaining active set in the same process.
+        if !finishing.is_empty() {
+            let _ = refresh_and_publish(&cache, &finishing, false, &state.panes);
+        }
+        if active.is_empty() {
+            break;
+        }
+        let _ = refresh_and_publish(&cache, &active, false, &state.panes);
+        previous_active = active;
+        if started.elapsed() >= MAX_ACTIVE_TURN_WATCH {
+            break;
+        }
+        thread::sleep(interval);
+    }
+    Ok(())
+}
+
+fn refresh_and_publish(
+    cache: &CacheStore,
+    providers: &[Provider],
+    force: bool,
+    panes: &[AgentPane],
+) -> Result<()> {
+    cache.with_lock(|| refresh_locked(cache, providers, force))?;
+    publish(cache, providers, None, Some(panes))
+}
+
 fn run_internal(
     providers: &[Provider],
     force: bool,
@@ -27,7 +115,7 @@ fn run_internal(
 ) -> Result<()> {
     let cache = CacheStore::from_env()?;
     let outcomes = cache.with_lock(|| refresh_locked(&cache, providers, force))?;
-    publish(&cache, providers, topic_pane)?;
+    publish(&cache, providers, topic_pane, None)?;
     if json {
         println!("{}", serde_json::to_string_pretty(&outcomes)?);
     }
@@ -43,7 +131,19 @@ pub fn event() -> Result<()> {
         .map(|provider| vec![provider])
         .unwrap_or_else(|| Provider::ALL.to_vec());
     let topic_pane = event.as_ref().and_then(find_pane_id);
-    run_internal(&providers, false, false, topic_pane)
+    let status = event.as_ref().and_then(find_status);
+    // The detached watcher owns the final debounced pass. Keeping the event
+    // itself debounced avoids a duplicate Codex/Grok fetch when the agent
+    // emits its idle transition immediately after a tool hook.
+    let result = run_internal(&providers, false, false, topic_pane);
+    if status.is_some_and(is_working_status) {
+        if let Err(error) = spawn_watch() {
+            if result.is_ok() {
+                return Err(error);
+            }
+        }
+    }
+    result
 }
 
 pub fn focus() -> Result<()> {
@@ -110,8 +210,16 @@ fn refresh_locked(
     Ok(outcomes)
 }
 
-fn publish(cache: &CacheStore, providers: &[Provider], topic_pane: Option<&str>) -> Result<()> {
-    let mut panes = list_agent_panes().unwrap_or_default();
+fn publish(
+    cache: &CacheStore,
+    providers: &[Provider],
+    topic_pane: Option<&str>,
+    agent_panes: Option<&[AgentPane]>,
+) -> Result<()> {
+    let mut panes = agent_panes.map_or_else(
+        || list_agent_panes().unwrap_or_default(),
+        |panes| panes.to_vec(),
+    );
     if let Some(pane) = topic_pane.and_then(|pane_id| {
         panes
             .iter_mut()
@@ -133,6 +241,37 @@ fn publish(cache: &CacheStore, providers: &[Provider], topic_pane: Option<&str>)
 fn event_json() -> Option<Value> {
     let input = std::env::var("HERDR_PLUGIN_EVENT_JSON").ok()?;
     serde_json::from_str(&input).ok()
+}
+
+fn find_status(value: &Value) -> Option<&str> {
+    find_field(value, &["agent_status", "agentStatus", "status", "state"])
+}
+
+fn is_working_status(status: &str) -> bool {
+    status.eq_ignore_ascii_case("working")
+}
+
+fn spawn_watch() -> Result<()> {
+    let executable = std::env::current_exe().context("resolve plugin executable")?;
+    let mut command = Command::new(executable);
+    command
+        .args(["watch", "--provider", "all"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    unsafe {
+        // A Herdr event process is short-lived. Put the watcher in its own
+        // process group so it survives the hook supervisor cleanly.
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    command.spawn().context("start active-turn quota watcher")?;
+    Ok(())
 }
 
 // Event payloads are nested and their shape differs per event, so look the
@@ -207,5 +346,15 @@ mod tests {
         let value: Value =
             serde_json::from_str(r#"{"event":"x","data":{"agent":"claude"}}"#).unwrap();
         assert_eq!(find_pane_id(&value), None);
+    }
+
+    #[test]
+    fn status_events_start_pulses_only_for_working_turns() {
+        let working: Value =
+            serde_json::from_str(r#"{"data":{"agent":"codex","agent_status":"working"}}"#).unwrap();
+        let idle: Value =
+            serde_json::from_str(r#"{"data":{"agent":"codex","status":"idle"}}"#).unwrap();
+        assert!(find_status(&working).is_some_and(is_working_status));
+        assert_eq!(find_status(&idle), Some("idle"));
     }
 }

--- a/tests/grok_hook_config.rs
+++ b/tests/grok_hook_config.rs
@@ -3,26 +3,22 @@ use std::fs;
 use tempfile::tempdir;
 
 #[test]
-fn grok_turn_hook_refreshes_quota_silently_and_is_reversible() {
+fn unified_watcher_removes_legacy_grok_hook() {
     let directory = tempdir().unwrap();
     let path = directory.path().join("herdr-agent-quota.json");
     let state = directory.path().join("state");
     let executable = directory.path().join("herdr-agent-quota");
 
+    fs::write(
+        &path,
+        r#"{"hooks":{"PostToolUse":[]},"managedBy":"herdr-agent-quota","command":"refresh --provider grok"}"#,
+    )
+    .unwrap();
     apply_at(&path, &state, &executable).unwrap();
-    let installed = fs::read_to_string(&path).unwrap();
-    assert!(installed.contains("\"PostToolUse\""));
-    assert!(installed.contains("\"Stop\""));
-    assert!(installed.contains("\"StopFailure\""));
-    assert!(installed.contains("\"StopCancelled\""));
-    assert!(installed.contains("refresh --provider grok"));
-    assert!(installed.contains(state.to_str().unwrap()));
-    assert!(!installed.contains("plugin action invoke"));
-    assert!(!installed.contains("--force"));
-    assert!(installed.contains(">/dev/null 2>&1"));
+    assert!(!path.exists());
 
     apply_at(&path, &state, &executable).unwrap();
-    assert_eq!(fs::read_to_string(&path).unwrap(), installed);
+    assert!(!path.exists());
 
     uninstall_at(&path).unwrap();
     assert!(!path.exists());

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Restore plugin-owned configuration, then unlink herdr-agent-quota.
+#
+# Usage:
+#   ./uninstall.sh
+#
+# The configuration action is intentionally run before unlinking: Herdr owns
+# the plugin state directory used to restore Claude/Agy statusLine backups.
+set -euo pipefail
+
+command -v herdr >/dev/null 2>&1 || {
+  printf 'error: Herdr is not installed or not on PATH\n' >&2
+  exit 1
+}
+
+if herdr plugin list 2>/dev/null | grep -q 'herdr-agent-quota'; then
+  # An earlier interrupted uninstall may have disabled the plugin. Enable it
+  # long enough for Herdr to provide the state directory to the restore action.
+  herdr plugin enable herdr-agent-quota >/dev/null 2>&1 || true
+  printf '%s\n' '→ restoring plugin-owned configuration'
+  herdr plugin action invoke herdr-agent-quota.uninstall
+
+  printf '%s\n' '→ disabling and unlinking the Herdr plugin'
+  herdr plugin disable herdr-agent-quota || true
+  herdr plugin unlink herdr-agent-quota
+  printf '%s\n' 'Uninstalled and restored.'
+else
+  printf '%s\n' 'herdr-agent-quota is not linked; no configuration was changed.'
+fi


### PR DESCRIPTION
## Summary
- replace per-provider active-turn watchers with one global poller
- default to 60s polling with a persisted 30s-1h setting
- remove legacy per-tool Grok hooks and add downloader-friendly install/uninstall scripts
- preserve reversible config restore and cap provider requests with existing 60s debounce

## Verification
- cargo fmt --all -- --check
- cargo test --all-targets --all-features --locked
- cargo clippy --release --all-targets --all-features -- -D warnings
- cargo build --release --locked
- bash -n install.sh uninstall.sh

Local Herdr was reloaded and confirmed enabled with a single `watch --provider all` smoke process.