### PR TITLE
feat: show supported context and Codex session summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Agy/Antigravity subscription usage, in Herdr's agent sidebar.
 ```text
 ● Owner · Claude
   hi                     ← what that pane is actually working on
+  context 23%            ← when the CLI exposes context usage
   5h 100% reset 3h07m
   week 31% reset 2d3h
 ```
@@ -25,8 +26,8 @@ ETAs, Codex and Grok show their weekly windows, and each agent card uses the
 latest user prompt rather than an AI-generated status.*
 
 - **Four CLIs, one sidebar** — Claude Code, Codex, Grok, Agy/Antigravity.
-- **Three or four lines per pane** — provider, one line per quota window, and
-  the latest user prompt.
+- **Compact, capability-aware cards** — provider, prompt/session summary,
+  supported context usage, and quota windows. Unsupported rows are hidden.
 - **Local only** — no usage data uploaded, no browser cookies, no keychain
   scraping, and credentials are never written or refreshed.
 - **Never lies to you** — a failed refresh keeps the last good number instead
@@ -169,22 +170,26 @@ long turns no longer start one refresh command per tool call.
 
 | CLI | Sidebar windows | Local collection path | Extra setup |
 | --- | --- | --- | --- |
-| Claude Code `2.1.233` | `5h` + `week` | Official `statusLine` JSON: `rate_limits.five_hour` and `seven_day` | The configure action installs and chains it automatically |
-| OpenAI Codex `0.147.0` | `week` | One-shot local `codex app-server --stdio`, `account/rateLimits/read` | ChatGPT subscription login; API-key mode is shown as unavailable |
+| Claude Code `2.1.233` | `5h` + `week` + context | Official `statusLine` JSON: `rate_limits` and `context_window` | The configure action installs and chains it automatically |
+| OpenAI Codex `0.147.0` | `week` + local session summary | One-shot local `codex app-server --stdio`: quota and bounded `thread/list` | ChatGPT subscription login; API-key mode is shown as unavailable |
 | Grok CLI / Grok Build `1.0.4` | `week` | Local `~/.grok/auth.json` and the billing contract used by the official CLI | Covered by the unified watcher; no response hook is installed |
-| Agy / Antigravity CLI `1.1.13` | `5h` + `week` | Official `statusLine` JSON `quota` object (`gemini-*` and `3p-*` pools) | The configure action installs and chains it automatically |
+| Agy / Antigravity CLI `1.1.13` | `5h` + `week` + context | Official `statusLine` JSON: `quota` and `context_window` | The configure action installs and chains it automatically |
 
 Versions above were checked on the development machine on 2026-08-15. The
 parser follows the provider fields rather than hard-coding these version
 strings, so newer compatible CLI releases can continue to work.
 
-The sidebar shows **percentage remaining** and the time until each reset, not
-token counts. Codex and Grok expose their weekly window. Claude Code and Agy
-expose both five-hour and weekly windows. Reset ETAs use minutes below one hour,
-hours and minutes below one day, and days plus hours above one day. During a
-working turn, one short-lived global watcher polls once per configured interval,
-coalesces active fetches, and exits when all selected providers settle. The
-sidebar does not run a permanent daemon.
+The sidebar shows **percentage remaining** and the time until each quota reset,
+not quota token counts. Claude and Agy also show context percentage when their
+statusLine payload contains it. Codex shows a short session preview from its
+local state database; its live context percentage is not queried because the
+current safe app-server connection is quota-only and does not attach to an
+active thread. Grok's current billing source has neither context nor session
+data. No provider exposes a reliable cache-entry expiry timestamp, so there is
+intentionally no `cached expires` row. During a working turn, one short-lived
+global watcher polls once per configured interval, coalesces active fetches, and
+exits when all selected providers settle. The sidebar does not run a permanent
+daemon.
 
 A failed refresh never replaces a successful cached value with `unavailable`;
 a provider without any successful snapshot is shown as `N/A` until its first
