### PR TITLE
feat: show cumulative session cache diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Claude and Agy context rows now include the latest cache hit percentage when
-  their statusLine exposes cache counters. Claude can also show a bounded,
-  explicitly approximate `ttl≈` estimate from a transcript tail; no provider
-  request or extra metadata token is used.
+- Context now follows the provider name, while cache diagnostics use two
+  dedicated rows: a one-decimal cumulative session hit rate and the elapsed
+  time since the latest cache-bearing response plus an explicitly approximate
+  TTL estimate when the provider exposes a cache bucket. Claude/Agy collectors
+  use local statusLine/transcript data only; they do not log in or start model
+  requests.
 - Quota rows now show a compact `reset` ETA: minutes below one hour, hours and
   minutes below one day, and days plus hours for longer windows.
 - Active turns now start one short-lived global refresh watcher for Claude,
@@ -93,9 +95,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- The context row now uses a dedicated violet accent and combines context/cache
-  diagnostics in the existing `$quota_context` token to stay within Herdr's
-  metadata limit.
+- The context row now uses a dedicated violet accent immediately after the
+  provider name. Cache hit and last-activity/TTL rows use separate teal and
+  amber accents, while metadata publication remains capped at sixteen tokens.
 - Quota formatting is centralized in one presentation module shared by the
   sidebar, dashboard, and statusLine fallbacks. Codex remains weekly-only.
 - Five-hour and weekly quota windows now occupy separate sidebar rows. Missing

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Agy/Antigravity subscription usage, in Herdr's agent sidebar.
 ```text
 ● Owner · Claude
   hi                     ← what that pane is actually working on
-  context 23% · cache 96% · ttl≈58m
-                         ← cache fields appear when the CLI exposes them
+  context 23%             ← provider-native context percentage
+  cache 99.6% hit         ← cumulative for this session
+  cache last 2m ago · ttl≈58m
   5h 100% reset 3h07m
   week 31% reset 2d3h
 ```
@@ -182,10 +183,13 @@ strings, so newer compatible CLI releases can continue to work.
 
 The sidebar shows **percentage remaining** and the time until each quota reset,
 not quota token counts. Claude and Agy also show provider-reported context
-percentage and, when `current_usage` contains the counters, the latest cache
-hit ratio (`read / (fresh + creation + read)`). Claude may additionally show
-`ttl≈...`: this is a local estimate from the last 16 KiB of its transcript and
-the provider's 5-minute/1-hour cache bucket, not a server-confirmed expiry.
+percentage. When a statusLine transcript and session id are available,
+`cache N.N% hit` is the cumulative main-session ratio
+(`read / (fresh + creation + read)`), not the latest turn. The next row shows
+how long ago the latest cache-bearing response arrived and, for Claude, a
+`ttl≈...` estimate from the provider's 5-minute/1-hour bucket. This is local
+diagnostic math, not a server-confirmed expiry; the first session update reads
+the existing transcript once, then later updates read only appended bytes.
 Codex shows a short session preview from its local state database; its live
 context and cache fields are not queried because the current safe app-server
 connection is quota-only and does not attach to an active thread. Grok's