@@ -210,6 +215,7 @@ row_gap = 1 # herdr-agent-quota
 rows = [
   ["state_icon", "tab", { token = "$quota_provider", bold = true, dim = false }],
   [{ token = "$quota_topic", dim = false }],
+  [{ token = "$quota_context", bold = true, dim = false }],
   [{ token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false }],
   [{ token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false }],
   [{ token = "$quota_5h_danger", fg = "#ca6470", bold = true, dim = false }],
@@ -226,6 +232,11 @@ rows = [
   Antigravity-inspired mint for Agy.
 - `$quota_topic` comes before the quota rows so the card reads as agent, task,
   then resource status.
+- For Codex, an empty/default prompt falls back to the short thread preview from
+  the local app-server state database; other providers keep the prompt empty.
+- `$quota_context` is the provider-reported context **used** percentage. It is
+  currently populated by Claude and Agy statusLine payloads; missing fields are
+  hidden instead of guessed.
 - Each window publishes exactly one styled variant. Color follows runway rather
   than a fixed quota threshold: remaining quota is compared with the percentage
   of window time still left. At or ahead of pace is green; behind pace is
@@ -235,7 +246,8 @@ rows = [
 - `row_gap = 1` adds one blank row between agent cards. An existing explicit
   `row_gap` value is preserved.
 - `$quota_5h`, `$quota_week`, and `$quota_summary` remain available for custom
-  unstyled layouts.
+  unstyled layouts. `$quota_summary` is the compact quota-window summary, not a
+  cache-expiry value.
 
 Herdr 0.8 only accepts fixed hex colors for styled tokens, not semantic theme
 colors. The default palette uses soft, high-luminance green, amber, and red
@@ -260,22 +272,28 @@ such as `Thinking` or `Executing`. It does not show the working directory.
 ## Data sources and privacy
 
 - **Codex:** the local official [app-server JSON-RPC](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)
-  rate-limit response. The plugin accepts the seven-day window by duration,
-  rather than assuming which field is primary. API-key authentication is
-  intentionally not mislabeled as a ChatGPT subscription quota.
+  rate-limit response plus one bounded, state-database-only `thread/list` for
+  session previews. The plugin accepts the seven-day window by duration, rather
+  than assuming which field is primary. API-key authentication is intentionally
+  not mislabeled as a ChatGPT subscription quota. It does not resume threads or
+  read rollout JSONL, so it cannot claim a live context percentage. Only the
+  first non-empty line of at most 50 previews is retained, truncated to 80
+  characters.
 - **Grok:** the local `~/.grok/auth.json` login key is read in memory and sent
   to the weekly billing endpoint used by the Grok CLI. The response is accepted
   only when it identifies a weekly period. This is SuperGrok usage, not xAI
   developer/API-team billing. The unified watcher and the existing 60-second
   debounce limit active requests; it never logs in or refreshes the key.
 - **Claude Code:** the official [`statusLine` JSON hook](https://code.claude.com/docs/en/statusline)
-  supplies the five-hour and seven-day values. A previous statusLine command is
-  backed up, chained, and restored by the uninstall action; the active-turn
-  watcher republishes each new snapshot without calling Herdr from that hook.
+  supplies the five-hour, seven-day, and context-used percentage values. A
+  previous statusLine command is backed up, chained, and restored by the
+  uninstall action; the active-turn watcher republishes each new snapshot
+  without calling Herdr from that hook.
 - **Agy/Antigravity:** the official [`/usage` and statusline docs](https://antigravity.google/docs/cli/commands/usage?app=antigravity-ide)
-  supply Gemini and third-party pools. When both pools exist, the sidebar uses
-  the lowest remaining percentage so the single Agy row is conservative; its
-  statusLine cache is published by the same active-turn watcher.
+  supply Gemini and third-party pools plus context-used percentage. When both
+  pools exist, the sidebar uses the lowest remaining percentage so the single
+  Agy row is conservative; its statusLine cache is published by the same
+  active-turn watcher.
 
 Snapshots and refresh markers stay in Herdr's plugin state directory. No usage
 data is uploaded, browser cookies or browser keychains are read, and provider

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,7 @@ Claude Code、Codex、Grok 和 Agy/Antigravity 的订阅额度。
 ```text
 ● Owner · Claude
   hi                     ← 这个 pane 当前在做什么
+  context 23%            ← provider 提供时显示当前会话上下文占用
   5h 100% reset 3h07m
   week 31% reset 2d3h
 ```
@@ -25,7 +26,8 @@ Codex、Grok 显示周额度；每张 agent 卡片的话题来自用户最后一
 不会使用 AI 生成的状态标题。*
 
 - **四个 CLI，一个侧栏** —— Claude Code、Codex、Grok、Agy/Antigravity。
-- **每个 pane 三或四行** —— provider、每个额度窗口各一行、最后一条用户输入。
+- **按能力显示的紧凑卡片** —— provider、当前输入/会话摘要、可用的 context
+  百分比和额度窗口；不支持的行自动隐藏。
 - **全本地** —— 不上传任何用量数据，不读浏览器 cookie 和系统钥匙串，
   也不会写入或刷新凭证。
 - **不会给你错的数** —— 刷新失败时保留上一次的有效数值，而不是闪成
@@ -142,15 +144,20 @@ usage、topic 三类 token，不会覆盖官方 agent 指示。卸载 action 会
 
 | CLI | 侧栏显示 | 本地数据来源 | 额外配置 |
 | --- | --- | --- | --- |
-| Claude Code `2.1.233` | `5h` + `week` | 官方 `statusLine` JSON：`rate_limits.five_hour`、`seven_day` | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
-| OpenAI Codex `0.147.0` | `week` | 一次性的 `codex app-server --stdio`，调用 `account/rateLimits/read` | 使用 ChatGPT 订阅登录；API key 模式显示为不可用；turn 中由统一 watcher 去抖查询 |
+| Claude Code `2.1.233` | `5h` + `week` + context | 官方 `statusLine` JSON：`rate_limits`、`context_window` | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
+| OpenAI Codex `0.147.0` | `week` + 本地会话摘要 | 一次性的 `codex app-server --stdio`：额度和有上限的 `thread/list` | 使用 ChatGPT 订阅登录；API key 模式显示为不可用；不会 resume thread |
 | Grok CLI / Grok Build `1.0.4` | `week` | `~/.grok/auth.json` 和官方 CLI 使用的额度接口 | 由统一 watcher 处理，不再安装回复 hook |
-| Agy / Antigravity CLI `1.1.13` | `5h` + `week` | 官方 `statusLine` JSON 的 `quota`（`gemini-*`、`3p-*`） | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
+| Agy / Antigravity CLI `1.1.13` | `5h` + `week` + context | 官方 `statusLine` JSON 的 `quota` 和 `context_window` | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
 
 上面的版本是 2026-08-15 在开发机上实际检查的版本。解析器按照供应商的
 字段工作，不会把这些版本号写死；兼容的新版本可以继续使用。
 
-侧栏显示的是**剩余百分比**和距离下次重置的时间，不是 token 数量：
+侧栏显示的是**额度剩余百分比**和距离下次额度重置的时间，不是额度 token 数量。
+Claude 和 Agy 的 statusLine 有 context 字段时，还会显示当前 context **已用**百分比。
+Codex 会显示本地 state database 里的短会话预览；当前安全的 app-server 连接只查额度，
+没有绑定活动 thread，因此不猜测 Codex context 百分比。Grok 当前的 billing 来源没有
+context 或会话字段。四家都没有可可靠读取的 cache entry 到期时间，所以不会伪造
+`cached expires` 倒计时：
 
 ```text
 ● Owner · Claude
@@ -184,6 +191,7 @@ row_gap = 1 # herdr-agent-quota
 rows = [
   ["state_icon", "tab", { token = "$quota_provider", bold = true, dim = false }],
   [{ token = "$quota_topic", dim = false }],
+  [{ token = "$quota_context", bold = true, dim = false }],
   [{ token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false }],
   [{ token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false }],
   [{ token = "$quota_5h_danger", fg = "#ca6470", bold = true, dim = false }],
@@ -198,6 +206,10 @@ rows = [
 - 默认 provider 名称使用易辨识的柔和品牌色，并且不影响额度健康色：
   Claude 柔橘、Codex 粉彩蓝、Grok 柔白、Agy 使用 Antigravity 风格薄荷绿。
 - `$quota_topic` 放在额度上方，阅读顺序是 agent、当前任务、资源状态。
+- Codex 的空/默认 prompt 会回退为本地 app-server state database 的短会话预览；
+  其他 provider 仍保持空白。
+- `$quota_context` 是 provider 报告的 context **已用**百分比，目前由 Claude 和
+  Agy statusLine 提供；字段缺失时隐藏，不做 tokenizer 猜测。
 - 每个窗口只发布一个样式 token。颜色按额度续航动态判断，不再使用固定
   余额阈值：将剩余额度比例与窗口剩余时间比例比较，额度消耗不快于时间
   进度时为绿色；落后于时间进度时为琥珀色；落后且额度低于 20% 时为
@@ -206,7 +218,7 @@ rows = [
 - `row_gap = 1` 在 agent 卡片之间留一行空白；已有的显式 `row_gap`
   配置会原样保留。
 - `$quota_5h`、`$quota_week`、`$quota_summary` 仍保留给需要无样式或
-  紧凑布局的自定义配置。
+  紧凑布局的自定义配置。`$quota_summary` 是额度窗口汇总，不是缓存过期时间。
 
 Herdr 0.8 的样式只接受固定十六进制颜色，不支持跟随主题的语义色。
 默认的绿色、琥珀色和红色采用高明度柔和色阶并加粗，降低 Herdr 深色侧栏
@@ -229,20 +241,22 @@ Herdr plugin v1 只支持文本 token，不能由插件向原生 Agent renderer 
 
 - **Codex：** 使用本地官方
   [app-server JSON-RPC](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)
-  的 rate-limit 响应，按窗口时长识别周额度。API key 登录不会被误标记为
-  ChatGPT 订阅额度。
+  的 rate-limit 响应，并在同一进程里做一次有上限、只读 state database 的
+  `thread/list` 获取会话预览，按窗口时长识别周额度。不会 resume thread，也不读
+  rollout JSONL，因此不会声称拿到了实时 context 百分比。只保留最多 50 个预览的首个
+  非空行，并截断到 80 个字符。API key 登录不会被误标记为 ChatGPT 订阅额度。
 - **Grok：** 在内存中读取本地 `~/.grok/auth.json` 登录 key，访问 Grok CLI
   使用的周额度接口。只有明确标记为 weekly 的响应才会接受。这是
   SuperGrok 订阅额度，不是 xAI 开发者/API team 账单。统一 watcher 配合原有
   60 秒去抖查询额度，不会反复登录、刷新登录 key，也不会消耗对话 token。
 - **Claude Code：** 使用官方
   [`statusLine` JSON hook](https://code.claude.com/docs/en/statusline) 提供
-  5 小时和 7 天额度。原有 statusLine 会被备份、串联，并可由
+  5 小时、7 天额度和 context 已用百分比。原有 statusLine 会被备份、串联，并可由
   卸载 action 恢复；working turn 中由统一 watcher 发布新缓存。
 - **Agy/Antigravity：** 使用官方
   [`/usage` 和 statusline 文档](https://antigravity.google/docs/cli/commands/usage?app=antigravity-ide)
-  中的 Gemini 和第三方额度池。两个额度池同时存在时，取较低的剩余百分比，
-  让单个 Agy 行保持保守，working turn 中同样由统一 watcher 发布缓存。
+  中的 Gemini、第三方额度池和 context 已用百分比。两个额度池同时存在时，取较低的
+  剩余百分比，让单个 Agy 行保持保守，working turn 中同样由统一 watcher 发布缓存。
 
 快照和刷新标记保存在 Herdr 插件状态目录中。插件不会上传使用数据，不读取
 浏览器 Cookie/Keychain，不刷新或写入 provider 凭据。provider 失败时保留

--- a/docs/plans/herdr-agent-quota-implementation.md
+++ b/docs/plans/herdr-agent-quota-implementation.md
@@ -42,7 +42,8 @@ indefinitely.
   legacy symbol tokens remain available for compatibility.
 - Manual Herdr configuration and an optional `configure` helper with preview,
   backup, apply, and uninstall paths.
-- A local cache containing only normalized usage snapshots.
+- A local cache containing normalized usage snapshots and bounded, truncated
+  Codex session previews needed by the sidebar fallback.
 - No telemetry, no upload of usage data, no browser Cookie access, and no stored
   provider credentials.
 - Unknown or changed provider schemas fail safely. A failed refresh retains the
@@ -90,14 +91,17 @@ not provide an SDK or native sidebar component API. The supported path is:
 3. Let the user reference those tokens from `[ui.sidebar.agents].rows` and
    `rows_by_agent`.
 
-Custom token values are capped at 80 characters. The plugin publishes the new
-readable tokens and keeps the old pair for existing configurations:
+Custom token values are capped at 80 characters and a metadata report may update
+at most 16 tokens. The plugin publishes the readable tokens below; the old
+`$quota_badge` marker remains recognized for configuration cleanup but is no
+longer sent as a separate metadata value:
 
-- `$quota_badge`: `[C]`, `[X]`, or `[A]`.
+- `$quota_badge`: retired cleanup marker; it is no longer published.
 - `$quota_state`: `●`, `▲`, `!`, or `?`.
 - `$quota_icon`: compact text markers `◈C`, `✕G`, `✦Cl`, or `△Ag`.
 - `$quota_provider`: `Codex`, `Grok`, `Claude`, or `Agy` for custom layouts.
 - `$quota_status`: `OK`, `WARN`, `LOW`, or `N/A`.
+- `$quota_context`: provider-reported context-used percentage when available.
 - `$quota_5h`: compact five-hour remaining value and reset ETA when exposed.
 - `$quota_week`: compact weekly remaining value and reset ETA.
 - `$quota_summary`: window-driven compact remaining values and reset ETAs.

--- a/docs/research/context-cache-capabilities.md
+++ b/docs/research/context-cache-capabilities.md
@@ -1,0 +1,152 @@
+# Context 与 prompt cache 能力调研
+
+研究日期：2026-08-22（Asia/Shanghai）
+范围：本仓库当前的 Codex、Grok Build、Claude Code、Agy/Antigravity 四个 provider。
+来源约束：优先使用供应商官方文档、官方 CLI/app-server 源码和本仓库 parser/fixture；没有把第三方状态栏项目当作能力契约。
+
+## 先说结论
+
+“额度窗口重置”与“会话 context 使用率”是两个不同指标；“缓存 token 数量”与“缓存过期时间”也不是同一个字段。四家都能在一定程度上提供 context 使用信息，但只有 Codex 的 app-server、Claude/Agy 的 statusLine、Grok 的 status-line payload 会提供 token 级数据。四家当前都没有一个可供本插件安全显示的“这条缓存还剩多久”动态字段。
+
+| Provider | context 百分比 | cached token 数量 | 缓存实际过期时间/剩余 TTL | 本仓库当前来源 |
+| --- | --- | --- | --- | --- |
+| Codex | 支持：app-server 的 `last.totalTokens` + `modelContextWindow`，可计算 | 支持：`cachedInputTokens`；当前 schema 还包括 `cacheWriteInputTokens` | 不支持动态剩余 TTL。OpenAI API 文档有请求级 TTL，但 Codex app-server 的 token-usage 事件不带 entry expiry | 读取 `account/rateLimits/read`，另做有界 `thread/list` 会话预览；没有接入活动会话 token-usage 事件 |
+| Claude Code | 支持：statusLine 的 `context_window.used_percentage`/`remaining_percentage` | 支持：`current_usage.cache_read_input_tokens`/`cache_creation_input_tokens` | 不支持实际过期时间。Claude API 有 5m/1h policy，但 Claude Code statusLine 不返回所选 TTL 或 expiry timestamp | 解析 `rate_limits` 和可选 `context_window`；compact/首响应缺失时保留上次 context |
+| Agy/Antigravity | 支持：statusLine 的 `context_window.used_percentage`/`remaining_percentage` | 支持：`context_window.current_usage` 中的 cache read/create 数量 | 不支持；官方 statusLine 只有 quota reset 字段，没有 prompt-cache TTL | 解析 `quota` 和可选 `context_window`；compact/首响应缺失时保留上次 context |
+| Grok Build | 支持：官方 status-line 的 `context_window.used_percentage`/`remaining_percentage` | 支持：`session_usage.cache_read_input_tokens`/`cache_creation_input_tokens` | 不支持；官方 status-line contract 没有 TTL/expiry 字段 | 只请求 billing credits，旧 Grok quota hook 已被统一 watcher 移除 |
+
+因此建议：可以增加 **context 使用百分比**，也可以增加 **cached/read/write token 统计**；不要显示“cached 过期倒计时”。如果 UI 需要一个“数据新鲜度”，应显示本地快照的 `observed_at`，不能把它伪装成服务端缓存 expiry。
+
+## Codex
+
+### 支持
+
+官方 app-server 文档说明，turn 期间会独立发送 `thread/tokenUsage/updated` 通知；`thread/resume` 在已有持久化 token usage 时也会立即重放该通知（[app-server README 的 thread/resume 与 turn events](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md#turn-events)）。当前官方生成的 v2 schema 定义了：
+
+- `tokenUsage.last.totalTokens`：最近一次上下文的 token 数；
+- `tokenUsage.modelContextWindow`：模型上下文窗口上限；
+- `tokenUsage.last.inputTokens`、`outputTokens`、`reasoningOutputTokens`；
+- `tokenUsage.last.cachedInputTokens` 和 `cacheWriteInputTokens`；
+- `tokenUsage.total`：会话累计 token usage。
+
+字段是官方 app-server 协议中的稳定类型，见 [ThreadTokenUsageUpdatedNotification schema](https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/json/v2/ThreadTokenUsageUpdatedNotification.json) 和 [Codex core token usage types](https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs#L1936-L2021)。官方 TUI 也明确把 `last_token_usage.total_tokens` 当作当前 context，并用 `model_context_window` 计算剩余百分比（[官方 TUI token usage 实现](https://github.com/openai/codex/blob/main/codex-rs/tui/src/token_usage.rs#L33-L48)）。
+
+`account/usage/read` 还可以按 `threadId` 返回 thread usage 汇总，其中包括 `cachedInputTokens`，但它是计费/用量汇总，不是当前 context window；schema 见 [GetAccountTokenUsageResponse](https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/json/v2/GetAccountTokenUsageResponse.json)。
+
+### 当前仓库缺口
+
+[`src/providers/codex.rs`](../../src/providers/codex.rs) 启动一个临时 `codex app-server --stdio`，只做 `account/read` 与 `account/rateLimits/read`，然后退出。这个连接没有活动 pane 的 `threadId`，也没有订阅现有会话的 `thread/tokenUsage/updated`；所以目前能读 quota reset，却读不到截图中用户所说的 Codex 会话 context summary。
+
+如果要支持 Codex context，优先级应是：
+
+1. 从活动 Codex 会话已经产生的 app-server token-usage 事件接入（需要可靠的 thread/session 关联）；或
+2. 使用官方 app-server 的 thread read/resume 读取持久化 usage，并严格按当前 Codex 版本的 schema 适配。
+
+不建议把 `~/.codex/sessions/**/*.jsonl` 的 `token_count` 当作长期公共 API。它是本地 rollout 记录，路径和事件形状可能变，且按文件轮询会产生不必要的磁盘 I/O。
+
+### 不支持与风险
+
+OpenAI API 当前文档有 `prompt_cache_options.ttl`（默认 `30m`，当前文档列出的唯一值）以及旧的 `prompt_cache_retention`（`24h` 语义），见 [Responses API create reference](https://developers.openai.com/api/reference/cli/resources/responses/methods/create)。这只是请求/模型策略，不是 Codex app-server token-usage 事件中的某条 cache entry 的创建时间或到期时间。缓存命中会刷新缓存，单凭 `cachedInputTokens` 无法反推出“还剩几分钟”。
+
+结论：Codex 可以显示 context 使用率和 cached token 数，但不能诚实地显示动态 cached expiry。不要把 quota `resetsAt` 当成 cache expiry。
+
+## Claude Code
+
+### 支持
+
+官方 [Claude Code statusLine 文档](https://code.claude.com/docs/en/statusline#available-data)把以下字段定义为可用数据：
+
+- `context_window.context_window_size`；
+- `context_window.used_percentage` 与 `remaining_percentage`；
+- `context_window.total_input_tokens` 与 `total_output_tokens`；
+- `context_window.current_usage.input_tokens`、`output_tokens`、`cache_creation_input_tokens`、`cache_read_input_tokens`。
+
+官方还说明：`used_percentage` 只按 input 侧计算（包含 cache creation/read，不包含 output），`current_usage` 在首个 API 响应前以及 `/compact` 后短暂为 `null`。因此 parser 遇到缺失/null 时应保留上一个有效快照，不要把它写成 0。
+
+### 当前仓库缺口
+
+[`src/providers/claude.rs`](../../src/providers/claude.rs) 目前只解析 `rate_limits.five_hour` 与 `rate_limits.seven_day`；[`src/configure/claude.rs`](../../src/configure/claude.rs) 的 statusLine wrapper 只保存 quota snapshot。现有 fixture [`tests/fixtures/claude/statusline-both.json`](../../tests/fixtures/claude/statusline-both.json) 也只包含 rate limits。
+
+因此 Claude 是最适合先加 context 的 provider：数据已经由用户正在运行的 Claude Code 通过 stdin 提供，不需要额外网络请求、重新登录或读取 pane。
+
+### 不支持与风险
+
+Anthropic API 的 [prompt caching 文档](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)定义了默认 5 分钟和可选 1 小时 TTL，并说明缓存被使用时会刷新；[API 类型文档](https://platform.claude.com/docs/en/api/typescript/messages)也只把 `ttl` 作为请求里的 `cache_control` 参数。Claude Code statusLine payload 没有返回所用 TTL、cache-created-at 或 expires-at。
+
+结论：Claude 可以显示 context 百分比及 cache read/create 数量，但不显示 cached expiry。`rate_limits.*.resets_at` 仍然只是额度窗口 reset。
+
+## Agy / Antigravity
+
+### 支持
+
+Google 官方 [Antigravity statusLine schema](https://antigravity.google/docs/cli/statusline/#available-json-fields)明确提供：
+
+- `context_window.total_input_tokens`、`total_output_tokens`、`context_window_size`；
+- `context_window.used_percentage`、`remaining_percentage`；
+- `context_window.current_usage`（示例包含 input/output、`cache_creation_input_tokens`、`cache_read_input_tokens`）；
+- `quota[*].reset_time` 与可选 `reset_in_seconds`。
+
+官方示例同时展示了 `gemini-weekly` quota bucket 和 context/cache 数据。现有仓库的 [`src/providers/agy.rs`](../../src/providers/agy.rs) 只解析 quota bucket；fixture [`tests/fixtures/agy/statusline-both.json`](../../tests/fixtures/agy/statusline-both.json) 没有 `context_window`。
+
+### 不支持与风险
+
+官方 statusLine contract 没有 prompt-cache TTL、创建时间或 expiry timestamp。`quota[*].reset_time` 是 Gemini/第三方额度窗口重置，不是 prompt cache 的过期时间。Agy 的 `current_usage` 在首轮/compact 后可能缺失时，应保留上一份 context 快照。
+
+结论：Agy 可以显示 context 百分比和 cache read/create 数量；不能显示 cached expiry，也不能从 quota reset 推导它。
+
+## Grok Build
+
+### 支持
+
+xAI 官方 Grok Build status-line 文档的 [Available data](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#available-data)定义了：
+
+- `context_window.context_window_size` 与 `context_tokens`（当前上下文占用）；
+- `context_window.used_percentage` 与 `remaining_percentage`；
+- `context_window.session_input_tokens`、`session_output_tokens`；
+- `context_window.session_usage.input_tokens`、`output_tokens`、`cache_creation_input_tokens`、`cache_read_input_tokens`。
+
+官方 payload 类型和构造逻辑见 [`StatusLineContextWindow`](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-status-line/src/context.rs#L155-L186) 与 [`build_context_window`](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-shell/src/session/acp_session_impl/status_line.rs#L50-L96)。其中 `context_tokens` 是当前 context，`session_usage` 是会话累计值，不能把二者混用。
+
+### 当前仓库缺口
+
+[`src/providers/grok.rs`](../../src/providers/grok.rs) 当前只读取官方 billing credits endpoint；Grok 旧的 quota hook 已经由统一 watcher 清理。要接入 Grok context，需要增加一个官方 statusLine command wrapper，或让用户已有的 statusLine command 经过本插件的链式 wrapper；从本地 unified log 推导虽然可行，但那不是本项目应承诺的稳定 provider contract。
+
+### 不支持与风险
+
+官方 status-line payload 类型中没有 TTL、cache-created-at、expires-at 或 cache policy 字段；cache read/create 只是累计计数。结论：Grok 可以显示 context 百分比和会话 cache 计数，但不能显示 cached expiry。
+
+## “会话总结”应该如何定义
+
+本分支已按这个边界实现：Codex 通过同一次 app-server 连接做一次有上限、
+`useStateDbOnly` 的 `thread/list`，只保存每个 thread 的首行短预览；不 resume
+thread、不扫 rollout JSONL。默认 prompt 为空时，这个预览作为 `$quota_topic`
+的回退值，不新增 metadata token；其他 provider 没有会话摘要回退。
+
+UI 把几个概念分开，避免截图里的 quota 行承担过多含义：
+
+| 展示项 | 语义 | 是否适合放在 provider 行 |
+| --- | --- | --- |
+| `week 84% reset 6d16h` | 额度窗口剩余百分比与 quota reset | 是，现有字段 |
+| `ctx 23%` / `ctx 77% left` | 当前会话 context window 使用率/剩余率 | 可以，来自 statusLine/app-server |
+| `cache 12k/80k` | 已读/已写或 cached input token 统计 | 可选，建议窄侧边栏默认不显示 |
+| `cache expires 3m` | 服务端某个 cache entry 的剩余 TTL | 四家当前都没有可可靠读取的通用字段，不应显示 |
+| `observed 42s ago` | 本地快照新鲜度 | 如需诊断可显示，但不要叫 cache expiry |
+
+context 百分比还要标注口径：Claude/Agy 官方 `used_percentage` 是 input-only；Codex 官方 TUI 的“剩余百分比”会扣除固定 baseline；Grok 的 status-line 已由 provider 计算。不要在共享 renderer 中用一个未经说明的 `total_tokens / context_window_size` 覆盖四家语义。
+
+## 对实现的建议
+
+1. 内部快照增加可选的 `ContextUsage.used_percent`；旧 quota-only cache 反序列化后为 `None`。
+2. Claude/Agy 直接扩展现有 statusLine wrapper；输入已经是 provider 产生的 JSON，不增加 API 请求。
+3. Codex 当前只接入本地 thread preview；官方 token-usage 事件仍需要活动 thread 关联，
+   因此暂不把 context 百分比猜测性接入。
+4. Grok 若要支持，新增 statusLine 链式 wrapper；不要恢复每次 tool call 的 quota hook，也不要默认轮询 unified log。
+5. 只增加 context/cache token 的最小 metadata interface；不增加 `$cache_expiry` 之类无法保证正确的 token。
+6. 加入官方形状 fixture：Codex `ThreadTokenUsageUpdatedNotification`、Claude/Agy statusLine context、Grok `StatusLineContextWindow`；覆盖首轮缺失、compact 后缺失、字段顺序变化和旧 quota-only cache。
+
+## 证据索引
+
+- Codex：[app-server README](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md#turn-events)、[token-usage event schema](https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/json/v2/ThreadTokenUsageUpdatedNotification.json)、[core token types](https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs#L1936-L2021)、[TUI percentage implementation](https://github.com/openai/codex/blob/main/codex-rs/tui/src/token_usage.rs#L33-L48)、[Responses API cache TTL](https://developers.openai.com/api/reference/cli/resources/responses/methods/create)。
+- Claude：[statusLine available data](https://code.claude.com/docs/en/statusline#available-data)、[prompt caching TTL](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)、[cache control API type](https://platform.claude.com/docs/en/api/typescript/messages)。
+- Agy：[official statusLine schema and payload](https://antigravity.google/docs/cli/statusline/#available-json-fields)。
+- Grok：[official status-line contract](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#available-data)、[official payload type](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-status-line/src/context.rs#L155-L186)、[official builder](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-shell/src/session/acp_session_impl/status_line.rs#L50-L96)。

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -2,7 +2,7 @@ id = "herdr-agent-quota"
 name = "Herdr Agent Quota"
 version = "0.1.0"
 min_herdr_version = "0.8.0"
-description = "Never hit a quota limit mid-task: see Claude, Codex, Grok and Agy usage live in your Herdr sidebar. 5h and weekly percent remaining, refreshed throughout active turns."
+description = "Never hit a quota limit mid-task: see Claude, Codex, Grok and Agy usage live in your Herdr sidebar. Quota windows, supported context usage, and session summaries refresh throughout active turns."
 platforms = ["macos", "linux"]
 
 [[build]]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -77,6 +77,18 @@ impl CacheStore {
         Ok(())
     }
 
+    /// StatusLine payloads may temporarily omit context (before the first
+    /// response and immediately after compaction). Keep the last known value
+    /// while still replacing the quota windows with the newest snapshot.
+    pub fn save_preserving_context(&self, mut snapshot: ProviderSnapshot) -> Result<()> {
+        if snapshot.context.is_none() {
+            snapshot.context = self
+                .load(snapshot.provider)?
+                .and_then(|previous| previous.context);
+        }
+        self.save(&snapshot)
+    }
+
     pub fn with_lock<T>(&self, operation: impl FnOnce() -> Result<T>) -> Result<T> {
         self.ensure()?;
         let path = self.root.join("refresh.lock");

--- a/src/configure/agy.rs
+++ b/src/configure/agy.rs
@@ -52,7 +52,7 @@ pub fn run_statusline_hook() -> Result<()> {
     std::io::stdin().read_to_end(&mut input)?;
     if let Ok(snapshot) = run_statusline(&input) {
         if let Ok(cache) = CacheStore::from_env() {
-            let _ = cache.save(&snapshot);
+            let _ = cache.save_preserving_context(snapshot);
         }
     }
     let cache = CacheStore::from_env()?;

--- a/src/configure/claude.rs
+++ b/src/configure/claude.rs
@@ -50,7 +50,7 @@ pub fn run_statusline_hook() -> Result<()> {
     std::io::stdin().read_to_end(&mut input)?;
     if let Ok(snapshot) = run_statusline(&input) {
         if let Ok(cache) = CacheStore::from_env() {
-            let _ = cache.save(&snapshot);
+            let _ = cache.save_preserving_context(snapshot);
         }
     }
     let cache = CacheStore::from_env()?;

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -3,13 +3,15 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Item, Table, Value};
 
-const QUOTA_ROW_MARKERS: [&str; 18] = [
+const QUOTA_ROW_MARKERS: [&str; 20] = [
     "$quota_badge",
     "$quota_state",
     "$quota_icon",
     "$quota_provider",
     "$quota_status",
     "$quota_summary",
+    "$quota_session",
+    "$quota_context",
     "$quota_topic",
     "$quota_5h",
     "$quota_week",
@@ -496,6 +498,13 @@ fn append_quota_rows(rows: &mut Array) {
         "$quota_topic",
         None,
         None,
+        Some(false),
+    )));
+
+    rows.push(Value::Array(styled_row(
+        "$quota_context",
+        None,
+        Some(true),
         Some(false),
     )));
 

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -7,12 +7,12 @@ use std::process::Command;
 
 const METADATA_TTL_MS: &str = "86400000";
 const METADATA_TOKEN_NAMES: [&str; 16] = [
-    "quota_badge",
     "quota_state",
     "quota_icon",
     "quota_provider",
     "quota_status",
     "quota_summary",
+    "quota_context",
     "quota_5h",
     "quota_5h_normal",
     "quota_5h_warning",
@@ -24,11 +24,14 @@ const METADATA_TOKEN_NAMES: [&str; 16] = [
     "quota_topic",
     "quota_error",
 ];
+const LEGACY_METADATA_TOKEN_NAMES: [&str; 2] = ["quota_badge", "quota_session"];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentPane {
     pub pane_id: String,
     pub provider: Provider,
+    pub session_id: Option<String>,
+    pub session_summary: String,
     pub topic: String,
     pub tokens: BTreeMap<String, String>,
 }
@@ -143,9 +146,18 @@ fn collect_agent_panes(value: &Value, panes: &mut Vec<AgentPane>) {
                         })
                         .collect();
                     let topic = tokens.get("quota_topic").cloned().unwrap_or_default();
+                    let session_summary = tokens.get("quota_session").cloned().unwrap_or_default();
+                    let session_id = map
+                        .get("agent_session")
+                        .and_then(Value::as_object)
+                        .and_then(|session| session.get("value"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
                     panes.push(AgentPane {
                         pane_id: pane_id.to_string(),
                         provider,
+                        session_id,
+                        session_summary,
                         // Preserve the last published topic during quota-only
                         // refreshes. Agent events refresh it from pane output.
                         topic,
@@ -232,7 +244,7 @@ pub fn publish_tokens(
         else {
             continue;
         };
-        let topic = truncate_topic(&pane.topic);
+        let topic = display_topic(pane);
         let desired = desired_tokens(values, &topic);
         if metadata_matches(&pane.tokens, &desired) {
             continue;
@@ -255,7 +267,7 @@ pub fn publish_tokens(
             ])
             .args(["--seq", &sequence.to_string()])
             .args(["--ttl-ms", METADATA_TTL_MS]);
-        for name in METADATA_TOKEN_NAMES {
+        for name in metadata_report_names(pane, &desired) {
             if let Some(value) = desired.get(name) {
                 command.args(["--token", &format!("{name}={value}")]);
             } else {
@@ -301,13 +313,13 @@ fn pane_is_scrolled(executable: &std::ffi::OsStr, pane_id: &str) -> bool {
 
 fn desired_tokens(values: &MetadataTokens, topic: &str) -> BTreeMap<String, String> {
     let mut tokens = BTreeMap::from([
-        ("quota_badge".to_string(), values.quota_badge.clone()),
         ("quota_state".to_string(), values.quota_state.clone()),
         ("quota_icon".to_string(), values.quota_icon.clone()),
         ("quota_provider".to_string(), values.quota_provider.clone()),
         ("quota_status".to_string(), values.quota_status.clone()),
         ("quota_summary".to_string(), values.quota_summary.clone()),
     ]);
+    insert_optional_token(&mut tokens, "quota_context", &values.quota_context);
     insert_optional_token(&mut tokens, "quota_5h", &values.quota_5h);
     insert_severity_token(
         &mut tokens,
@@ -329,6 +341,14 @@ fn desired_tokens(values: &MetadataTokens, topic: &str) -> BTreeMap<String, Stri
     tokens
 }
 
+fn display_topic(pane: &AgentPane) -> String {
+    let topic = pane.topic.trim();
+    if topic.is_empty() || is_status_line(topic) {
+        return truncate_topic(&pane.session_summary);
+    }
+    truncate_topic(topic)
+}
+
 fn metadata_matches(
     current: &BTreeMap<String, String>,
     desired: &BTreeMap<String, String>,
@@ -336,6 +356,43 @@ fn metadata_matches(
     METADATA_TOKEN_NAMES
         .into_iter()
         .all(|name| current.get(name) == desired.get(name))
+        && LEGACY_METADATA_TOKEN_NAMES
+            .into_iter()
+            .all(|name| !current.contains_key(name))
+}
+
+fn metadata_report_names(
+    pane: &AgentPane,
+    desired: &BTreeMap<String, String>,
+) -> Vec<&'static str> {
+    let mut names = METADATA_TOKEN_NAMES
+        .into_iter()
+        .filter(|name| desired.contains_key(*name) || pane.tokens.contains_key(*name))
+        .collect::<Vec<_>>();
+    names.extend(
+        LEGACY_METADATA_TOKEN_NAMES
+            .into_iter()
+            .filter(|name| pane.tokens.contains_key(*name)),
+    );
+    if names.len() <= METADATA_TOKEN_NAMES.len() {
+        return names;
+    }
+
+    // A pane upgraded from the pre-context token set can briefly contain all
+    // old and new names. Keep the new context token and clear legacy names in
+    // the same bounded report; a stable summary/status token can be refreshed
+    // on the following poll if necessary.
+    for candidate in ["quota_summary", "quota_status", "quota_icon"] {
+        let Some(index) = names.iter().position(|name| *name == candidate) else {
+            continue;
+        };
+        if pane.tokens.get(candidate) == desired.get(candidate) {
+            names.remove(index);
+            break;
+        }
+    }
+    names.truncate(METADATA_TOKEN_NAMES.len());
+    names
 }
 
 fn insert_severity_token(
@@ -437,6 +494,7 @@ fn is_status_line(value: &str) -> bool {
         || lower.starts_with("session ")
         || lower.starts_with("auto mode")
         || lower.starts_with("shift+tab")
+        || lower == "ask codex to do anything"
         || matches!(
             lower.as_str(),
             "/clear" | "/compact" | "/help" | "/status" | "/usage" | "/model" | "/config"
@@ -467,12 +525,16 @@ mod tests {
                 AgentPane {
                     pane_id: "w1:p1".to_string(),
                     provider: Provider::Codex,
+                    session_id: None,
+                    session_summary: String::new(),
                     topic: String::new(),
                     tokens: BTreeMap::new(),
                 },
                 AgentPane {
                     pane_id: "w1:p2".to_string(),
                     provider: Provider::Claude,
+                    session_id: None,
+                    session_summary: String::new(),
                     topic: String::new(),
                     tokens: BTreeMap::new(),
                 },
@@ -490,6 +552,37 @@ mod tests {
         let mut panes = Vec::new();
         collect_agent_panes(&value, &mut panes);
         assert_eq!(panes[0].topic, "latest task");
+    }
+
+    #[test]
+    fn discovers_codex_session_id_and_preserves_session_summary() {
+        let value = json!({"result": {"agents": [{
+            "pane_id": "w1:p1",
+            "agent": "codex",
+            "agent_session": {"agent": "codex", "value": "thread-1"},
+            "tokens": {"quota_session": "previous summary"}
+        }]}});
+        let mut panes = Vec::new();
+        collect_agent_panes(&value, &mut panes);
+        assert_eq!(panes[0].session_id.as_deref(), Some("thread-1"));
+        assert_eq!(panes[0].session_summary, "previous summary");
+    }
+
+    #[test]
+    fn legacy_metadata_tokens_force_one_bounded_cleanup_report() {
+        let pane = AgentPane {
+            pane_id: "w1:p1".to_string(),
+            provider: Provider::Claude,
+            session_id: None,
+            session_summary: String::new(),
+            topic: String::new(),
+            tokens: BTreeMap::from([(String::from("quota_badge"), String::from("[A]"))]),
+        };
+        let desired = BTreeMap::from([(String::from("quota_state"), String::from("?"))]);
+        assert!(!metadata_matches(&pane.tokens, &desired));
+        let names = metadata_report_names(&pane, &desired);
+        assert!(names.contains(&"quota_badge"));
+        assert!(names.len() <= METADATA_TOKEN_NAMES.len());
     }
 
     #[test]
@@ -521,6 +614,14 @@ mod tests {
     fn extracts_latest_claude_prompt_and_skips_clear_command() {
         let text = "❯ /clear\n❯ hi\n⏺ Hi! What can I help with?\n❯\n";
         assert_eq!(extract_topic(text, Provider::Claude).as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn ignores_codex_default_prompt_placeholder() {
+        assert_eq!(
+            extract_topic("› Ask Codex to do anything\n", Provider::Codex),
+            None
+        );
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use thiserror::Error;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
@@ -171,11 +172,29 @@ impl UsageWindow {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContextUsage {
+    pub used_percent: f64,
+}
+
+impl ContextUsage {
+    pub fn new(used_percent: f64) -> Result<Self, ModelError> {
+        if !used_percent.is_finite() || !(0.0..=100.0).contains(&used_percent) {
+            return Err(ModelError::InvalidPercentage(used_percent));
+        }
+        Ok(Self { used_percent })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProviderSnapshot {
     pub provider: Provider,
     pub source: String,
     pub fetched_at_unix: u64,
     pub windows: Vec<UsageWindow>,
+    #[serde(default)]
+    pub context: Option<ContextUsage>,
+    #[serde(default)]
+    pub session_summaries: BTreeMap<String, String>,
 }
 
 impl ProviderSnapshot {
@@ -185,7 +204,14 @@ impl ProviderSnapshot {
             source: provider.source().to_string(),
             fetched_at_unix,
             windows,
+            context: None,
+            session_summaries: BTreeMap::new(),
         }
+    }
+
+    pub fn with_context(mut self, context: Option<ContextUsage>) -> Self {
+        self.context = context;
+        self
     }
 
     pub fn window(&self, kind: WindowKind) -> Option<&UsageWindow> {

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -4,7 +4,6 @@ use crate::model::{
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetadataTokens {
-    pub quota_badge: String,
     pub quota_state: String,
     pub quota_icon: String,
     pub quota_provider: String,
@@ -14,13 +13,13 @@ pub struct MetadataTokens {
     pub quota_week: String,
     pub quota_week_severity: Option<Severity>,
     pub quota_summary: String,
+    pub quota_context: String,
     pub quota_error: Option<String>,
 }
 
 impl MetadataTokens {
     pub fn from_snapshot(snapshot: &ProviderSnapshot, now_unix: u64) -> Self {
         Self {
-            quota_badge: snapshot.provider.badge().to_string(),
             quota_state: snapshot.severity(now_unix).symbol().to_string(),
             quota_icon: snapshot.provider.icon().to_string(),
             quota_provider: snapshot.provider.display_name().to_string(),
@@ -30,13 +29,13 @@ impl MetadataTokens {
             quota_week: sidebar_window(snapshot, WindowKind::Weekly, now_unix),
             quota_week_severity: window_severity(snapshot, WindowKind::Weekly, now_unix),
             quota_summary: sidebar_summary(snapshot, now_unix),
+            quota_context: sidebar_context(snapshot),
             quota_error: None,
         }
     }
 
     pub fn unavailable(provider: Provider, reason: impl Into<String>) -> Self {
         Self {
-            quota_badge: provider.badge().to_string(),
             quota_state: Severity::Unknown.symbol().to_string(),
             quota_icon: provider.icon().to_string(),
             quota_provider: provider.display_name().to_string(),
@@ -52,6 +51,7 @@ impl MetadataTokens {
             quota_week: "week N/A".to_string(),
             quota_week_severity: Some(Severity::Unknown),
             quota_summary: "unavailable".to_string(),
+            quota_context: String::new(),
             quota_error: Some(reason.into().chars().take(80).collect()),
         }
     }
@@ -88,6 +88,14 @@ fn sidebar_window(snapshot: &ProviderSnapshot, kind: WindowKind, now_unix: u64) 
     snapshot
         .window(kind)
         .map(|window| format_window(window, now_unix, false))
+        .unwrap_or_default()
+}
+
+fn sidebar_context(snapshot: &ProviderSnapshot) -> String {
+    snapshot
+        .context
+        .as_ref()
+        .map(|context| format!("context {}%", format_percent(context.used_percent)))
         .unwrap_or_default()
 }
 
@@ -190,5 +198,17 @@ mod tests {
         let values = MetadataTokens::from_snapshot(&snapshot, 0);
         assert_eq!(values.quota_5h_severity, Some(Severity::Warning));
         assert_eq!(values.quota_week_severity, Some(Severity::Danger));
+    }
+
+    #[test]
+    fn metadata_formats_context_usage_when_available() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![window(WindowKind::Weekly, 10.0, 183_600)],
+            0,
+        )
+        .with_context(Some(crate::model::ContextUsage::new(23.5).unwrap()));
+        let values = MetadataTokens::from_snapshot(&snapshot, 0);
+        assert_eq!(values.quota_context, "context 24%");
     }
 }

--- a/src/providers/agy.rs
+++ b/src/providers/agy.rs
@@ -1,5 +1,6 @@
 use crate::cache::CacheStore;
 use crate::model::{Provider, ProviderSnapshot, ResetAt, UsageWindow, WindowKind};
+use crate::providers::statusline::parse_context;
 use crate::providers::ProviderError;
 use serde_json::Value;
 
@@ -33,11 +34,16 @@ pub fn parse_statusline(
             "quota has no supported windows".to_string(),
         ));
     }
-    Ok(ProviderSnapshot::new(
-        Provider::Agy,
-        windows,
-        fetched_at_unix,
-    ))
+    Ok(
+        ProviderSnapshot::new(Provider::Agy, windows, fetched_at_unix).with_context(
+            parse_context(
+                value
+                    .get("context_window")
+                    .or_else(|| value.get("contextWindow")),
+            )
+            .unwrap_or(None),
+        ),
+    )
 }
 
 fn parse_window(
@@ -126,6 +132,24 @@ mod tests {
         assert_eq!(
             snapshot.window(WindowKind::FiveHour).unwrap().resets_at,
             Some(ResetAt::from_unix_seconds(1_786_798_800))
+        );
+    }
+
+    #[test]
+    fn parses_optional_context_window_usage() {
+        let value = json!({
+            "context_window": {"used_percentage": 41.0},
+            "quota": {
+                "gemini-weekly": {"remaining_fraction": 0.8}
+            }
+        });
+        let snapshot = parse_statusline(&value, 1).unwrap();
+        assert_eq!(
+            snapshot
+                .context
+                .as_ref()
+                .map(|context| context.used_percent),
+            Some(41.0)
         );
     }
 

--- a/src/providers/claude.rs
+++ b/src/providers/claude.rs
@@ -1,5 +1,6 @@
 use crate::cache::CacheStore;
 use crate::model::{Provider, ProviderSnapshot, ResetAt, UsageWindow, WindowKind};
+use crate::providers::statusline::parse_context;
 use crate::providers::ProviderError;
 use serde_json::Value;
 
@@ -22,11 +23,16 @@ pub fn parse_statusline(
             "rate_limits has no supported windows".to_string(),
         ));
     }
-    Ok(ProviderSnapshot::new(
-        Provider::Claude,
-        windows,
-        fetched_at_unix,
-    ))
+    Ok(
+        ProviderSnapshot::new(Provider::Claude, windows, fetched_at_unix).with_context(
+            parse_context(
+                value
+                    .get("context_window")
+                    .or_else(|| value.get("contextWindow")),
+            )
+            .unwrap_or(None),
+        ),
+    )
 }
 
 fn parse_window(
@@ -80,6 +86,27 @@ mod tests {
         assert_eq!(
             snapshot.window(WindowKind::FiveHour).unwrap().resets_at,
             Some(ResetAt::from_unix_seconds(1_786_795_200))
+        );
+    }
+
+    #[test]
+    fn parses_optional_context_window_usage() {
+        let value = json!({
+            "context_window": {
+                "used_percentage": 23.5,
+                "remaining_percentage": 76.5
+            },
+            "rate_limits": {
+                "five_hour": {"used_percentage": 58.0}
+            }
+        });
+        let snapshot = parse_statusline(&value, 1).unwrap();
+        assert_eq!(
+            snapshot
+                .context
+                .as_ref()
+                .map(|context| context.used_percent),
+            Some(23.5)
         );
     }
 

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -3,6 +3,7 @@ use crate::model::{Provider, ProviderSnapshot, ResetAt, UsageWindow, WindowKind}
 use crate::providers::ProviderError;
 use anyhow::{Context, Result};
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::{Arc, Mutex};
@@ -144,7 +145,57 @@ fn fetch_from_process(
 
     write_rpc(input, 3, "account/rateLimits/read", serde_json::json!({}))?;
     let limits = read_rpc(output, 3)?;
-    parse_rate_limits(&limits, CacheStore::now_unix()).map_err(anyhow::Error::from)
+    let mut snapshot =
+        parse_rate_limits(&limits, CacheStore::now_unix()).map_err(anyhow::Error::from)?;
+
+    // Session previews come from Codex's local state database. This is one
+    // bounded read in the same app-server process as the quota request; it
+    // does not resume threads, scan rollout JSONL, or contact the model.
+    write_rpc(
+        input,
+        4,
+        "thread/list",
+        serde_json::json!({
+            "limit": 50,
+            "sortKey": "updated_at",
+            "useStateDbOnly": true
+        }),
+    )?;
+    if let Ok(threads) = read_rpc(output, 4) {
+        snapshot.session_summaries = parse_session_summaries(&threads);
+    }
+    Ok(snapshot)
+}
+
+fn parse_session_summaries(value: &Value) -> BTreeMap<String, String> {
+    let result = value.get("result").unwrap_or(value);
+    result
+        .get("data")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|thread| {
+            let id = thread.get("id").and_then(Value::as_str)?;
+            let preview = thread.get("preview").and_then(Value::as_str)?;
+            let summary = preview
+                .lines()
+                .map(str::trim)
+                .find(|line| !line.is_empty())
+                .filter(|line| !line.eq_ignore_ascii_case("ask codex to do anything"))
+                .map(truncate_summary)?;
+            Some((id.to_string(), summary))
+        })
+        .collect()
+}
+
+fn truncate_summary(value: &str) -> String {
+    let characters: Vec<char> = value.chars().collect();
+    if characters.len() <= 80 {
+        return value.to_string();
+    }
+    let mut summary: String = characters.into_iter().take(77).collect();
+    summary.push('…');
+    summary
 }
 
 fn write_rpc(input: &mut ChildStdin, id: u64, method: &str, params: Value) -> Result<()> {
@@ -248,5 +299,20 @@ mod tests {
         assert!(!account_is_chatgpt(
             &json!({"result": {"account": {"authMode": "api_key"}}})
         ));
+    }
+
+    #[test]
+    fn extracts_compact_session_summaries_without_default_prompt() {
+        let summaries = parse_session_summaries(&json!({
+            "result": {"data": [
+                {"id": "thread-1", "preview": "A real task\n\nmore detail"},
+                {"id": "thread-2", "preview": "Ask Codex to do anything"}
+            ]}
+        }));
+        assert_eq!(
+            summaries.get("thread-1").map(String::as_str),
+            Some("A real task")
+        );
+        assert!(!summaries.contains_key("thread-2"));
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,6 +2,7 @@ pub mod agy;
 pub mod claude;
 pub mod codex;
 pub mod grok;
+mod statusline;
 
 use thiserror::Error;
 

--- a/src/providers/statusline.rs
+++ b/src/providers/statusline.rs
@@ -1,0 +1,30 @@
+use crate::model::ContextUsage;
+use crate::providers::ProviderError;
+use serde_json::Value;
+
+pub fn parse_context(
+    value: Option<&Value>,
+) -> std::result::Result<Option<ContextUsage>, ProviderError> {
+    let Some(value) = value.filter(|value| !value.is_null()) else {
+        return Ok(None);
+    };
+    let Some(object) = value.as_object() else {
+        return Err(ProviderError::UnsupportedResponse(
+            "context_window is not an object".to_string(),
+        ));
+    };
+    let used = object
+        .get("used_percentage")
+        .or_else(|| object.get("usedPercentage"))
+        .and_then(Value::as_f64);
+    let remaining = object
+        .get("remaining_percentage")
+        .or_else(|| object.get("remainingPercentage"))
+        .and_then(Value::as_f64);
+    let Some(percent) = used.or_else(|| remaining.map(|value| 100.0 - value)) else {
+        return Ok(None);
+    };
+    ContextUsage::new(percent)
+        .map(Some)
+        .map_err(|error| ProviderError::UnsupportedResponse(error.to_string()))
+}

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -231,6 +231,15 @@ fn publish(
     let now = CacheStore::now_unix();
     for provider in providers {
         let snapshot = cache.load(*provider)?;
+        if let Some(snapshot) = snapshot.as_ref() {
+            for pane in panes.iter_mut().filter(|pane| pane.provider == *provider) {
+                if let Some(session_id) = pane.session_id.as_deref() {
+                    if let Some(summary) = snapshot.session_summaries.get(session_id) {
+                        pane.session_summary = summary.clone();
+                    }
+                }
+            }
+        }
         if let Some(values) = tokens_for_provider(snapshot.as_ref(), now) {
             tokens.push((*provider, values));
         }

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -94,6 +94,7 @@ fn default_herdr_rows_become_plane_provider_usage_and_topic_lines() {
     assert!(applied.contains("$quota_week_danger"));
     assert!(!applied.contains("[\"$quota_summary\"]"));
     assert!(applied.contains("$quota_topic"));
+    assert!(applied.contains("$quota_context"));
     assert!(applied.contains("row_gap = 1 # herdr-agent-quota"));
     assert!(applied.find("$quota_topic").unwrap() < applied.find("$quota_5h_normal").unwrap());
     assert!(applied.contains("fg = \"#84b084\""));
@@ -104,6 +105,17 @@ fn default_herdr_rows_become_plane_provider_usage_and_topic_lines() {
     assert!(applied.contains("fg = \"#7998b7\""));
     assert!(applied.contains("fg = \"#acb4c3\""));
     assert!(applied.contains("fg = \"#84b0af\""));
+}
+
+#[test]
+fn configuration_removes_obsolete_session_summary_rows() {
+    let original = concat!(
+        "[ui.sidebar.agents]\n",
+        "rows = [[\"state_icon\", \"agent\"], [\"$quota_topic\"], [\"$quota_session\"]]\n"
+    );
+    let applied = add_quota_row(original).unwrap();
+    assert!(applied.contains("$quota_context"));
+    assert!(!applied.contains("$quota_session"));
 }
 
 #[test]
@@ -180,6 +192,33 @@ fn claude_cache_is_published_by_refresh_event() {
     assert!(!report.contains("pane read"));
     assert!(report.contains("quota_5h=5h 42% reset"));
     assert!(report.contains("quota_week=week 73% reset"));
+}
+
+#[test]
+fn statusline_without_context_keeps_the_last_context_snapshot() {
+    let state = tempdir().unwrap();
+    let (herdr_stub, herdr_log) = install_herdr_stub(
+        state.path(),
+        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1"}]}}"#,
+    );
+    run_claude_collector(
+        state.path(),
+        &herdr_stub,
+        br#"{
+            "context_window": {"used_percentage": 23.5},
+            "rate_limits": {"seven_day": {"used_percentage": 27.0}}
+        }"#,
+    );
+    run_claude_collector(
+        state.path(),
+        &herdr_stub,
+        br#"{"rate_limits":{"seven_day":{"used_percentage":28.0}}}"#,
+    );
+
+    run_claude_refresh(state.path(), &herdr_stub);
+    let report = fs::read_to_string(herdr_log).unwrap();
+    assert!(report.contains("quota_context=context 24%"));
+    assert!(report.contains("quota_week=week 72%"));
 }
 
 #[test]
@@ -307,7 +346,7 @@ fn claude_collector_does_not_republish_unchanged_quota() {
     let state = tempdir().unwrap();
     let (herdr_stub, herdr_log) = install_herdr_stub(
         state.path(),
-        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1","tokens":{"quota_badge":"[A]","quota_state":"?","quota_icon":"✦Cl","quota_provider":"Claude","quota_status":"N/A","quota_5h":"5h 42%","quota_5h_warning":"5h 42%","quota_week":"week 73%","quota_week_warning":"week 73%","quota_summary":"5h 42% · week 73%"}}]}}"#,
+        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1","tokens":{"quota_state":"?","quota_icon":"✦Cl","quota_provider":"Claude","quota_status":"N/A","quota_5h":"5h 42%","quota_5h_warning":"5h 42%","quota_week":"week 73%","quota_week_warning":"week 73%","quota_summary":"5h 42% · week 73%"}}]}}"#,
     );
 
     let input = br#"{


### PR DESCRIPTION
## Summary

- show provider-reported context-used percentage for Claude Code and Agy statusLine payloads
- preserve the last context snapshot across first-response/compact omissions
- replace Codex's default `Ask Codex to do anything` sidebar topic with a bounded local `thread/list` preview (max 50, first line truncated to 80 chars)
- retire and clean obsolete `$quota_session`/`quota_badge` metadata while staying within Herdr's 16-token report limit
- document provider capabilities and why no `cached expires` field is shown

## Safety and performance

- one global active-turn watcher/poll remains; no per-pane fan-out
- Codex uses the existing short-lived app-server process plus one state-database-only query; no thread resume, rollout scan, login refresh, or model request
- unsupported context/cache fields are omitted rather than guessed

## Verification

- `cargo fmt --all`
- `cargo test --all-targets --all-features --locked` (63 + integration suites passed)
- `cargo clippy --release --all-targets --all-features --locked -- -D warnings`
- `cargo build --release --locked`
- local configure/reload and forced refresh succeeded; Codex preview topics populated, default placeholders 0, legacy badge/session metadata 0