@@ -216,9 +220,10 @@ once:
 [ui.sidebar.agents]
 row_gap = 1 # herdr-agent-quota
 rows = [
-  ["state_icon", "tab", { token = "$quota_provider", bold = true, dim = false }],
+  ["state_icon", "tab", { token = "$quota_provider", bold = true, dim = false }, { token = "$quota_context", fg = "#9b8fd8", bold = true, dim = false }],
   [{ token = "$quota_topic", dim = false }],
-  [{ token = "$quota_context", fg = "#9b8fd8", bold = true, dim = false }],
+  [{ token = "$quota_cache", fg = "#6fb5b7", bold = true, dim = false }],
+  [{ token = "$quota_cache_ttl", fg = "#cdaa65", bold = true, dim = false }],
   [{ token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false }],
   [{ token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false }],
   [{ token = "$quota_5h_danger", fg = "#ca6470", bold = true, dim = false }],
@@ -237,11 +242,13 @@ rows = [
   then resource status.
 - For Codex, an empty/default prompt falls back to the short thread preview from
   the local app-server state database; other providers keep the prompt empty.
-- `$quota_context` starts with the provider-reported context **used** percentage.
-  Claude and Agy can append `cache N%` from the latest statusLine request; a
-  Claude transcript with an explicit cache bucket can append `ttl≈...`. Missing
-  fields are hidden instead of guessed, and the TTL marker is deliberately
-  approximate.
+- `$quota_context` is the provider-reported context **used** percentage and sits
+  directly after the provider name. `$quota_cache` is the cumulative hit rate
+  for the main session transcript, not a per-turn value; it is shown to one
+  decimal place so `99.6%` is not rounded to `100%`. `$quota_cache_ttl` shows
+  the elapsed time since the latest cache-bearing assistant response and, when
+  Claude exposes a 5m/1h bucket, the remaining `ttl≈...` estimate. Missing
+  fields are hidden instead of guessed.
 - The context row uses a violet accent (`#9b8fd8`) so context pressure is easy
   to distinguish from the green/amber/red quota runway colors.
 - Each window publishes exactly one styled variant. Color follows runway rather
@@ -254,8 +261,8 @@ rows = [
   `row_gap` value is preserved.
 - `$quota_5h`, `$quota_week`, and `$quota_summary` remain available for custom
   unstyled layouts. `$quota_summary` is the compact quota-window summary, not a
-  cache-expiry value; `$quota_context` is the single token for context and cache
-  diagnostics so the plugin stays within Herdr's metadata-token limit.
+  cache-expiry value. Herdr reports no more than sixteen metadata tokens; old
+  `$quota_icon`/`$quota_status` fields are cleaned up during migration.
 
 Herdr 0.8 only accepts fixed hex colors for styled tokens, not semantic theme
 colors. The default palette uses soft, high-luminance green, amber, and red
@@ -295,15 +302,16 @@ such as `Thinking` or `Executing`. It does not show the working directory.
 - **Claude Code:** the official [`statusLine` JSON hook](https://code.claude.com/docs/en/statusline)
   supplies the five-hour, seven-day, context-used percentage, and latest
   cache counters. A previous statusLine command is backed up, chained, and
-  restored by the uninstall action. When a transcript path and an explicit
-  cache bucket are present, the hook reads only its final 16 KiB to produce the
-  `ttl≈...` estimate; it makes no network request and does not read the full
-  conversation.
+  restored by the uninstall action. When a transcript path and session id are
+  present, the hook accumulates the main session's assistant usage using a
+  byte offset; the first update reads the existing transcript once and later
+  updates read only appended lines. A cache bucket gives the explicitly
+  approximate `ttl≈...`; there is no network request or model turn.
 - **Agy/Antigravity:** the official [`/usage` and statusline docs](https://antigravity.google/docs/cli/commands/usage?app=antigravity-ide)
-  supply Gemini and third-party pools plus context-used percentage and latest
-  cache counters. When both pools exist, the sidebar uses the lowest remaining
-  percentage so the single Agy row is conservative; Agy has no reliable TTL
-  field, so it shows the hit ratio only.
+  supply Gemini and third-party pools plus context-used percentage and cache
+  counters. When both pools exist, the sidebar uses the lowest remaining
+  percentage so the single Agy row is conservative. Agy has no reliable TTL
+  field; its cache rows appear only when a session transcript/id is supplied.
 
 Snapshots and refresh markers stay in Herdr's plugin state directory. No usage
 data is uploaded, browser cookies or browser keychains are read, and provider

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,8 +14,9 @@ Claude Code、Codex、Grok 和 Agy/Antigravity 的订阅额度。
 ```text
 ● Owner · Claude
   hi                     ← 这个 pane 当前在做什么
-  context 23% · cache 96% · ttl≈58m
-                         ← provider 提供字段时显示 context/cache 诊断
+  context 23%             ← provider 原生 context 百分比
+  cache 99.6% hit         ← 整个 session 累计命中率
+  cache last 2m ago · ttl≈58m
   5h 100% reset 3h07m
   week 31% reset 2d3h
 ```
@@ -154,11 +155,12 @@ usage、topic 三类 token，不会覆盖官方 agent 指示。卸载 action 会
 字段工作，不会把这些版本号写死；兼容的新版本可以继续使用。
 
 侧栏显示的是**额度剩余百分比**和距离下次额度重置的时间，不是额度 token 数量。
-Claude 和 Agy 的 statusLine 有 context 字段时，还会显示当前 context **已用**百分比；
-同时提供 `current_usage` 时会显示最新请求的缓存命中率
-（`read / (fresh + creation + read)`）。Claude 如果同时有 transcript 路径和明确的
-5 分钟/1 小时缓存桶，还会显示 `ttl≈...`，这是只读取 transcript 最后 16 KiB 得到的
-本地近似，不是服务端确认的过期时间。Codex 会显示本地 state database 里的短会话预览；
+Claude 和 Agy 的 statusLine 有 context 字段时，还会显示当前 context **已用**百分比。
+如果有 statusLine transcript 和 session id，`cache N.N% hit` 是主 session 的累计命中率
+（`read / (fresh + creation + read)`），不是最新一轮；下一行显示最近一次有缓存响应
+距离现在多久。Claude 如果还有明确的 5 分钟/1 小时缓存桶，会显示 `ttl≈...`，这是本地
+近似，不是服务端确认的过期时间。首次 session 更新会读取一次已有 transcript，之后只读
+新增字节。Codex 会显示本地 state database 里的短会话预览；
 当前安全的 app-server 连接只查额度，没有绑定活动 thread，因此不猜测 Codex context
 或缓存字段。Grok 当前的 billing 来源没有 context 或缓存字段。没有证据的字段会隐藏，
 不会伪造 `cached expires`：
@@ -166,6 +168,9 @@ Claude 和 Agy 的 statusLine 有 context 字段时，还会显示当前 context
 ```text
 ● Owner · Claude
   hi
+  context 23%
+  cache 99.6% hit
+  cache last 2m ago · ttl≈58m
   5h 100% reset 3h07m
   week 31% reset 2d3h
 ```
@@ -193,9 +198,10 @@ Agy 通过原生的一次性 `statusLine` hook 把额度 JSON 传给插件。配
 [ui.sidebar.agents]
 row_gap = 1 # herdr-agent-quota
 rows = [
-  ["state_icon", "tab", { token = "$quota_provider", bold = true, dim = false }],
+  ["state_icon", "tab", { token = "$quota_provider", bold = true, dim = false }, { token = "$quota_context", fg = "#9b8fd8", bold = true, dim = false }],
   [{ token = "$quota_topic", dim = false }],
-  [{ token = "$quota_context", fg = "#9b8fd8", bold = true, dim = false }],
+  [{ token = "$quota_cache", fg = "#6fb5b7", bold = true, dim = false }],
+  [{ token = "$quota_cache_ttl", fg = "#cdaa65", bold = true, dim = false }],
   [{ token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false }],
   [{ token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false }],
   [{ token = "$quota_5h_danger", fg = "#ca6470", bold = true, dim = false }],
@@ -212,9 +218,11 @@ rows = [
 - `$quota_topic` 放在额度上方，阅读顺序是 agent、当前任务、资源状态。
 - Codex 的空/默认 prompt 会回退为本地 app-server state database 的短会话预览；
   其他 provider 仍保持空白。
-- `$quota_context` 先显示 provider 报告的 context **已用**百分比。Claude 和 Agy
-  可以追加最新请求的 `cache N%`；Claude 在有 transcript 和明确缓存桶时还会追加
-  `ttl≈...`。字段缺失时隐藏，不做 tokenizer 猜测，TTL 也明确标记为近似。
+- `$quota_context` 显示 provider 报告的 context **已用**百分比，并紧跟在 provider
+  名称后面。`$quota_cache` 是主 session transcript 的累计命中率，不是每一轮的比例；
+  固定保留一位小数，避免 `99.6%` 被显示成 `100%`。`$quota_cache_ttl` 显示最近一次
+  有缓存响应距离现在多久；Claude 提供 5m/1h 缓存桶时还会显示剩余的 `ttl≈...`。
+  字段缺失时隐藏，不做猜测。
 - context 行使用紫色强调色（`#9b8fd8`），与额度续航的绿/琥珀/红色区分开。
 - 每个窗口只发布一个样式 token。颜色按额度续航动态判断，不再使用固定
   余额阈值：将剩余额度比例与窗口剩余时间比例比较，额度消耗不快于时间
@@ -224,8 +232,9 @@ rows = [
 - `row_gap = 1` 在 agent 卡片之间留一行空白；已有的显式 `row_gap`
   配置会原样保留。
 - `$quota_5h`、`$quota_week`、`$quota_summary` 仍保留给需要无样式或
-  紧凑布局的自定义配置。`$quota_summary` 是额度窗口汇总，不是缓存过期时间；
-  context/cache 诊断共用 `$quota_context`，不会新增 metadata token。
+  紧凑布局的自定义配置。`$quota_summary` 是额度窗口汇总，不是缓存过期时间。
+  Herdr metadata 始终不超过 16 个 token；升级时会清理旧的 `$quota_icon`/
+  `$quota_status` 字段。
 
 Herdr 0.8 的样式只接受固定十六进制颜色，不支持跟随主题的语义色。
 默认的绿色、琥珀色和红色采用高明度柔和色阶并加粗，降低 Herdr 深色侧栏
@@ -259,13 +268,14 @@ Herdr plugin v1 只支持文本 token，不能由插件向原生 Agent renderer 
 - **Claude Code：** 使用官方
   [`statusLine` JSON hook](https://code.claude.com/docs/en/statusline) 提供
   5 小时、7 天额度、context 已用百分比和最新缓存计数。原有 statusLine 会被备份、
-  串联，并可由卸载 action 恢复；当输入同时提供 transcript 路径和明确缓存桶时，
-  采集器只读取 transcript 最后 16 KiB 推断 `ttl≈...`，不联网、不读取完整对话。
+  串联，并可由卸载 action 恢复；当输入提供 transcript 路径和 session id 时，
+  采集器首次读取一次已有主会话并按 offset 增量累计，之后只读新增行；明确缓存桶
+  才推断 `ttl≈...`，不联网、不发模型请求。
 - **Agy/Antigravity：** 使用官方
   [`/usage` 和 statusline 文档](https://antigravity.google/docs/cli/commands/usage?app=antigravity-ide)
   中的 Gemini、第三方额度池、context 已用百分比和最新缓存计数。两个额度池同时存在时，
-  取较低的剩余百分比，让单个 Agy 行保持保守；Agy 没有可靠的 TTL 字段，因此只显示
-  命中率。
+  取较低的剩余百分比，让单个 Agy 行保持保守；Agy 没有可靠的 TTL 字段，只有在
+  statusLine 提供 transcript/session 标识时才显示缓存累计行。
 
 快照和刷新标记保存在 Herdr 插件状态目录中。插件不会上传使用数据，不读取
 浏览器 Cookie/Keychain，不刷新或写入 provider 凭据。provider 失败时保留

--- a/docs/plans/herdr-agent-quota-implementation.md
+++ b/docs/plans/herdr-agent-quota-implementation.md
@@ -98,10 +98,16 @@ longer sent as a separate metadata value:
 
 - `$quota_badge`: retired cleanup marker; it is no longer published.
 - `$quota_state`: `●`, `▲`, `!`, or `?`.
-- `$quota_icon`: compact text markers `◈C`, `✕G`, `✦Cl`, or `△Ag`.
+- `$quota_icon`: retired cleanup marker; native Herdr state plus provider name
+  replaces this redundant value.
 - `$quota_provider`: `Codex`, `Grok`, `Claude`, or `Agy` for custom layouts.
-- `$quota_status`: `OK`, `WARN`, `LOW`, or `N/A`.
+- `$quota_status`: retired cleanup marker; quota window rows carry the visible
+  health color.
 - `$quota_context`: provider-reported context-used percentage when available.
+- `$quota_cache`: one-decimal cumulative cache hit rate for the main session
+  transcript when a session boundary is available.
+- `$quota_cache_ttl`: elapsed time since the latest cache-bearing response and
+  an explicitly approximate provider TTL estimate when supported.
 - `$quota_5h`: compact five-hour remaining value and reset ETA when exposed.
 - `$quota_week`: compact weekly remaining value and reset ETA.
 - `$quota_summary`: window-driven compact remaining values and reset ETAs.

--- a/docs/research/cache-observability-open-source.md
+++ b/docs/research/cache-observability-open-source.md
@@ -7,17 +7,18 @@
 ## 结论先行
 
 1. **context 百分比可以按 provider 原生字段显示，并建议按 0–50 / 50–80 / 80+ 分成正常、警告、危险三色。** Claude/Agy 的 `used_percentage` 由 CLI 计算，Codex 的活动会话 token-usage 事件带 `last.totalTokens/modelContextWindow`，Grok 的 status/headless 数据也有当前 context token。不要在共享渲染器里重新推导四家百分比，否则会混用不同口径。
-2. **缓存命中率可以安全显示“最近一次 API 调用”的比例。** Claude/Agy 直接从 statusLine 的 `current_usage` 读取；Grok 的官方 headless 结果有 `cache_read_input_tokens`；Codex app-server 的官方 token-usage schema 有 `cachedInputTokens` 和 `cacheWriteInputTokens`。推荐公式：
+2. **provider 只给最近一次请求时，session 命中率必须由本地会话记录累计。** Claude/Agy 的 `current_usage` 是 latest-request 口径；Claude 的 statusLine 同时给出 `transcript_path` 和 `session_id`，插件按 transcript 字节 offset 增量解析 assistant usage，把整个主会话的 fresh/read/create 累计后再展示。Grok Build 已有 `session_usage` 累计字段；Codex app-server 也有 `total`。没有可靠 session 边界就隐藏累计百分比，不把某一轮冒充整个 session。推荐公式：
 
    ```text
    hit_percent = cache_read / (fresh_input + cache_creation + cache_read) * 100
    ```
 
    `cache_creation` 是写入，不算命中；把它放进分母比 `read / (fresh + read)` 更诚实。分母为零时隐藏该字段。
+   这条三段式适用于 Claude/Agy statusLine 与 Grok Build headless；OpenAI/Codex 的 `input_tokens` 已包含 cached 子集，应使用 `cached_tokens / input_tokens`（若另有 `cache_write_tokens`，再单独展示写入量）。
 
 3. **“缓存还剩几分钟”只有 Claude 可以做一个近似显示，而且不应作为准确 expiry。** Claude API 返回 5m/1h 写入桶，官方说明缓存使用时会刷新，且 TTL 从请求开始计时；statusLine 本身没有 entry 的 `created_at`/`expires_at`。开源项目通过读取当前会话 transcript 的尾部推断 TTL 桶和最近 timestamp，但这仍是近似值，不能代表多个 cache breakpoint 的统一到期时间。
 4. **Codex/OpenAI、Agy、Grok 当前没有可供本插件诚实显示的动态 cache-entry expiry。** OpenAI 的 `prompt_cache_options.ttl` 是请求策略（不是活动 cache entry 的剩余时间）；Agy/Grok status payload 只有 token 计数；Codex token-usage event 也没有 expiry timestamp。
-5. **实现把 cache read/write/fresh 计数和命中率合并进现有 `$quota_context`，不增加 `$cache_expiry`。** 计数来自正在运行的 CLI/statusLine 输入，不联网、不登录、不消耗模型 token。Claude 在 statusLine 同时提供 transcript 路径和明确 5m/1h bucket 时，默认显示带 `≈` 的有界 TTL 估算；证据不足就隐藏。
+5. **实现把 context、session cache 命中率、最近发送距今与 TTL 估算拆成三行。** `$quota_context` 紧跟 provider 名称；`$quota_cache` 显示整个主 session 的累计命中率（固定一位小数，避免 99.6% 被四舍五入成 100%）；`$quota_cache_ttl` 显示 `cache last 2m ago · ttl≈58m`。计数来自正在运行的 CLI/statusLine 输入和本地 transcript，不联网、不登录、不消耗模型 token。Claude 在 statusLine 同时提供明确 5m/1h bucket 时显示带 `≈` 的 TTL；证据不足只显示已知的 last 时间或隐藏未知部分。
 
 ## 四个 provider 的可获取字段
 
@@ -26,15 +27,30 @@
 | Claude Code | `context_window.used_percentage`；`context_window.context_window_size` | `context_window.current_usage.input_tokens`、`cache_creation_input_tokens`、`cache_read_input_tokens` | API usage 有 `cache_creation.ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens`，但 statusLine 没有 entry expiry；可由 transcript 做近似 countdown | 当前 statusLine 的 stdin JSON |
 | Agy/Antigravity | `context_window.used_percentage`、`context_window.context_window_size` | 同名 `current_usage` 字段 | 官方 statusLine 没有 TTL/expiry 字段 | 当前 statusLine 的 stdin JSON |
 | Codex | app-server `thread/tokenUsage/updated` 的 `last.totalTokens` / `modelContextWindow` 可计算；必须关联活动 `threadId` | app-server schema 的 `cachedInputTokens`、`cacheWriteInputTokens` | event/schema 无 expiry；OpenAI API TTL 是请求级策略 | 活动 app-server 事件；临时独立 app-server 无法读取活动 thread 的实时事件 |
-| Grok Build | 官方 status/headless payload 的 context token/percentage | headless `usage.cache_read_input_tokens`、`cache_creation_input_tokens`；统一 TokenUsage 也保留 cache-read | 当前 xAI status/headless contract 无 cache-entry TTL | 当前会话 event/status 输出；不要为了 HUD 额外启动模型 turn |
+| Grok Build | 官方 status-line 的 `context_window.context_tokens` / `used_percentage` | status-line `context_window.session_usage.{input_tokens,cache_creation_input_tokens,cache_read_input_tokens}` 是 session 累计；headless 也报 `cache_read_input_tokens` / `cache_creation_input_tokens` | 当前 xAI status/headless contract 无 cache-entry TTL | 当前会话 event/status 输出；不要为了 HUD 额外启动模型 turn |
 
 官方字段依据：
 
 - [Claude statusLine 可用字段与 context 口径](https://code.claude.com/docs/en/statusline#available-data) 明确给出 `current_usage` 四类 token，并说明 `used_percentage` 只计算 input + cache creation + cache read；statusLine 命令在本地运行且不消耗 API token。
 - [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) 说明默认 5 分钟、可选 1 小时、命中会刷新 TTL、TTL 从请求开始计时，并给出 `cache_creation` 的 5m/1h 分桶。
-- [Antigravity statusLine schema](https://www.agy.dev/docs/cli/statusline/#available-json-fields) 的示例包含 context window、cache read/create 和 quota reset；没有 cache expiry 字段。
+- [Antigravity statusLine schema](https://antigravity.google/docs/cli/statusline/#available-json-fields) 的示例包含 context window、cache read/create 和 quota reset；没有 cache expiry 字段。
 - [Codex `ThreadTokenUsageUpdatedNotification` schema](https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/json/v2/ThreadTokenUsageUpdatedNotification.json) 包含 `last`、`total`、`modelContextWindow` 及 `cachedInputTokens`、`cacheWriteInputTokens`；没有 TTL。
 - [Grok headless usage contract](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/14-headless-mode.md) 明确区分 uncached `input_tokens`、`cache_read_input_tokens` 和 `cache_creation_input_tokens`；[Grok normalized TokenUsage](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-sampling-types/src/conversation.rs) 也保留 cache-read/write 语义。
+
+说明：上表的 Grok status-line 字段属于当前 Grok Build `main` 合同；本仓库现有 Grok adapter 仍只调用 CLI billing endpoint，因此这些 context/cache 字段在本插件里暂不显示，除非后续显式接入 Grok 的 status-line 配置。
+
+### 口径和 TTL 的补充细节
+
+- **Claude**：`input_tokens` 是最后一次请求中没有从 cache 读取、也没有写入 cache 的部分；`cache_creation_input_tokens` 是写入部分；`cache_read_input_tokens` 是命中部分。因此单轮分母是三者之和。Claude Code 的 statusLine 不提供 session 累计，插件只读 `transcript_path`，按 `session_id + transcript_offset` 累加主会话中的 assistant usage；首个 payload 会扫描一次已有 transcript，后续只读新增完整行。官方 OTel 仍可提供外部 collector 的逐请求指标，但插件不为此联网。
+- **Codex/OpenAI**：Responses API 的 `input_tokens` 是总输入，`input_tokens_details.cached_tokens` 是其中的命中子集；usage 还可能提供 `cache_write_tokens`。所以 Codex 的最新请求命中率可用 `cached / input`；不要把 Claude 的三段式公式套过来。当前 OpenAI 文档把两类策略分开：GPT-5.6 的 `prompt_cache_options.ttl` 只有 `30m`，从写入开始计时，复用会刷新 eligibility，服务可以保留更久；支持旧 retention 的模型则用 `prompt_cache_retention`（`in_memory` 通常空闲 5–10 分钟、最多 1 小时，或扩展的最长 24 小时），这些都是策略/上限而非活动 entry 的实际 expiry 或命中保证。Codex app-server event 没有 `created_at`/`expires_at`；其 `cacheWriteInputTokens` 虽在 schema 中存在，却可能因 Codex 当前 Responses 解析链路丢弃 GPT-5.6 的 `cache_write_tokens` 而保持 0，因此只能把写入量当可选诊断，不把 0 解释成“没有写入”。
+- **Agy/Gemini**：Google Gemini API 的 implicit cache 只在响应 `usage.total_cached_tokens`（或旧 API 的 `usage_metadata.cached_content_token_count`）报告命中数，没有 TTL 或 entry id。显式 `CachedContent` 资源另有 `createTime`、`updateTime`、`expireTime`，但它要求独立 Gemini API/Vertex 凭证；Antigravity OAuth/Code Assist 的 statusLine 不暴露这些资源元数据。不能把显式 cache 的过期时间套到交互会话上。并且官方 CLI 已把 SQLite（`.db`/`.db-wal`）作为会话格式，statusLine 示例里的 `transcript_path` JSONL 不能当作稳定的公开 usage schema；只有能解析到明确 `assistant` usage 行时才做 session 累计，否则退回 latest-request 计数。
+- **Grok/xAI**：官方 API 的 cached token 是总 prompt 的子集，命中率可用 `cached_tokens / prompt_tokens`。xAI 明确写明缓存会因内存压力和请求路由变化而随时淘汰，没有公开 TTL；`x-grok-conv-id`/`prompt_cache_key` 只能改善路由和命中率，不能提供 expiry。Grok Build status-line 另提供 `context_window.session_usage` 的 `input_tokens`、`cache_creation_input_tokens`、`cache_read_input_tokens`，三者累计到 session 输入；因此可计算 session 命中率 `read / (input + creation + read)`，但这不是 provider 的 cache-entry 状态。Grok Build headless 的 `input_tokens` 采用 uncached 口径，另报 `cache_read_input_tokens`/`cache_creation_input_tokens`，需要按其 own output contract 计算。
+
+### Agy headless 的额外边界
+
+Antigravity CLI v1.1.7 起在 `json`/`stream-json` usage 中增加 `cache_read_tokens`，但 headless 模式会真正执行一次 prompt；它不能被本插件的 watcher 当作“无成本查询”。交互 statusLine 已经把 cache read/create 作为输入 payload，优先使用后者。
+
+来源：[Claude OTel usage](https://code.claude.com/docs/en/monitoring-usage)、[OpenAI prompt caching guide](https://developers.openai.com/api/docs/guides/prompt-caching)、[Gemini context caching](https://ai.google.dev/gemini-api/docs/generate-content/caching)、[Gemini caching API](https://ai.google.dev/api/caching)、[xAI cache behavior](https://docs.x.ai/developers/advanced-api-usage/prompt-caching/how-it-works)、[xAI usage and pricing](https://docs.x.ai/developers/advanced-api-usage/prompt-caching/usage-and-pricing)、[Grok Build status-line available data](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#available-data)、[Antigravity headless mode](https://antigravity.google/docs/cli/headless/)、[Antigravity CLI changelog](https://github.com/google-antigravity/antigravity-cli/blob/main/CHANGELOG.md)、[Antigravity issue: transcript schema is not public](https://github.com/google-antigravity/antigravity-cli/issues/423)。
 
 ## 可借鉴的开源实现
 
@@ -46,9 +62,10 @@
 
 推荐借鉴：
 
-- 默认只显示最新调用的 raw read/write/fresh 与 hit%；无需读取 transcript。
-- 需要 session 累计时，使用 `session_id + transcript_path` 做 key，并缓存文件 size/offset；每次只读取新增尾部，不扫完整历史。
+- 默认展示 session 累计的 raw read/write/fresh-derived hit%；首个 session statusLine 调用会读取一次 transcript 建立基线，之后使用 `session_id + transcript_offset` 只读取新增完整行，不重复统计。
 - `current_usage` 在首个响应及 `/compact` 后可能为 `null`；保持上次有效值，不能写成 0。
+
+这里的“session 累计”只覆盖 statusLine `transcript_path` 指向的主会话。Claude Code 的 Task/subagent 可能另有 JSONL 文件；除非明确遍历并关联这些文件，否则不要把主 transcript 的合计声称为全任务树总量。
 
 ### 2. Claude TTL：可做近似，但不要伪装成 expiry
 
@@ -61,6 +78,8 @@
 - 配合 `refreshInterval: 60`，避免 idle 时倒计时冻结。
 
 其文档同时承认 stdin 没有 TTL bucket 和 per-message timestamp，因此这是估算，不是服务端 expiry。Anthropic 官方还说明 TTL 从请求开始计时，并且每次命中都会刷新；长响应、多个 breakpoint、compact、模型/工具切换都会让“最后一条 assistant timestamp + TTL”偏离真实条目状态。本项目只在证据齐全时默认显示这个带 `≈` 的提示，其他情况隐藏。
+
+另一种实现是 [`leeguooooo/claude-code-usage-bar`](https://github.com/leeguooooo/claude-code-usage-bar)：按最多 320 KiB 的尾部窗口反向读取 JSONL，分别记录最新 assistant timestamp 与最近一个 cache-write bucket，再计算倒计时；该项目在 bucket 缺失时采用 5 分钟保守回退。回退有助于始终显示状态，但会把未知的服务端策略伪装成 5m，因此本插件继续选择“无 bucket 就不显示 TTL”，只借鉴其 bounded tail + newest assistant anchor。
 
 ### 3. Codex 本地 usage：可统计命中率，但当前不适合实时 watcher
 
@@ -91,14 +110,14 @@
    不把四家不同口径的 context 百分比重新套成统一危险阈值。
 2. `CacheUsage` 使用可选字段：`fresh_input_tokens`、`read_tokens`、`creation_tokens`、`hit_percent`。
 3. Claude/Agy 从当前 statusLine payload 解析；Grok/Codex 只有在当前安全链路拿到官方字段时才显示，缺失就隐藏。
-4. Herdr metadata report 有 16-token 上限；不要另加 `$quota_cache`，应把 `cache 87%`（或 R/W）并入现有 context token，避免触发报告失败。
+4. Herdr metadata report 有 16-token 上限；当前固定保留 16 个动态 token，淘汰旧的 `$quota_icon`/`$quota_status` 发布位，并将 `$quota_cache` 与 `$quota_cache_ttl` 纳入固定预算。报告名始终不超过 16，旧 token 只做有界清理。
 5. 不把 quota reset 当作 cache expiry。
 
 ### 有界 TTL 诊断层
 
-本项目采用 ilia 项目的边界：只读取 `transcript_path` 尾部 16 KiB，并显示
-`ttl≈54m` 这类带剩余时间的本地估算（5m/1h bucket），不显示“expires in”。任何解析失败、compact、字段缺失
-都不生成新估算，并保留上次合法值；不会把估算放进独立 metadata token 或全局 watcher。
+本项目采用 ilia 项目的 bucket/timestamp 口径：session 首次建立累计时读取 transcript，之后每次只读新增字节；TTL 行显示
+`cache last 2m ago · ttl≈54m` 这类带剩余时间的本地估算（5m/1h bucket），不显示“expires in”。任何解析失败、compact、字段缺失
+都不生成新估算；跨 session 不继承旧 TTL，避免误报。该扫描发生在已有 statusLine hook 内，不是全局 watcher，也不读取 pane。
 
 ### 明确不做
 
@@ -106,7 +125,8 @@
 - 不 resume 活动 Codex thread；
 - 不把 quota `resets_at/reset_time` 伪装为 cache expiry；
 - 不对每个 pane 启动独立 watcher 或重复读取 pane；
-- 不默认扫描完整 transcript/rollout JSONL。
+- 不扫描 Codex rollout 或其他未关联的 session JSONL；Claude/Agy 只在 statusLine
+  提供主 transcript 时首次建立一次累计基线，后续按 offset 增量读取。
 
 ## 风险与验证重点
 
@@ -114,18 +134,22 @@
 - **口径漂移**：Claude 官方 `used_percentage` 是 input-only；Codex TUI 还有 baseline；Grok/Agy 可能由自身 CLI 计算。保存原始 provider 字段和 `source`，不要在 renderer 中二次“统一计算”。
 - **缓存不是单一条目**：一个请求可有多个 breakpoint 和不同 TTL；任何倒计时都只能是近似提示。
 - **compact/首轮空值**：`current_usage=null` 或字段缺失时保留旧值，避免侧栏闪烁和 metadata repaint。
-- **性能**：cache 计数解析是 O(1) JSON；Claude TTL 每次 statusLine 最多读取 transcript 最后 16 KiB，不能从头扫文件，也不启动 daemon；全局 watcher 和 pane 访问路径不变。
+- **性能**：每次 statusLine 只解析当前 JSON；Claude/Agy session 首次需要读取一次主 transcript（这是得到“整个 session”总量的必要成本），之后按字节 offset 只读取新增行，且同一 state 目录用文件锁避免多 pane 重复写入。不会启动 daemon、登录、发模型请求、读取 pane；全局 watcher 和 60 秒默认轮询路径不变。
 
 ## 参考来源
 
 - [Claude statusLine data and local execution](https://code.claude.com/docs/en/statusline#available-data)
 - [Anthropic prompt caching: TTL, refresh, usage fields](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)
-- [Antigravity statusLine schema](https://www.agy.dev/docs/cli/statusline/#available-json-fields)
+- [Antigravity statusLine schema](https://antigravity.google/docs/cli/statusline/#available-json-fields)
 - [Codex app-server token usage schema](https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/json/v2/ThreadTokenUsageUpdatedNotification.json)
+- [Codex token usage fields](https://github.com/openai/codex/blob/main/codex-rs/exec/src/exec_events.rs)
+- [Codex issue: `cache_write_tokens` dropped from usage events](https://github.com/openai/codex/issues/32479)
 - [Grok headless usage fields](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/14-headless-mode.md)
+- [Grok status-line available data](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#available-data)
 - [Grok normalized token usage](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-sampling-types/src/conversation.rs)
 - [waelmas/claude-stat](https://github.com/waelmas/claude-stat)
 - [ilia-pluzhnikov/claude-code-statusline](https://github.com/ilia-pluzhnikov/claude-code-statusline)
+- [leeguooooo/claude-code-usage-bar](https://github.com/leeguooooo/claude-code-usage-bar)
 - [vfmatzkin/claude-statusline](https://github.com/vfmatzkin/claude-statusline)
 - [razzededge/codex-usage-audit](https://github.com/razzededge/codex-usage-audit)
 - [harveyxiacn/codex-usage-monitor](https://github.com/harveyxiacn/codex-usage-monitor)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -80,7 +80,27 @@ impl CacheStore {
     /// StatusLine payloads may temporarily omit context (before the first
     /// response and immediately after compaction). Keep the last known value
     /// while still replacing the quota windows with the newest snapshot.
-    pub fn save_preserving_context(&self, mut snapshot: ProviderSnapshot) -> Result<()> {
+    pub fn save_preserving_context(&self, snapshot: ProviderSnapshot) -> Result<()> {
+        self.save_preserving_context_for_session(snapshot, None)
+    }
+
+    /// Save a statusLine snapshot while matching preserved diagnostics to the
+    /// session id from the same stdin payload. This keeps a compacted Claude
+    /// session's aggregate offset without carrying it into a new session.
+    pub fn save_preserving_context_for_session(
+        &self,
+        mut snapshot: ProviderSnapshot,
+        session_id: Option<&str>,
+    ) -> Result<()> {
+        if let Some(session_id) = session_id {
+            if let Some(cache) = snapshot
+                .context
+                .as_mut()
+                .and_then(|context| context.cache.as_mut())
+            {
+                cache.session_id = Some(session_id.to_string());
+            }
+        }
         // A malformed/temporarily unreadable old snapshot must not prevent a
         // fresh statusLine value from replacing it.
         if let Some(previous) = self
@@ -90,18 +110,68 @@ impl CacheStore {
             .and_then(|snapshot| snapshot.context)
         {
             match (&mut snapshot.context, previous) {
-                (None, previous) => snapshot.context = Some(previous),
+                (None, mut previous) => {
+                    let same_session = session_id.is_some_and(|session_id| {
+                        previous
+                            .cache
+                            .as_ref()
+                            .and_then(|cache| cache.session_id.as_deref())
+                            == Some(session_id)
+                    });
+                    if !same_session {
+                        if let Some(cache) = previous.cache.as_mut() {
+                            let clear_ttl = cache.session_id.is_some() || session_id.is_some();
+                            strip_session_cache_state(cache, clear_ttl);
+                        }
+                    }
+                    snapshot.context = Some(previous);
+                }
                 (Some(current), previous) => {
                     if current.cache.is_none() {
-                        current.cache = previous.cache;
+                        let same_session = session_id.is_some_and(|session_id| {
+                            previous
+                                .cache
+                                .as_ref()
+                                .and_then(|cache| cache.session_id.as_deref())
+                                == Some(session_id)
+                        });
+                        let mut previous_cache = previous.cache;
+                        if !same_session {
+                            if let Some(cache) = previous_cache.as_mut() {
+                                strip_session_cache_state(
+                                    cache,
+                                    cache.session_id.is_some() || session_id.is_some(),
+                                );
+                            }
+                        }
+                        current.cache = previous_cache;
                     } else if let (Some(cache), Some(previous_cache)) =
                         (&mut current.cache, previous.cache)
                     {
-                        if cache.ttl_seconds.is_none() {
-                            cache.ttl_seconds = previous_cache.ttl_seconds;
+                        let same_session = cache.session_id.is_some()
+                            && cache.session_id == previous_cache.session_id
+                            && session_id.is_none_or(|session_id| {
+                                cache.session_id.as_deref() == Some(session_id)
+                            });
+                        if same_session {
+                            if cache.session_totals.is_none() {
+                                cache.session_totals = previous_cache.session_totals;
+                            }
+                            if cache.transcript_offset == 0 {
+                                cache.transcript_offset = previous_cache.transcript_offset;
+                            }
                         }
-                        if cache.last_activity_unix.is_none() {
-                            cache.last_activity_unix = previous_cache.last_activity_unix;
+                        let can_preserve_ttl = same_session
+                            || (session_id.is_none()
+                                && cache.session_id.is_none()
+                                && previous_cache.session_id.is_none());
+                        if can_preserve_ttl {
+                            if cache.ttl_seconds.is_none() {
+                                cache.ttl_seconds = previous_cache.ttl_seconds;
+                            }
+                            if cache.last_activity_unix.is_none() {
+                                cache.last_activity_unix = previous_cache.last_activity_unix;
+                            }
                         }
                     }
                 }
@@ -282,6 +352,16 @@ impl CacheStore {
     }
 }
 
+fn strip_session_cache_state(cache: &mut crate::model::CacheUsage, clear_ttl: bool) {
+    cache.session_totals = None;
+    cache.session_id = None;
+    cache.transcript_offset = 0;
+    if clear_ttl {
+        cache.ttl_seconds = None;
+        cache.last_activity_unix = None;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -327,6 +407,66 @@ mod tests {
             .unwrap();
         assert_eq!(saved_context.used_percent, 24.0);
         assert_eq!(saved_context.cache, context.cache);
+    }
+
+    #[test]
+    fn statusline_refresh_preserves_session_totals_only_for_the_same_session() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let previous_cache = CacheUsage::from_token_counts(10, 90, 0)
+            .unwrap()
+            .with_ttl_estimate(300, 1_000)
+            .with_session_totals(
+                crate::model::CacheTotals::from_token_counts(10, 90, 0),
+                "session-1",
+                512,
+            );
+        cache
+            .save(
+                &snapshot().with_context(Some(
+                    ContextUsage::new(23.5)
+                        .unwrap()
+                        .with_cache(Some(previous_cache.clone())),
+                )),
+            )
+            .unwrap();
+
+        let same_session = snapshot().with_context(Some(
+            ContextUsage::new(24.0).unwrap().with_cache(Some(
+                CacheUsage::from_token_counts(1, 2, 3)
+                    .unwrap()
+                    .with_session_totals(None, "session-1", 0),
+            )),
+        ));
+        cache
+            .save_preserving_context_for_session(same_session, Some("session-1"))
+            .unwrap();
+        let saved = cache.load(Provider::Grok).unwrap().unwrap();
+        let saved_cache = saved.context.unwrap().cache.unwrap();
+        assert_eq!(saved_cache.session_totals, previous_cache.session_totals);
+        assert_eq!(saved_cache.transcript_offset, 512);
+        assert_eq!(saved_cache.ttl_seconds, Some(300));
+
+        let new_session = snapshot().with_context(Some(
+            ContextUsage::new(25.0).unwrap().with_cache(Some(
+                CacheUsage::from_token_counts(1, 2, 3)
+                    .unwrap()
+                    .with_session_totals(None, "session-2", 0),
+            )),
+        ));
+        cache
+            .save_preserving_context_for_session(new_session, Some("session-2"))
+            .unwrap();
+        let saved_cache = cache
+            .load(Provider::Grok)
+            .unwrap()
+            .unwrap()
+            .context
+            .unwrap()
+            .cache
+            .unwrap();
+        assert!(saved_cache.session_totals.is_none());
+        assert!(saved_cache.ttl_seconds.is_none());
     }
 
     #[test]

--- a/src/configure/agy.rs
+++ b/src/configure/agy.rs
@@ -1,7 +1,10 @@
 use super::statusline::{settings_path, Adapter};
 use crate::cache::CacheStore;
-use crate::providers::agy::run_statusline;
+use crate::model::Provider;
+use crate::providers::agy::parse_statusline;
+use crate::providers::statusline::enrich_cache_session;
 use anyhow::{Context, Result};
+use serde_json::Value;
 use std::io::{Read, Write};
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -50,9 +53,24 @@ pub fn uninstall_at(settings: &Path, state: &Path) -> Result<()> {
 pub fn run_statusline_hook() -> Result<()> {
     let mut input = Vec::new();
     std::io::stdin().read_to_end(&mut input)?;
-    if let Ok(snapshot) = run_statusline(&input) {
-        if let Ok(cache) = CacheStore::from_env() {
-            let _ = cache.save_preserving_context(snapshot);
+    if let Ok(value) = serde_json::from_slice::<Value>(&input) {
+        if let Ok(mut snapshot) = parse_statusline(&value, CacheStore::now_unix()) {
+            if let Ok(cache) = CacheStore::from_env() {
+                let _ = cache.with_lock(|| {
+                    let previous_cache = cache
+                        .load(Provider::Agy)
+                        .ok()
+                        .flatten()
+                        .and_then(|snapshot| snapshot.context)
+                        .and_then(|context| context.cache);
+                    enrich_cache_session(&mut snapshot, &value, previous_cache.as_ref());
+                    let session_id = value
+                        .get("session_id")
+                        .or_else(|| value.get("sessionId"))
+                        .and_then(Value::as_str);
+                    cache.save_preserving_context_for_session(snapshot, session_id)
+                });
+            }
         }
     }
     let cache = CacheStore::from_env()?;

--- a/src/configure/claude.rs
+++ b/src/configure/claude.rs
@@ -1,7 +1,10 @@
 use super::statusline::{settings_path, Adapter};
 use crate::cache::CacheStore;
-use crate::providers::claude::run_statusline;
+use crate::model::Provider;
+use crate::providers::claude::parse_statusline;
+use crate::providers::statusline::enrich_cache_session;
 use anyhow::{Context, Result};
+use serde_json::Value;
 use std::io::{Read, Write};
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -48,9 +51,24 @@ pub fn uninstall_at(settings: &Path, state: &Path) -> Result<()> {
 pub fn run_statusline_hook() -> Result<()> {
     let mut input = Vec::new();
     std::io::stdin().read_to_end(&mut input)?;
-    if let Ok(snapshot) = run_statusline(&input) {
-        if let Ok(cache) = CacheStore::from_env() {
-            let _ = cache.save_preserving_context(snapshot);
+    if let Ok(value) = serde_json::from_slice::<Value>(&input) {
+        if let Ok(mut snapshot) = parse_statusline(&value, CacheStore::now_unix()) {
+            if let Ok(cache) = CacheStore::from_env() {
+                let _ = cache.with_lock(|| {
+                    let previous_cache = cache
+                        .load(Provider::Claude)
+                        .ok()
+                        .flatten()
+                        .and_then(|snapshot| snapshot.context)
+                        .and_then(|context| context.cache);
+                    enrich_cache_session(&mut snapshot, &value, previous_cache.as_ref());
+                    let session_id = value
+                        .get("session_id")
+                        .or_else(|| value.get("sessionId"))
+                        .and_then(Value::as_str);
+                    cache.save_preserving_context_for_session(snapshot, session_id)
+                });
+            }
         }
     }
     let cache = CacheStore::from_env()?;

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Item, Table, Value};
 
-const QUOTA_ROW_MARKERS: [&str; 20] = [
+const QUOTA_ROW_MARKERS: [&str; 22] = [
     "$quota_badge",
     "$quota_state",
     "$quota_icon",
@@ -12,6 +12,8 @@ const QUOTA_ROW_MARKERS: [&str; 20] = [
     "$quota_summary",
     "$quota_session",
     "$quota_context",
+    "$quota_cache",
+    "$quota_cache_ttl",
     "$quota_topic",
     "$quota_5h",
     "$quota_week",
@@ -34,6 +36,8 @@ const QUOTA_SAFE_COLOR: &str = "#84b084";
 const QUOTA_WARNING_COLOR: &str = "#cdaa65";
 const QUOTA_DANGER_COLOR: &str = "#ca6470";
 const CONTEXT_COLOR: &str = "#9b8fd8";
+const CACHE_COLOR: &str = "#6fb5b7";
+const CACHE_TTL_COLOR: &str = "#cdaa65";
 const PROVIDER_STYLES: [(&str, Option<&str>); 4] = [
     ("claude", Some("#c47f6a")),
     ("codex", Some("#7998b7")),
@@ -478,20 +482,34 @@ fn append_quota_rows(rows: &mut Array) {
     *rows = compacted_rows;
 
     let official_index = rows.iter().position(|row| {
-        row.as_array().is_some_and(|items| {
-            items.iter().any(|item| item.as_str() == Some("state_icon"))
-                && !items.iter().any(|item| item.as_str() == Some("agent"))
-        })
+        row.as_array()
+            .is_some_and(|items| items.iter().any(|item| item.as_str() == Some("state_icon")))
     });
 
     if let Some(index) = official_index {
         if let Some(row) = rows.get_mut(index).and_then(Value::as_array_mut) {
-            row.push(styled_token(
-                "$quota_provider",
-                None,
-                Some(true),
-                Some(false),
-            ));
+            if !row
+                .iter()
+                .any(|item| matches!(item.as_str(), Some("agent") | Some("$quota_provider")))
+            {
+                row.push(styled_token(
+                    "$quota_provider",
+                    None,
+                    Some(true),
+                    Some(false),
+                ));
+            }
+            if !row
+                .iter()
+                .any(|item| configured_token_name(item) == Some("$quota_context"))
+            {
+                row.push(styled_token(
+                    "$quota_context",
+                    Some(CONTEXT_COLOR),
+                    Some(true),
+                    Some(false),
+                ));
+            }
         }
     }
 
@@ -503,8 +521,15 @@ fn append_quota_rows(rows: &mut Array) {
     )));
 
     rows.push(Value::Array(styled_row(
-        "$quota_context",
-        Some(CONTEXT_COLOR),
+        "$quota_cache",
+        Some(CACHE_COLOR),
+        Some(true),
+        Some(false),
+    )));
+
+    rows.push(Value::Array(styled_row(
+        "$quota_cache_ttl",
+        Some(CACHE_TTL_COLOR),
         Some(true),
         Some(false),
     )));

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -6,13 +6,14 @@ use std::collections::BTreeMap;
 use std::process::Command;
 
 const METADATA_TTL_MS: &str = "86400000";
+const MAX_METADATA_TOKENS: usize = 16;
 const METADATA_TOKEN_NAMES: [&str; 16] = [
     "quota_state",
-    "quota_icon",
     "quota_provider",
-    "quota_status",
     "quota_summary",
     "quota_context",
+    "quota_cache",
+    "quota_cache_ttl",
     "quota_5h",
     "quota_5h_normal",
     "quota_5h_warning",
@@ -24,6 +25,7 @@ const METADATA_TOKEN_NAMES: [&str; 16] = [
     "quota_topic",
     "quota_error",
 ];
+const OBSOLETE_METADATA_TOKEN_NAMES: [&str; 2] = ["quota_icon", "quota_status"];
 const LEGACY_METADATA_TOKEN_NAMES: [&str; 2] = ["quota_badge", "quota_session"];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -314,12 +316,12 @@ fn pane_is_scrolled(executable: &std::ffi::OsStr, pane_id: &str) -> bool {
 fn desired_tokens(values: &MetadataTokens, topic: &str) -> BTreeMap<String, String> {
     let mut tokens = BTreeMap::from([
         ("quota_state".to_string(), values.quota_state.clone()),
-        ("quota_icon".to_string(), values.quota_icon.clone()),
         ("quota_provider".to_string(), values.quota_provider.clone()),
-        ("quota_status".to_string(), values.quota_status.clone()),
         ("quota_summary".to_string(), values.quota_summary.clone()),
     ]);
     insert_optional_token(&mut tokens, "quota_context", &values.quota_context);
+    insert_optional_token(&mut tokens, "quota_cache", &values.quota_cache);
+    insert_optional_token(&mut tokens, "quota_cache_ttl", &values.quota_cache_ttl);
     insert_optional_token(&mut tokens, "quota_5h", &values.quota_5h);
     insert_severity_token(
         &mut tokens,
@@ -356,6 +358,9 @@ fn metadata_matches(
     METADATA_TOKEN_NAMES
         .into_iter()
         .all(|name| current.get(name) == desired.get(name))
+        && OBSOLETE_METADATA_TOKEN_NAMES
+            .into_iter()
+            .all(|name| !current.contains_key(name))
         && LEGACY_METADATA_TOKEN_NAMES
             .into_iter()
             .all(|name| !current.contains_key(name))
@@ -369,29 +374,51 @@ fn metadata_report_names(
         .into_iter()
         .filter(|name| desired.contains_key(*name) || pane.tokens.contains_key(*name))
         .collect::<Vec<_>>();
-    names.extend(
-        LEGACY_METADATA_TOKEN_NAMES
-            .into_iter()
-            .filter(|name| pane.tokens.contains_key(*name)),
-    );
-    if names.len() <= METADATA_TOKEN_NAMES.len() {
+    let cleanup_names = OBSOLETE_METADATA_TOKEN_NAMES
+        .into_iter()
+        .filter(|name| pane.tokens.contains_key(*name))
+        .chain(
+            LEGACY_METADATA_TOKEN_NAMES
+                .into_iter()
+                .filter(|name| pane.tokens.contains_key(*name)),
+        )
+        .collect::<Vec<_>>();
+    if names.len() + cleanup_names.len() <= MAX_METADATA_TOKENS {
+        names.extend(cleanup_names);
         return names;
     }
 
-    // A pane upgraded from the pre-context token set can briefly contain all
-    // old and new names. Keep the new context token and clear legacy names in
-    // the same bounded report; a stable summary/status token can be refreshed
-    // on the following poll if necessary.
-    for candidate in ["quota_summary", "quota_status", "quota_icon"] {
-        let Some(index) = names.iter().position(|name| *name == candidate) else {
-            continue;
-        };
-        if pane.tokens.get(candidate) == desired.get(candidate) {
+    // Herdr accepts at most sixteen token arguments. Reserve room for stale
+    // names first so an upgraded pane can actually clear them; unchanged
+    // cosmetic fields can be restored on the next bounded report.
+    let active_capacity = MAX_METADATA_TOKENS.saturating_sub(cleanup_names.len());
+    for candidate in ["quota_summary", "quota_state", "quota_5h", "quota_week"] {
+        while names.len() > active_capacity {
+            let Some(index) = names.iter().position(|name| {
+                *name == candidate && pane.tokens.get(candidate) == desired.get(candidate)
+            }) else {
+                break;
+            };
             names.remove(index);
-            break;
         }
     }
-    names.truncate(METADATA_TOKEN_NAMES.len());
+    while names.len() > active_capacity {
+        let Some(index) = names.iter().position(|name| {
+            !matches!(
+                *name,
+                "quota_context"
+                    | "quota_cache"
+                    | "quota_cache_ttl"
+                    | "quota_provider"
+                    | "quota_topic"
+            )
+        }) else {
+            break;
+        };
+        names.remove(index);
+    }
+    names.truncate(active_capacity);
+    names.extend(cleanup_names);
     names
 }
 
@@ -582,7 +609,98 @@ mod tests {
         assert!(!metadata_matches(&pane.tokens, &desired));
         let names = metadata_report_names(&pane, &desired);
         assert!(names.contains(&"quota_badge"));
-        assert!(names.len() <= METADATA_TOKEN_NAMES.len());
+        assert!(names.len() <= MAX_METADATA_TOKENS);
+    }
+
+    #[test]
+    fn cache_diagnostics_stay_inside_herdr_metadata_cap() {
+        let snapshot = crate::model::ProviderSnapshot::new(
+            Provider::Claude,
+            vec![
+                crate::model::UsageWindow::new(crate::model::WindowKind::FiveHour, 20.0, None)
+                    .unwrap(),
+                crate::model::UsageWindow::new(crate::model::WindowKind::Weekly, 30.0, None)
+                    .unwrap(),
+            ],
+            0,
+        )
+        .with_context(Some(
+            crate::model::ContextUsage::new(42.0)
+                .unwrap()
+                .with_cache(Some(
+                    crate::model::CacheUsage::from_token_counts(100, 800, 100)
+                        .unwrap()
+                        .with_ttl_estimate(3_600, 0)
+                        .with_session_totals(
+                            crate::model::CacheTotals::from_token_counts(100, 800, 100),
+                            "session-1",
+                            1,
+                        ),
+                )),
+        ));
+        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        let pane = AgentPane {
+            pane_id: "w1:p1".to_string(),
+            provider: Provider::Claude,
+            session_id: None,
+            session_summary: String::new(),
+            topic: String::new(),
+            tokens: BTreeMap::new(),
+        };
+        let names = metadata_report_names(&pane, &desired);
+        assert!(names.len() <= MAX_METADATA_TOKENS);
+        assert!(names.contains(&"quota_cache"));
+        assert!(names.contains(&"quota_cache_ttl"));
+    }
+
+    #[test]
+    fn stale_metadata_tokens_are_reported_for_cleanup_with_new_cache_rows() {
+        let snapshot = crate::model::ProviderSnapshot::new(
+            Provider::Claude,
+            vec![
+                crate::model::UsageWindow::new(crate::model::WindowKind::FiveHour, 20.0, None)
+                    .unwrap(),
+                crate::model::UsageWindow::new(crate::model::WindowKind::Weekly, 30.0, None)
+                    .unwrap(),
+            ],
+            0,
+        )
+        .with_context(Some(
+            crate::model::ContextUsage::new(42.0)
+                .unwrap()
+                .with_cache(Some(
+                    crate::model::CacheUsage::from_token_counts(100, 800, 100)
+                        .unwrap()
+                        .with_ttl_estimate(3_600, 0)
+                        .with_session_totals(
+                            crate::model::CacheTotals::from_token_counts(100, 800, 100),
+                            "session-1",
+                            1,
+                        ),
+                )),
+        ));
+        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        let mut tokens = desired.clone();
+        tokens.insert("quota_icon".to_string(), "✦Cl".to_string());
+        tokens.insert("quota_status".to_string(), "OK".to_string());
+        tokens.insert("quota_badge".to_string(), "[C]".to_string());
+        tokens.insert("quota_session".to_string(), "old".to_string());
+        let pane = AgentPane {
+            pane_id: "w1:p1".to_string(),
+            provider: Provider::Claude,
+            session_id: None,
+            session_summary: String::new(),
+            topic: String::new(),
+            tokens,
+        };
+        let names = metadata_report_names(&pane, &desired);
+        assert!(names.len() <= MAX_METADATA_TOKENS);
+        assert!(names.contains(&"quota_cache"));
+        assert!(names.contains(&"quota_cache_ttl"));
+        assert!(names.contains(&"quota_icon"));
+        assert!(names.contains(&"quota_status"));
+        assert!(names.contains(&"quota_badge"));
+        assert!(names.contains(&"quota_session"));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -211,6 +211,67 @@ pub struct CacheUsage {
     pub ttl_seconds: Option<u64>,
     #[serde(default)]
     pub last_activity_unix: Option<u64>,
+    /// Cumulative cache counters for the current provider session.
+    ///
+    /// `current_usage` is a latest-request view for Claude/Agy, so the
+    /// sidebar uses this optional aggregate when a local transcript gives us
+    /// a trustworthy session boundary and offset.
+    #[serde(default)]
+    pub session_totals: Option<CacheTotals>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub transcript_offset: u64,
+}
+
+/// Cache counters accumulated across all completed requests in one session.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CacheTotals {
+    pub fresh_input_tokens: u64,
+    pub read_tokens: u64,
+    pub creation_tokens: u64,
+    pub hit_percent: f64,
+}
+
+impl CacheTotals {
+    pub fn from_token_counts(
+        fresh_input_tokens: u64,
+        read_tokens: u64,
+        creation_tokens: u64,
+    ) -> Option<Self> {
+        let total = fresh_input_tokens
+            .saturating_add(read_tokens)
+            .saturating_add(creation_tokens);
+        if total == 0 {
+            return None;
+        }
+        Some(Self {
+            fresh_input_tokens,
+            read_tokens,
+            creation_tokens,
+            hit_percent: read_tokens as f64 / total as f64 * 100.0,
+        })
+    }
+
+    pub fn add_token_counts(
+        &mut self,
+        fresh_input_tokens: u64,
+        read_tokens: u64,
+        creation_tokens: u64,
+    ) {
+        self.fresh_input_tokens = self.fresh_input_tokens.saturating_add(fresh_input_tokens);
+        self.read_tokens = self.read_tokens.saturating_add(read_tokens);
+        self.creation_tokens = self.creation_tokens.saturating_add(creation_tokens);
+        let total = self
+            .fresh_input_tokens
+            .saturating_add(self.read_tokens)
+            .saturating_add(self.creation_tokens);
+        self.hit_percent = if total == 0 {
+            0.0
+        } else {
+            self.read_tokens as f64 / total as f64 * 100.0
+        };
+    }
 }
 
 impl CacheUsage {
@@ -232,6 +293,9 @@ impl CacheUsage {
             hit_percent: read_tokens as f64 / total as f64 * 100.0,
             ttl_seconds: None,
             last_activity_unix: None,
+            session_totals: None,
+            session_id: None,
+            transcript_offset: 0,
         })
     }
 
@@ -245,6 +309,18 @@ impl CacheUsage {
         let ttl = self.ttl_seconds?;
         let last_activity = self.last_activity_unix?;
         Some(last_activity.saturating_add(ttl).saturating_sub(now_unix))
+    }
+
+    pub fn with_session_totals(
+        mut self,
+        totals: Option<CacheTotals>,
+        session_id: impl Into<String>,
+        transcript_offset: u64,
+    ) -> Self {
+        self.session_totals = totals;
+        self.session_id = Some(session_id.into());
+        self.transcript_offset = transcript_offset;
+        self
     }
 }
 
@@ -381,6 +457,16 @@ mod tests {
                 .hit_percent,
             0.0
         );
+    }
+
+    #[test]
+    fn session_cache_totals_accumulate_and_recompute_hit_ratio() {
+        let mut totals = CacheTotals::from_token_counts(100, 800, 100).unwrap();
+        totals.add_token_counts(100, 0, 0);
+        assert_eq!(totals.fresh_input_tokens, 200);
+        assert_eq!(totals.read_tokens, 800);
+        assert_eq!(totals.creation_tokens, 100);
+        assert_eq!(totals.hit_percent, 72.72727272727273);
     }
 
     #[test]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -14,6 +14,8 @@ pub struct MetadataTokens {
     pub quota_week_severity: Option<Severity>,
     pub quota_summary: String,
     pub quota_context: String,
+    pub quota_cache: String,
+    pub quota_cache_ttl: String,
     pub quota_error: Option<String>,
 }
 
@@ -29,7 +31,9 @@ impl MetadataTokens {
             quota_week: sidebar_window(snapshot, WindowKind::Weekly, now_unix),
             quota_week_severity: window_severity(snapshot, WindowKind::Weekly, now_unix),
             quota_summary: sidebar_summary(snapshot, now_unix),
-            quota_context: sidebar_context(snapshot, now_unix),
+            quota_context: sidebar_context(snapshot),
+            quota_cache: sidebar_cache(snapshot),
+            quota_cache_ttl: sidebar_cache_ttl(snapshot, now_unix),
             quota_error: None,
         }
     }
@@ -52,6 +56,8 @@ impl MetadataTokens {
             quota_week_severity: Some(Severity::Unknown),
             quota_summary: "unavailable".to_string(),
             quota_context: String::new(),
+            quota_cache: String::new(),
+            quota_cache_ttl: String::new(),
             quota_error: Some(reason.into().chars().take(80).collect()),
         }
     }
@@ -91,18 +97,43 @@ fn sidebar_window(snapshot: &ProviderSnapshot, kind: WindowKind, now_unix: u64) 
         .unwrap_or_default()
 }
 
-fn sidebar_context(snapshot: &ProviderSnapshot, now_unix: u64) -> String {
+fn sidebar_context(snapshot: &ProviderSnapshot) -> String {
     let Some(context) = snapshot.context.as_ref() else {
         return String::new();
     };
-    let mut parts = vec![format!("context {}%", format_percent(context.used_percent))];
-    if let Some(cache) = context.cache.as_ref() {
-        parts.push(format!("cache {}%", format_percent(cache.hit_percent)));
-        if let Some(seconds) = cache.remaining_ttl_seconds(now_unix) {
-            parts.push(format!("ttl≈{}", format_ttl(seconds)));
-        }
+    format!("context {}%", format_percent(context.used_percent))
+}
+
+fn sidebar_cache(snapshot: &ProviderSnapshot) -> String {
+    let Some(totals) = snapshot
+        .context
+        .as_ref()
+        .and_then(|context| context.cache.as_ref())
+        .and_then(|cache| cache.session_totals.as_ref())
+    else {
+        return String::new();
+    };
+    format!("cache {:.1}% hit", totals.hit_percent)
+}
+
+fn sidebar_cache_ttl(snapshot: &ProviderSnapshot, now_unix: u64) -> String {
+    let Some(cache) = snapshot
+        .context
+        .as_ref()
+        .and_then(|context| context.cache.as_ref())
+    else {
+        return String::new();
+    };
+    let Some(last_activity) = cache.last_activity_unix else {
+        return String::new();
+    };
+    let elapsed = now_unix.saturating_sub(last_activity);
+    let mut value = format!("cache last {} ago", format_elapsed(elapsed));
+    if let Some(remaining) = cache.remaining_ttl_seconds(now_unix) {
+        value.push_str(" · ttl≈");
+        value.push_str(&format_ttl(remaining));
     }
-    parts.join(" · ")
+    value
 }
 
 fn format_window(window: &UsageWindow, now_unix: u64, include_left: bool) -> String {
@@ -142,6 +173,13 @@ fn format_ttl(seconds: u64) -> String {
     let minutes = seconds / 60;
     if (60..24 * 60).contains(&minutes) && minutes.is_multiple_of(60) {
         return format!("{}h", minutes / 60);
+    }
+    format_duration(seconds)
+}
+
+fn format_elapsed(seconds: u64) -> String {
+    if seconds < 60 {
+        return "<1m".to_string();
     }
     format_duration(seconds)
 }
@@ -236,10 +274,15 @@ mod tests {
     }
 
     #[test]
-    fn metadata_formats_cache_hit_rate_and_approximate_ttl() {
+    fn metadata_formats_session_cache_hit_rate_and_approximate_ttl() {
         let cache = crate::model::CacheUsage::from_token_counts(100, 800, 100)
             .unwrap()
-            .with_ttl_estimate(60 * 60, 0);
+            .with_ttl_estimate(60 * 60, 0)
+            .with_session_totals(
+                crate::model::CacheTotals::from_token_counts(100, 800, 100),
+                "session-1",
+                1,
+            );
         let context = crate::model::ContextUsage::new(23.5)
             .unwrap()
             .with_cache(Some(cache));
@@ -250,6 +293,26 @@ mod tests {
         )
         .with_context(Some(context));
         let values = MetadataTokens::from_snapshot(&snapshot, 0);
-        assert_eq!(values.quota_context, "context 24% · cache 80% · ttl≈1h");
+        assert_eq!(values.quota_context, "context 24%");
+        assert_eq!(values.quota_cache, "cache 80.0% hit");
+        assert_eq!(values.quota_cache_ttl, "cache last <1m ago · ttl≈1h");
+    }
+
+    #[test]
+    fn session_cache_percentage_keeps_one_decimal_instead_of_rounding_to_100() {
+        let cache = crate::model::CacheUsage::from_token_counts(2_000, 433_336, 1_655)
+            .unwrap()
+            .with_session_totals(
+                crate::model::CacheTotals::from_token_counts(2_000, 433_336, 1_655),
+                "session-1",
+                1,
+            );
+        let snapshot = ProviderSnapshot::new(Provider::Claude, vec![], 0).with_context(Some(
+            crate::model::ContextUsage::new(43.0)
+                .unwrap()
+                .with_cache(Some(cache)),
+        ));
+        let values = MetadataTokens::from_snapshot(&snapshot, 0);
+        assert_eq!(values.quota_cache, "cache 99.2% hit");
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,7 +2,7 @@ pub mod agy;
 pub mod claude;
 pub mod codex;
 pub mod grok;
-mod statusline;
+pub mod statusline;
 
 use thiserror::Error;
 

--- a/src/providers/statusline.rs
+++ b/src/providers/statusline.rs
@@ -1,8 +1,8 @@
-use crate::model::{CacheUsage, ContextUsage, ProviderSnapshot, ResetAt};
+use crate::model::{CacheTotals, CacheUsage, ContextUsage, ProviderSnapshot, ResetAt};
 use crate::providers::ProviderError;
 use serde_json::Value;
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 
 const TRANSCRIPT_TAIL_BYTES: u64 = 16 * 1024;
@@ -86,12 +86,122 @@ pub fn enrich_cache_ttl(snapshot: &mut ProviderSnapshot, statusline: &Value) {
     let Some(tail) = read_transcript_tail(Path::new(path)) else {
         return;
     };
-    let Some((ttl_seconds, last_activity_unix)) = latest_cache_activity(&tail) else {
+    let Some((Some(ttl_seconds), Some(last_activity_unix))) = latest_cache_activity(&tail) else {
         return;
     };
     *cache = cache
         .clone()
         .with_ttl_estimate(ttl_seconds, last_activity_unix);
+}
+
+/// Accumulate cache counters from the provider session transcript.
+///
+/// StatusLine's `current_usage` is deliberately a latest-request view. The
+/// transcript is the only local source that lets us present a session total,
+/// so this function stores a byte offset and reads only appended complete
+/// lines after the first call. It never starts a model turn or contacts a
+/// provider.
+pub fn enrich_cache_session(
+    snapshot: &mut ProviderSnapshot,
+    statusline: &Value,
+    previous_cache: Option<&CacheUsage>,
+) {
+    let Some(context) = snapshot.context.as_mut() else {
+        return;
+    };
+    let Some(cache) = context.cache.as_mut() else {
+        return;
+    };
+    let Some(session_id) = statusline
+        .get("session_id")
+        .or_else(|| statusline.get("sessionId"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    else {
+        return;
+    };
+    // Keep the session boundary even when this payload has no transcript
+    // path. That prevents a later statusLine update from inheriting another
+    // session's TTL estimate.
+    cache.session_id = Some(session_id.to_string());
+    let Some(path) = statusline.get("transcript_path").and_then(Value::as_str) else {
+        return;
+    };
+
+    let matching_previous =
+        previous_cache.filter(|previous| previous.session_id.as_deref() == Some(session_id));
+    let previous_offset = matching_previous
+        .map(|previous| previous.transcript_offset)
+        .unwrap_or_default();
+    let mut increment_totals: Option<CacheTotals> = None;
+    let mut latest_activity = None;
+    let mut latest_ttl = None;
+    let Some((next_offset, transcript_reset)) = read_transcript_increment(
+        Path::new(path),
+        if matching_previous.is_some() {
+            previous_offset
+        } else {
+            0
+        },
+        |line| {
+            let Ok(entry) = serde_json::from_str::<Value>(line) else {
+                return;
+            };
+            let Some(usage) = assistant_usage(&entry) else {
+                return;
+            };
+            let fresh = token_count(usage, "input_tokens", "inputTokens");
+            let read = token_count(usage, "cache_read_input_tokens", "cacheReadInputTokens");
+            let creation = token_count(
+                usage,
+                "cache_creation_input_tokens",
+                "cacheCreationInputTokens",
+            );
+            if fresh == 0 && read == 0 && creation == 0 {
+                return;
+            }
+            if let Some(existing) = increment_totals.as_mut() {
+                existing.add_token_counts(fresh, read, creation);
+            } else {
+                increment_totals = CacheTotals::from_token_counts(fresh, read, creation);
+            }
+            if read > 0 || creation > 0 {
+                latest_activity = Some(entry.get("timestamp").and_then(parse_timestamp));
+                if let Some(ttl_seconds) = cache_ttl_seconds(usage) {
+                    latest_ttl = Some(ttl_seconds);
+                }
+            }
+        },
+    ) else {
+        return;
+    };
+
+    let mut totals = if transcript_reset {
+        None
+    } else {
+        matching_previous.and_then(|previous| previous.session_totals.clone())
+    };
+    if let Some(increment) = increment_totals {
+        if let Some(existing) = totals.as_mut() {
+            existing.add_token_counts(
+                increment.fresh_input_tokens,
+                increment.read_tokens,
+                increment.creation_tokens,
+            );
+        } else {
+            totals = Some(increment);
+        }
+    }
+
+    cache.session_totals = totals;
+    cache.transcript_offset = next_offset;
+
+    if let Some(ttl_seconds) = latest_ttl {
+        cache.ttl_seconds = Some(ttl_seconds);
+    }
+    if let Some(Some(last_activity_unix)) = latest_activity {
+        cache.last_activity_unix = Some(last_activity_unix);
+    }
 }
 
 fn read_transcript_tail(path: &Path) -> Option<String> {
@@ -109,23 +219,51 @@ fn read_transcript_tail(path: &Path) -> Option<String> {
         .map(|(_, complete_lines)| complete_lines.to_string())
 }
 
-fn latest_cache_activity(text: &str) -> Option<(u64, u64)> {
+fn read_transcript_increment<F>(path: &Path, offset: u64, mut on_line: F) -> Option<(u64, bool)>
+where
+    F: FnMut(&str),
+{
+    let mut file = File::open(path).ok()?;
+    let length = file.metadata().ok()?.len();
+    let transcript_reset = offset > length;
+    let start = if transcript_reset { 0 } else { offset };
+    file.seek(SeekFrom::Start(start)).ok()?;
+    let mut reader = BufReader::new(file.take(length - start));
+    let mut line = Vec::new();
+    let mut next_offset = start;
+    loop {
+        line.clear();
+        let bytes_read = reader.read_until(b'\n', &mut line).ok()?;
+        if bytes_read == 0 || line.last() != Some(&b'\n') {
+            break;
+        }
+        next_offset += bytes_read as u64;
+        let content = &line[..line.len() - 1];
+        on_line(&String::from_utf8_lossy(content));
+    }
+    Some((next_offset, transcript_reset))
+}
+
+fn assistant_usage(entry: &Value) -> Option<&serde_json::Map<String, Value>> {
+    if entry.get("type").and_then(Value::as_str) != Some("assistant") {
+        return None;
+    }
+    entry
+        .get("message")
+        .and_then(Value::as_object)
+        .and_then(|message| message.get("usage"))
+        .or_else(|| entry.get("usage"))
+        .and_then(Value::as_object)
+}
+
+fn latest_cache_activity(text: &str) -> Option<(Option<u64>, Option<u64>)> {
     let mut last_activity = None;
     let mut ttl_seconds = None;
     for line in text.lines().rev() {
         let Ok(entry) = serde_json::from_str::<Value>(line) else {
             continue;
         };
-        if entry.get("type").and_then(Value::as_str) != Some("assistant") {
-            continue;
-        }
-        let Some(usage) = entry
-            .get("message")
-            .and_then(Value::as_object)
-            .and_then(|message| message.get("usage"))
-            .or_else(|| entry.get("usage"))
-            .and_then(Value::as_object)
-        else {
+        let Some(usage) = assistant_usage(&entry) else {
             continue;
         };
         let read = token_count(usage, "cache_read_input_tokens", "cacheReadInputTokens");
@@ -143,15 +281,22 @@ fn latest_cache_activity(text: &str) -> Option<(u64, u64)> {
         if ttl_seconds.is_none() {
             ttl_seconds = cache_ttl_seconds(usage);
         }
-        if let (Some(ttl_seconds), Some(last_activity)) = (ttl_seconds, last_activity) {
+        if ttl_seconds.is_some() && last_activity.is_some() {
             return Some((ttl_seconds, last_activity));
         }
     }
-    None
+    if ttl_seconds.is_some() || last_activity.is_some() {
+        Some((ttl_seconds, last_activity))
+    } else {
+        None
+    }
 }
 
 fn cache_ttl_seconds(usage: &serde_json::Map<String, Value>) -> Option<u64> {
-    let creation = usage.get("cache_creation")?.as_object()?;
+    let creation = usage
+        .get("cache_creation")
+        .or_else(|| usage.get("cacheCreation"))?
+        .as_object()?;
     if token_count(
         creation,
         "ephemeral_1h_input_tokens",
@@ -178,4 +323,77 @@ fn parse_timestamp(value: &Value) -> Option<u64> {
             .and_then(ResetAt::parse)
             .map(ResetAt::unix_seconds)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ContextUsage, Provider, UsageWindow, WindowKind};
+    use serde_json::json;
+    use std::io::Write;
+
+    fn snapshot_with_cache() -> ProviderSnapshot {
+        ProviderSnapshot::new(
+            Provider::Claude,
+            vec![UsageWindow::new(WindowKind::Weekly, 10.0, None).unwrap()],
+            0,
+        )
+        .with_context(Some(
+            ContextUsage::new(24.0)
+                .unwrap()
+                .with_cache(CacheUsage::from_token_counts(1, 1, 1)),
+        ))
+    }
+
+    #[test]
+    fn accumulates_session_cache_counters_once_per_transcript_offset() {
+        let transcript = tempfile::NamedTempFile::new().unwrap();
+        let first = br#"{"type":"assistant","timestamp":"2026-08-22T10:00:00Z","message":{"usage":{"input_tokens":100,"cache_read_input_tokens":800,"cache_creation_input_tokens":100,"cache_creation":{"ephemeral_1h_input_tokens":100}}}}
+{"type":"assistant","timestamp":"2026-08-22T10:01:00Z","message":{"usage":{"input_tokens":50,"cache_read_input_tokens":450,"cache_creation_input_tokens":0}}}
+"#;
+        std::fs::write(transcript.path(), first).unwrap();
+        let statusline = json!({
+            "session_id": "session-1",
+            "transcript_path": transcript.path(),
+        });
+
+        let mut first_snapshot = snapshot_with_cache();
+        enrich_cache_session(&mut first_snapshot, &statusline, None);
+        let first_cache = first_snapshot.context.unwrap().cache.unwrap();
+        let first_totals = first_cache.session_totals.clone().unwrap();
+        assert_eq!(first_totals.fresh_input_tokens, 150);
+        assert_eq!(first_totals.read_tokens, 1_250);
+        assert_eq!(first_totals.creation_tokens, 100);
+        assert_eq!(first_cache.ttl_seconds, Some(60 * 60));
+        assert_eq!(first_cache.last_activity_unix, Some(1_787_392_860));
+        assert!(first_cache.transcript_offset > 0);
+
+        let third = br#"{"type":"assistant","timestamp":"2026-08-22T10:02:00Z","message":{"usage":{"input_tokens":20,"cache_read_input_tokens":180,"cache_creation_input_tokens":0}}}
+"#;
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(transcript.path())
+            .unwrap();
+        file.write_all(third).unwrap();
+
+        let mut second_snapshot = snapshot_with_cache();
+        enrich_cache_session(&mut second_snapshot, &statusline, Some(&first_cache));
+        let second_cache = second_snapshot.context.unwrap().cache.unwrap();
+        let second_totals = second_cache.session_totals.as_ref().unwrap();
+        assert_eq!(second_totals.fresh_input_tokens, 170);
+        assert_eq!(second_totals.read_tokens, 1_430);
+        assert_eq!(second_totals.creation_tokens, 100);
+
+        let mut unchanged_snapshot = snapshot_with_cache();
+        enrich_cache_session(&mut unchanged_snapshot, &statusline, Some(&second_cache));
+        assert_eq!(
+            unchanged_snapshot
+                .context
+                .unwrap()
+                .cache
+                .unwrap()
+                .session_totals,
+            second_cache.session_totals
+        );
+    }
 }

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -96,6 +96,10 @@ fn default_herdr_rows_become_plane_provider_usage_and_topic_lines() {
     assert!(applied.contains("$quota_topic"));
     assert!(applied.contains("$quota_context"));
     assert!(applied.contains("fg = \"#9b8fd8\""));
+    assert!(applied.find("$quota_provider").unwrap() < applied.find("$quota_context").unwrap());
+    assert!(applied.contains("$quota_cache"));
+    assert!(applied.contains("$quota_cache_ttl"));
+    assert!(applied.contains("fg = \"#6fb5b7\""));
     assert!(applied.contains("row_gap = 1 # herdr-agent-quota"));
     assert!(applied.find("$quota_topic").unwrap() < applied.find("$quota_5h_normal").unwrap());
     assert!(applied.contains("fg = \"#84b084\""));
@@ -347,7 +351,7 @@ fn claude_collector_does_not_republish_unchanged_quota() {
     let state = tempdir().unwrap();
     let (herdr_stub, herdr_log) = install_herdr_stub(
         state.path(),
-        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1","tokens":{"quota_state":"?","quota_icon":"✦Cl","quota_provider":"Claude","quota_status":"N/A","quota_5h":"5h 42%","quota_5h_warning":"5h 42%","quota_week":"week 73%","quota_week_warning":"week 73%","quota_summary":"5h 42% · week 73%"}}]}}"#,
+        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1","tokens":{"quota_state":"?","quota_provider":"Claude","quota_5h":"5h 42%","quota_5h_warning":"5h 42%","quota_week":"week 73%","quota_week_warning":"week 73%","quota_summary":"5h 42% · week 73%"}}]}}"#,
     );
 
     let input = br#"{


### PR DESCRIPTION
## Summary
- show context immediately after provider, with a dedicated violet color
- show cumulative session cache hit percentage plus last cache activity and approximate TTL rows
- accumulate Claude/Agy statusLine transcript usage by session id and byte offset without network, login, model calls, or pane reads
- keep the global watcher at its configurable 60-second default and preserve one-click configure/uninstall behavior
- clean obsolete metadata tokens while staying within Herdr's 16-token cap

## Verification
- cargo fmt --all -- --check
- cargo test --all-targets --all-features --locked
- cargo clippy --release --all-targets --all-features -- -D warnings
- cargo build --release --locked
- local pane/config verification: context 43%, cache 96.9% hit, cache last 37m ago · ttl≈22m

TTL is explicitly approximate: Claude exposes 5m/1h cache buckets and refresh-on-read semantics, but no exact expiry timestamp.