### PR TITLE
Fix Claude reset freshness and compact quota rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   TTL estimate when the provider exposes a cache bucket. Claude/Agy collectors
   use local statusLine/transcript data only; they do not log in or start model
   requests.
-- Quota rows now show a compact `reset` ETA: minutes below one hour, hours and
-  minutes below one day, and days plus hours for longer windows.
+- Quota rows now show compact `5h`/`7d` window labels with minutes below one
+  hour, hours and minutes below one day, and days plus hours for longer windows.
+- Claude's plugin-owned statusLine now receives the configured global watcher
+  interval as its native `refreshInterval`, keeping idle-session reset times
+  fresh without an API call or model request; existing user-owned intervals are
+  preserved.
 - Active turns now start one short-lived global refresh watcher for Claude,
   Codex, Grok, and Agy. It reads the working provider set once per poll,
   publishes statusLine cache updates, keeps active fetches debounced, stops
@@ -100,8 +104,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   amber accents, while metadata publication remains capped at sixteen tokens.
 - Quota formatting is centralized in one presentation module shared by the
   sidebar, dashboard, and statusLine fallbacks. Codex remains weekly-only.
-- Five-hour and weekly quota windows now occupy separate sidebar rows. Missing
-  five-hour tokens are cleared so Herdr elides that row for Codex and Grok.
+- Five-hour and weekly quota windows now share one compact sidebar row. Herdr
+  elides missing tokens and their separators, while each window keeps its own
+  dynamic health color.
 - Sidebar agent cards default to one blank row of separation, while preserving
   an existing `row_gap`. The latest user prompt now precedes compact,
   single-spaced quota rows, and percentages render as whole numbers.

--- a/README.md
+++ b/README.md
@@ -17,15 +17,14 @@ Agy/Antigravity subscription usage, in Herdr's agent sidebar.
   context 23%             ← provider-native context percentage
   cache 99.6% hit         ← cumulative for this session
   cache last 2m ago · ttl≈58m
-  5h 100% reset 3h07m
-  week 31% reset 2d3h
+  5h 100% 3h07m · 7d 31% 2d3h
 ```
 
 ![Live Herdr agent sidebar](docs/screenshots/herdr-sidebar-live.png)
 
-*A real Herdr workspace: Claude shows separate five-hour and weekly reset
-ETAs, Codex and Grok show their weekly windows, and each agent card uses the
-latest user prompt rather than an AI-generated status.*
+*A real Herdr workspace: Claude shows five-hour and weekly reset ETAs on one
+compact row, Codex and Grok show their weekly windows, and each agent card uses
+the latest user prompt rather than an AI-generated status.*
 
 - **Four CLIs, one sidebar** — Claude Code, Codex, Grok, Agy/Antigravity.
 - **Compact, capability-aware cards** — provider, prompt/session summary,
@@ -102,7 +101,10 @@ herdr plugin action invoke herdr-agent-quota.configure
 
 The configure action consistently uses Herdr's plugin state, applies the
 sidebar rows, installs or repairs the reversible Claude and Agy statusLine
-collectors, and reloads Herdr's config. You can
+collectors, and reloads Herdr's config. Claude's native statusLine refresh is
+also aligned with the same watcher interval (60 seconds by default), so an
+idle session receives fresh reset timestamps without a provider login or model
+request. You can
 run it again safely from Herdr's action menu as **Install / repair agent quota**.
 Use **Refresh agent quota** for a one-shot refresh, or
 press `prefix+shift+r` after configuration. The shortcut force-fetches Codex
@@ -172,7 +174,7 @@ long turns no longer start one refresh command per tool call.
 
 | CLI | Sidebar windows | Local collection path | Extra setup |
 | --- | --- | --- | --- |
-| Claude Code `2.1.233` | `5h` + `week` + context + cache hit/approx. TTL | Official `statusLine` JSON: `rate_limits`, `context_window`, and `transcript_path` | The configure action installs and chains it automatically |
+| Claude Code `2.1.233` | `5h` + `7d` + context + cache hit/approx. TTL | Official `statusLine` JSON: `rate_limits`, `context_window`, and `transcript_path` | The configure action installs/chains it and keeps its refresh interval current |
 | OpenAI Codex `0.147.0` | `week` + local session summary | One-shot local `codex app-server --stdio`: quota and bounded `thread/list` | ChatGPT subscription login; API-key mode is shown as unavailable |
 | Grok CLI / Grok Build `1.0.4` | `week` | Local `~/.grok/auth.json` and the billing contract used by the official CLI | Covered by the unified watcher; no response hook is installed |
 | Agy / Antigravity CLI `1.1.13` | `5h` + `week` + context + cache hit | Official `statusLine` JSON: `quota` and `context_window` | The configure action installs and chains it automatically |
@@ -182,8 +184,10 @@ parser follows the provider fields rather than hard-coding these version
 strings, so newer compatible CLI releases can continue to work.
 
 The sidebar shows **percentage remaining** and the time until each quota reset,
-not quota token counts. Claude and Agy also show provider-reported context
-percentage. When a statusLine transcript and session id are available,
+not quota token counts. The two Claude windows use compact `5h` and `7d`
+labels on one row; each still keeps its own dynamic health color. Claude and
+Agy also show provider-reported context percentage. When a statusLine transcript
+and session id are available,
 `cache N.N% hit` is the cumulative main-session ratio
 (`read / (fresh + creation + read)`), not the latest turn. The next row shows
 how long ago the latest cache-bearing response arrived and, for Claude, a
@@ -224,12 +228,14 @@ rows = [
   [{ token = "$quota_topic", dim = false }],
   [{ token = "$quota_cache", fg = "#6fb5b7", bold = true, dim = false }],
   [{ token = "$quota_cache_ttl", fg = "#cdaa65", bold = true, dim = false }],
-  [{ token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false }],
-  [{ token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false }],
-  [{ token = "$quota_5h_danger", fg = "#ca6470", bold = true, dim = false }],
-  [{ token = "$quota_week_normal", fg = "#84b084", bold = true, dim = false }],
-  [{ token = "$quota_week_warning", fg = "#cdaa65", bold = true, dim = false }],
-  [{ token = "$quota_week_danger", fg = "#ca6470", bold = true, dim = false }],
+  [
+    { token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false },
+    { token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false },
+    { token = "$quota_5h_danger", fg = "#ca6470", bold = true, dim = false },
+    { token = "$quota_week_normal", fg = "#84b084", bold = true, dim = false },
+    { token = "$quota_week_warning", fg = "#cdaa65", bold = true, dim = false },
+    { token = "$quota_week_danger", fg = "#ca6470", bold = true, dim = false },
+  ],
 ]
 ```
 
@@ -251,12 +257,13 @@ rows = [
   fields are hidden instead of guessed.
 - The context row uses a violet accent (`#9b8fd8`) so context pressure is easy
   to distinguish from the green/amber/red quota runway colors.
-- Each window publishes exactly one styled variant. Color follows runway rather
-  than a fixed quota threshold: remaining quota is compared with the percentage
-  of window time still left. At or ahead of pace is green; behind pace is
-  amber; behind pace with less than 20% quota remaining is red. Missing or
-  expired reset data uses the warning color. Herdr hides all absent variants,
-  including the unsupported 5h row for Codex/Grok.
+- Each window publishes exactly one styled variant. Herdr renders adjacent
+  values on the same row with `·` separators and removes separators for missing
+  values, so 5h/7d stay compact while retaining independent colors. Color
+  follows runway rather than a fixed quota threshold: remaining quota is
+  compared with the percentage of window time still left. At or ahead of pace
+  is green; behind pace is amber; behind pace with less than 20% quota remaining
+  is red. Missing or expired reset data uses the warning color.
 - `row_gap = 1` adds one blank row between agent cards. An existing explicit
   `row_gap` value is preserved.
 - `$quota_5h`, `$quota_week`, and `$quota_summary` remain available for custom
@@ -301,12 +308,16 @@ such as `Thinking` or `Executing`. It does not show the working directory.
   debounce limit active requests; it never logs in or refreshes the key.
 - **Claude Code:** the official [`statusLine` JSON hook](https://code.claude.com/docs/en/statusline)
   supplies the five-hour, seven-day, context-used percentage, and latest
-  cache counters. A previous statusLine command is backed up, chained, and
-  restored by the uninstall action. When a transcript path and session id are
-  present, the hook accumulates the main session's assistant usage using a
-  byte offset; the first update reads the existing transcript once and later
-  updates read only appended lines. A cache bucket gives the explicitly
-  approximate `ttl≈...`; there is no network request or model turn.
+  cache counters. Configure sets Claude's native `refreshInterval` to the
+  unified watcher interval when it is plugin-owned (60 seconds by default),
+  so an idle session refreshes its absolute reset timestamps; an existing
+  user-owned interval is preserved. A previous statusLine command is backed
+  up, chained, and restored by the uninstall action. When a transcript path
+  and session id are present, the hook accumulates the main session's
+  assistant usage using a byte offset; the first update reads the existing
+  transcript once and later updates read only appended lines. A cache bucket
+  gives the explicitly approximate `ttl≈...`; there is no network request or
+  model turn.
 - **Agy/Antigravity:** the official [`/usage` and statusline docs](https://antigravity.google/docs/cli/commands/usage?app=antigravity-ide)
   supply Gemini and third-party pools plus context-used percentage and cache
   counters. When both pools exist, the sidebar uses the lowest remaining
@@ -328,6 +339,7 @@ weekly value instead of clearing the sidebar.
 | --- | --- |
 | The rows do not appear | Run `herdr server reload-config`, then **Refresh agent quota**. |
 | Claude or Agy is `N/A` | Start a conversation so the native `statusLine` emits JSON; then refresh. |
+| Claude reset time stays stale while the pane is idle | Run **Install / repair agent quota**, then restart the already-running Claude pane once so it loads the native statusLine refresh interval. |
 | Claude briefly changes while switching panes | The cached value is retained; run one prompt or a manual refresh if no snapshot exists yet. |
 | Agy has no quota | Run **Install / repair agent quota**, start one Agy turn, then manually refresh. |
 | A running Grok goal stays stale | Run **Install / repair agent quota**, then start the next turn; the unified watcher will pick up working sessions. |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,13 +17,12 @@ Claude Code、Codex、Grok 和 Agy/Antigravity 的订阅额度。
   context 23%             ← provider 原生 context 百分比
   cache 99.6% hit         ← 整个 session 累计命中率
   cache last 2m ago · ttl≈58m
-  5h 100% reset 3h07m
-  week 31% reset 2d3h
+  5h 100% 3h07m · 7d 31% 2d3h
 ```
 
 ![Herdr 左侧额度截图](docs/screenshots/herdr-sidebar-live.png)
 
-*真实的 Herdr 工作区：Claude 分行显示 5 小时和周额度及其重置倒计时，
+*真实的 Herdr 工作区：Claude 在一行紧凑显示 5 小时和 7 天额度及其重置倒计时，
 Codex、Grok 显示周额度；每张 agent 卡片的话题来自用户最后一次输入，
 不会使用 AI 生成的状态标题。*
 
@@ -93,7 +92,9 @@ herdr plugin action invoke herdr-agent-quota.configure
 ```
 
 configure action 会统一使用 Herdr 的插件 state 目录，批量写入 sidebar 行、安装
-或修复可恢复的 Claude/Agy statusLine 采集器，并自动 reload 配置。之后可随时在
+或修复可恢复的 Claude/Agy statusLine 采集器，并自动 reload 配置。Claude 的原生
+statusLine 刷新间隔也会跟随同一个 watcher 间隔（默认 60 秒），这样空闲会话也能
+更新 reset 时间，不会登录 provider 或发起模型请求。之后可随时在
 Herdr action 菜单执行 **Install / repair agent quota**，重复
 执行也是安全的。需要手动刷新时执行 **Refresh agent quota**。
 
@@ -146,7 +147,7 @@ usage、topic 三类 token，不会覆盖官方 agent 指示。卸载 action 会
 
 | CLI | 侧栏显示 | 本地数据来源 | 额外配置 |
 | --- | --- | --- | --- |
-| Claude Code `2.1.233` | `5h` + `week` + context + 缓存命中率/近似 TTL | 官方 `statusLine` JSON：`rate_limits`、`context_window`、`transcript_path` | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
+| Claude Code `2.1.233` | `5h` + `7d` + context + 缓存命中率/近似 TTL | 官方 `statusLine` JSON：`rate_limits`、`context_window`、`transcript_path` | 配置 action 自动安装/串联，并保持原生刷新间隔与 watcher 一致 |
 | OpenAI Codex `0.147.0` | `week` + 本地会话摘要 | 一次性的 `codex app-server --stdio`：额度和有上限的 `thread/list` | 使用 ChatGPT 订阅登录；API key 模式显示为不可用；不会 resume thread |
 | Grok CLI / Grok Build `1.0.4` | `week` | `~/.grok/auth.json` 和官方 CLI 使用的额度接口 | 由统一 watcher 处理，不再安装回复 hook |
 | Agy / Antigravity CLI `1.1.13` | `5h` + `week` + context + 缓存命中率 | 官方 `statusLine` JSON 的 `quota` 和 `context_window` | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
@@ -155,6 +156,7 @@ usage、topic 三类 token，不会覆盖官方 agent 指示。卸载 action 会
 字段工作，不会把这些版本号写死；兼容的新版本可以继续使用。
 
 侧栏显示的是**额度剩余百分比**和距离下次额度重置的时间，不是额度 token 数量。
+Claude 的两个窗口会用紧凑的 `5h` 和 `7d` 标签放在同一行，但仍各自保留动态健康色。
 Claude 和 Agy 的 statusLine 有 context 字段时，还会显示当前 context **已用**百分比。
 如果有 statusLine transcript 和 session id，`cache N.N% hit` 是主 session 的累计命中率
 （`read / (fresh + creation + read)`），不是最新一轮；下一行显示最近一次有缓存响应
@@ -171,8 +173,7 @@ Claude 和 Agy 的 statusLine 有 context 字段时，还会显示当前 context
   context 23%
   cache 99.6% hit
   cache last 2m ago · ttl≈58m
-  5h 100% reset 3h07m
-  week 31% reset 2d3h
+  5h 100% 3h07m · 7d 31% 2d3h
 ```
 
 Codex 和 Grok 提供周额度；Claude Code 和 Agy 提供 5 小时额度与周额度。
@@ -202,12 +203,14 @@ rows = [
   [{ token = "$quota_topic", dim = false }],
   [{ token = "$quota_cache", fg = "#6fb5b7", bold = true, dim = false }],
   [{ token = "$quota_cache_ttl", fg = "#cdaa65", bold = true, dim = false }],
-  [{ token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false }],
-  [{ token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false }],
-  [{ token = "$quota_5h_danger", fg = "#ca6470", bold = true, dim = false }],
-  [{ token = "$quota_week_normal", fg = "#84b084", bold = true, dim = false }],
-  [{ token = "$quota_week_warning", fg = "#cdaa65", bold = true, dim = false }],
-  [{ token = "$quota_week_danger", fg = "#ca6470", bold = true, dim = false }],
+  [
+    { token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false },
+    { token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false },
+    { token = "$quota_5h_danger", fg = "#ca6470", bold = true, dim = false },
+    { token = "$quota_week_normal", fg = "#84b084", bold = true, dim = false },
+    { token = "$quota_week_warning", fg = "#cdaa65", bold = true, dim = false },
+    { token = "$quota_week_danger", fg = "#ca6470", bold = true, dim = false },
+  ],
 ]
 ```
 
@@ -224,11 +227,12 @@ rows = [
   有缓存响应距离现在多久；Claude 提供 5m/1h 缓存桶时还会显示剩余的 `ttl≈...`。
   字段缺失时隐藏，不做猜测。
 - context 行使用紫色强调色（`#9b8fd8`），与额度续航的绿/琥珀/红色区分开。
-- 每个窗口只发布一个样式 token。颜色按额度续航动态判断，不再使用固定
-  余额阈值：将剩余额度比例与窗口剩余时间比例比较，额度消耗不快于时间
-  进度时为绿色；落后于时间进度时为琥珀色；落后且额度低于 20% 时为
-  红色。reset 缺失或过期时使用告警色。Codex/Grok 不支持的 5h 行
-  会自动隐藏。
+- 每个窗口只发布一个样式 token。Herdr 会把同一行相邻 token 自动用 `·`
+  分隔，并在 token 缺失时移除对应分隔符，所以 5h/7d 会紧凑地显示在一行，
+  但仍各自保留颜色。颜色按额度续航动态判断，不再使用固定余额阈值：将剩余
+  额度比例与窗口剩余时间比例比较，额度消耗不快于时间进度时为绿色；落后于
+  时间进度时为琥珀色；落后且额度低于 20% 时为红色。reset 缺失或过期时使用
+  告警色。
 - `row_gap = 1` 在 agent 卡片之间留一行空白；已有的显式 `row_gap`
   配置会原样保留。
 - `$quota_5h`、`$quota_week`、`$quota_summary` 仍保留给需要无样式或
@@ -268,9 +272,10 @@ Herdr plugin v1 只支持文本 token，不能由插件向原生 Agent renderer 
 - **Claude Code：** 使用官方
   [`statusLine` JSON hook](https://code.claude.com/docs/en/statusline) 提供
   5 小时、7 天额度、context 已用百分比和最新缓存计数。原有 statusLine 会被备份、
-  串联，并可由卸载 action 恢复；当输入提供 transcript 路径和 session id 时，
-  采集器首次读取一次已有主会话并按 offset 增量累计，之后只读新增行；明确缓存桶
-  才推断 `ttl≈...`，不联网、不发模型请求。
+  串联，并可由卸载 action 恢复。插件管理的 `refreshInterval` 会跟随统一 watcher
+  间隔（默认 60 秒），因此空闲会话也会刷新绝对 reset 时间；用户已有的刷新间隔会
+  保留。当输入提供 transcript 路径和 session id 时，采集器首次读取一次已有主会话
+  并按 offset 增量累计，之后只读新增行；明确缓存桶才推断 `ttl≈...`，不联网、不发模型请求。
 - **Agy/Antigravity：** 使用官方
   [`/usage` 和 statusline 文档](https://antigravity.google/docs/cli/commands/usage?app=antigravity-ide)
   中的 Gemini、第三方额度池、context 已用百分比和最新缓存计数。两个额度池同时存在时，
@@ -290,6 +295,7 @@ Grok CLI 的额度接口属于 CLI 内部契约，不是 xAI 面向开发者的�
 | --- | --- |
 | 侧栏没有新增行 | 执行 `herdr server reload-config`，再运行 **Refresh agent quota**。 |
 | Claude 或 Agy 显示 `N/A` | 发起一次对话，让原生 `statusLine` 产生 JSON，然后刷新。 |
+| Claude 空闲时 reset 时间不更新 | 执行 **Install / repair agent quota**，然后重启已有的 Claude pane 一次，让它加载原生 statusLine 刷新间隔。 |
 | 切换 pane 时 Claude 短暂变化 | 已有缓存会保留；如果还没有快照，发送一次 prompt 或手动刷新。 |
 | Agy 没有额度 | 执行 **Install / repair agent quota**，完成一次 Agy 对话后再手动刷新。 |
 | 任一运行中的 turn 额度不更新 | 执行 **Install / repair agent quota**，下一次 working turn 会自动启动统一 watcher，回合结束时还会按去抖规则补一次。 |

--- a/docs/plans/herdr-agent-quota-implementation.md
+++ b/docs/plans/herdr-agent-quota-implementation.md
@@ -119,11 +119,10 @@ Recommended compact values:
 ```text
 ● Owner · Grok
 B-325 budget cap
-week 39% reset 2d3h
+7d 39% 2d3h
 ● Owner · Claude
 refactor auth middleware
-5h 42% reset 3h07m
-week 73% reset 2d3h
+5h 42% 3h07m · 7d 73% 2d3h
 ```
 
 The same provider-level snapshot is repeated on every matching agent pane. Token
@@ -360,8 +359,9 @@ requests on the user's behalf.
 3. Back up the original once with a deterministic adjacent name.
 4. Retain Herdr's official `state_icon`/`tab` row (without the directory),
    add the plugin-owned `$quota_topic` as its own row, add
-   `$quota_provider` to the plane row, and add separate `$quota_5h` and
-   `$quota_week` rows. Herdr elides the missing 5h token for weekly-only agents.
+   `$quota_provider` to the plane row, and add one compact row containing the
+   styled `$quota_5h` and `$quota_week` variants. Herdr elides missing tokens
+   and their separators for weekly-only agents.
    The topic token is extracted from the latest user prompt on event refresh;
    it stays empty instead of falling back to AI status titles. This keeps every
    agent to three readable lines and shows the provider name only once. The

--- a/docs/research/quota-reset-capability.md
+++ b/docs/research/quota-reset-capability.md
@@ -125,9 +125,11 @@ ResetAt(i64)                 # Unix 秒，统一绝对时间
 推荐最终一行保持紧凑：
 
 ```text
-5h 42% reset 3h07m
-week 73% reset 2d3h
+5h 42% 3h07m · 7d 73% 2d3h
 ```
+
+侧栏省略重复的 `reset` 单词，并用 `7d` 缩写 weekly 窗口；dashboard 和
+`$quota_summary` 仍可使用带 `reset`/`left` 的完整 formatter。
 
 “有 d 就只显示 dh”会牺牲分钟精度，但符合窄 sidebar。dashboard 也应复用同一 formatter；如果未来真的需要完整本地时刻，再为 dashboard 扩展展示层，不让 provider parser 负责本地化。
 

--- a/src/configure/claude.rs
+++ b/src/configure/claude.rs
@@ -1,5 +1,5 @@
 use super::statusline::{settings_path, Adapter};
-use crate::cache::CacheStore;
+use crate::cache::{CacheStore, DEFAULT_WATCH_INTERVAL_SECONDS};
 use crate::model::Provider;
 use crate::providers::claude::parse_statusline;
 use crate::providers::statusline::enrich_cache_session;
@@ -25,10 +25,22 @@ pub fn check() -> Result<()> {
 pub fn apply() -> Result<()> {
     let cache = CacheStore::from_env()?;
     let executable = std::env::current_exe().context("resolve plugin executable")?;
-    apply_at(
+    apply_at_with_refresh_interval(
         &settings_path("CLAUDE_SETTINGS_FILE", ".claude/settings.json")?,
         cache.root(),
         &executable,
+        cache.watch_interval_seconds(),
+    )
+}
+
+pub fn apply_with_refresh_interval(refresh_interval_seconds: u64) -> Result<()> {
+    let cache = CacheStore::from_env()?;
+    let executable = std::env::current_exe().context("resolve plugin executable")?;
+    apply_at_with_refresh_interval(
+        &settings_path("CLAUDE_SETTINGS_FILE", ".claude/settings.json")?,
+        cache.root(),
+        &executable,
+        refresh_interval_seconds,
     )
 }
 
@@ -41,7 +53,16 @@ pub fn uninstall() -> Result<()> {
 }
 
 pub fn apply_at(settings: &Path, state: &Path, executable: &Path) -> Result<()> {
-    CONFIG.apply(settings, state, executable)
+    apply_at_with_refresh_interval(settings, state, executable, DEFAULT_WATCH_INTERVAL_SECONDS)
+}
+
+pub fn apply_at_with_refresh_interval(
+    settings: &Path,
+    state: &Path,
+    executable: &Path,
+    refresh_interval_seconds: u64,
+) -> Result<()> {
+    CONFIG.apply_with_refresh_interval(settings, state, executable, Some(refresh_interval_seconds))
 }
 
 pub fn uninstall_at(settings: &Path, state: &Path) -> Result<()> {

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -454,9 +454,9 @@ fn normalize_official_row(row: Array) -> Array {
 }
 
 fn append_quota_rows(rows: &mut Array) {
-    // Keep the official state row, but split each quota window onto its own
-    // row. Herdr elides rows whose custom token is absent, so weekly-only
-    // providers do not gain a blank five-hour row.
+    // Keep the official state row and put both quota windows on one compact
+    // row. Herdr elides missing tokens and their separators, so weekly-only
+    // providers do not gain a blank five-hour segment.
     for row in rows.iter_mut() {
         let Some(items) = row.as_array_mut() else {
             continue;
@@ -534,29 +534,32 @@ fn append_quota_rows(rows: &mut Array) {
         Some(false),
     )));
 
-    append_window_rows(rows, "quota_5h");
-    append_window_rows(rows, "quota_week");
+    append_window_row(rows);
 }
 
-fn append_window_rows(rows: &mut Array, base: &str) {
-    rows.push(Value::Array(styled_row(
-        &format!("${base}_normal"),
-        Some(QUOTA_SAFE_COLOR),
-        Some(true),
-        Some(false),
-    )));
-    rows.push(Value::Array(styled_row(
-        &format!("${base}_warning"),
-        Some(QUOTA_WARNING_COLOR),
-        Some(true),
-        Some(false),
-    )));
-    rows.push(Value::Array(styled_row(
-        &format!("${base}_danger"),
-        Some(QUOTA_DANGER_COLOR),
-        Some(true),
-        Some(false),
-    )));
+fn append_window_row(rows: &mut Array) {
+    let mut row = Array::new();
+    for base in ["quota_5h", "quota_week"] {
+        row.push(styled_token(
+            &format!("${base}_normal"),
+            Some(QUOTA_SAFE_COLOR),
+            Some(true),
+            Some(false),
+        ));
+        row.push(styled_token(
+            &format!("${base}_warning"),
+            Some(QUOTA_WARNING_COLOR),
+            Some(true),
+            Some(false),
+        ));
+        row.push(styled_token(
+            &format!("${base}_danger"),
+            Some(QUOTA_DANGER_COLOR),
+            Some(true),
+            Some(false),
+        ));
+    }
+    rows.push(Value::Array(row));
 }
 
 fn styled_row(token: &str, fg: Option<&str>, bold: Option<bool>, dim: Option<bool>) -> Array {
@@ -582,7 +585,7 @@ fn styled_token(token: &str, fg: Option<&str>, bold: Option<bool>, dim: Option<b
 
 fn print_diff_hint() {
     println!("  keep Herdr's official state icon and plane tab");
-    println!("  show the user prompt before separate, severity-colored 5h/week rows");
+    println!("  show the user prompt before one compact, severity-colored 5h/7d row");
 }
 
 #[cfg(test)]
@@ -603,6 +606,25 @@ rows = [["state_icon", "agent"]]
         assert!(updated.contains("$quota_5h_warning"));
         assert!(updated.contains("$quota_week_danger"));
         assert_eq!(add_quota_row(&updated).unwrap(), updated);
+    }
+
+    #[test]
+    fn puts_both_quota_windows_on_one_color_preserving_row() {
+        let updated =
+            add_quota_row("[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n").unwrap();
+        let document = updated.parse::<DocumentMut>().unwrap();
+        let rows = document["ui"]["sidebar"]["agents"]["rows"]
+            .as_array()
+            .unwrap();
+        assert!(rows.iter().any(|row| {
+            let items = row.as_array().unwrap();
+            items
+                .iter()
+                .any(|item| configured_token_name(item) == Some("$quota_5h_normal"))
+                && items
+                    .iter()
+                    .any(|item| configured_token_name(item) == Some("$quota_week_normal"))
+        }));
     }
 
     #[test]

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -35,11 +35,14 @@ pub fn run(
                 .ok()
                 .and_then(|value| value.parse().ok())
         });
-        if let Some(interval) = interval {
+        let interval = if let Some(interval) = interval {
             cache.set_watch_interval_seconds(interval)?;
-        }
+            interval
+        } else {
+            cache.watch_interval_seconds()
+        };
         herdr::apply()?;
-        claude::apply()?;
+        claude::apply_with_refresh_interval(interval)?;
         agy::apply()?;
         grok::apply()?;
     } else {

--- a/src/configure/statusline.rs
+++ b/src/configure/statusline.rs
@@ -29,6 +29,16 @@ impl Adapter {
     }
 
     pub fn apply(&self, path: &Path, state: &Path, executable: &Path) -> Result<()> {
+        self.apply_with_refresh_interval(path, state, executable, None)
+    }
+
+    pub fn apply_with_refresh_interval(
+        &self,
+        path: &Path,
+        state: &Path,
+        executable: &Path,
+        refresh_interval_seconds: Option<u64>,
+    ) -> Result<()> {
         let mut settings = read_settings(path, self.label)?;
         let installed = self.is_installed(settings.get("statusLine"));
         if !installed && !can_chain_statusline(settings.get("statusLine")) {
@@ -64,9 +74,20 @@ impl Adapter {
                     "command".to_string(),
                     Value::String(wrapper_command.clone()),
                 );
+                if let Some(seconds) = refresh_interval_seconds {
+                    if installed || !object.contains_key("refreshInterval") {
+                        object.insert("refreshInterval".to_string(), Value::from(seconds));
+                    }
+                }
                 Value::Object(object.clone())
             })
-            .unwrap_or_else(|| json!({"type": "command", "command": wrapper_command}));
+            .unwrap_or_else(|| {
+                let mut value = json!({"type": "command", "command": wrapper_command});
+                if let Some(seconds) = refresh_interval_seconds {
+                    value["refreshInterval"] = Value::from(seconds);
+                }
+                value
+            });
         settings["statusLine"] = status_line;
         write_settings(path, &settings, self.label)
     }

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -52,7 +52,7 @@ impl MetadataTokens {
                 Provider::Claude | Provider::Agy => Some(Severity::Unknown),
                 Provider::Codex | Provider::Grok => None,
             },
-            quota_week: "week N/A".to_string(),
+            quota_week: "7d N/A".to_string(),
             quota_week_severity: Some(Severity::Unknown),
             quota_summary: "unavailable".to_string(),
             quota_context: String::new(),
@@ -93,7 +93,7 @@ fn summary(snapshot: &ProviderSnapshot, now_unix: u64, include_left: bool) -> St
 fn sidebar_window(snapshot: &ProviderSnapshot, kind: WindowKind, now_unix: u64) -> String {
     snapshot
         .window(kind)
-        .map(|window| format_window(window, now_unix, false))
+        .map(|window| format_compact_window(window, now_unix))
         .unwrap_or_default()
 }
 
@@ -145,6 +145,18 @@ fn format_window(window: &UsageWindow, now_unix: u64, include_left: bool) -> Str
     };
     let eta = format_reset_eta(reset, now_unix);
     format!("{label} reset {eta}")
+}
+
+fn format_compact_window(window: &UsageWindow, now_unix: u64) -> String {
+    let label = match window.kind {
+        WindowKind::FiveHour => "5h",
+        WindowKind::Weekly => "7d",
+    };
+    let percent = format!("{}%", format_percent(window.remaining_percent));
+    let Some(reset) = window.resets_at else {
+        return format!("{label} {percent}");
+    };
+    format!("{label} {percent} {}", format_reset_eta(reset, now_unix))
 }
 
 fn format_reset_eta(reset_at: ResetAt, now_unix: u64) -> String {
@@ -259,6 +271,21 @@ mod tests {
         let values = MetadataTokens::from_snapshot(&snapshot, 0);
         assert_eq!(values.quota_5h_severity, Some(Severity::Warning));
         assert_eq!(values.quota_week_severity, Some(Severity::Danger));
+    }
+
+    #[test]
+    fn metadata_uses_compact_quota_window_labels() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![
+                window(WindowKind::FiveHour, 58.0, 14_820),
+                window(WindowKind::Weekly, 27.0, 183_600),
+            ],
+            0,
+        );
+        let values = MetadataTokens::from_snapshot(&snapshot, 0);
+        assert_eq!(values.quota_5h, "5h 42% 4h07m");
+        assert_eq!(values.quota_week, "7d 73% 2d3h");
     }
 
     #[test]

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -195,8 +195,8 @@ fn claude_cache_is_published_by_refresh_event() {
     run_claude_refresh(state.path(), &herdr_stub);
     let report = fs::read_to_string(herdr_log).unwrap();
     assert!(!report.contains("pane read"));
-    assert!(report.contains("quota_5h=5h 42% reset"));
-    assert!(report.contains("quota_week=week 73% reset"));
+    assert!(report.contains("quota_5h=5h 42%"));
+    assert!(report.contains("quota_week=7d 73%"));
 }
 
 #[test]
@@ -223,7 +223,7 @@ fn statusline_without_context_keeps_the_last_context_snapshot() {
     run_claude_refresh(state.path(), &herdr_stub);
     let report = fs::read_to_string(herdr_log).unwrap();
     assert!(report.contains("quota_context=context 24%"));
-    assert!(report.contains("quota_week=week 72%"));
+    assert!(report.contains("quota_week=7d 72%"));
 }
 
 #[test]
@@ -351,7 +351,7 @@ fn claude_collector_does_not_republish_unchanged_quota() {
     let state = tempdir().unwrap();
     let (herdr_stub, herdr_log) = install_herdr_stub(
         state.path(),
-        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1","tokens":{"quota_state":"?","quota_provider":"Claude","quota_5h":"5h 42%","quota_5h_warning":"5h 42%","quota_week":"week 73%","quota_week_warning":"week 73%","quota_summary":"5h 42% · week 73%"}}]}}"#,
+        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1","tokens":{"quota_state":"?","quota_provider":"Claude","quota_5h":"5h 42%","quota_5h_warning":"5h 42%","quota_week":"7d 73%","quota_week_warning":"7d 73%","quota_summary":"5h 42% · week 73%"}}]}}"#,
     );
 
     let input = br#"{

--- a/tests/statusline_config.rs
+++ b/tests/statusline_config.rs
@@ -58,6 +58,53 @@ fn old_plugin_wrappers_are_repaired_without_becoming_the_backup() {
 }
 
 #[test]
+fn claude_statusline_refreshes_rate_limits_with_the_configured_interval() {
+    let directory = tempdir().unwrap();
+    let settings = directory.path().join("settings.json");
+    let state = directory.path().join("state");
+    let executable = directory.path().join("herdr-agent-quota");
+    fs::write(
+        &settings,
+        r#"{"statusLine":{"type":"command","command":"echo old"}}"#,
+    )
+    .unwrap();
+
+    claude::apply_at(&settings, &state, &executable).unwrap();
+    let installed: Value = serde_json::from_slice(&fs::read(&settings).unwrap()).unwrap();
+    assert_eq!(installed["statusLine"]["refreshInterval"], 60);
+
+    claude::apply_at_with_refresh_interval(&settings, &state, &executable, 300).unwrap();
+    let customized: Value = serde_json::from_slice(&fs::read(&settings).unwrap()).unwrap();
+    assert_eq!(customized["statusLine"]["refreshInterval"], 300);
+
+    claude::uninstall_at(&settings, &state).unwrap();
+    let restored: Value = serde_json::from_slice(&fs::read(&settings).unwrap()).unwrap();
+    assert_eq!(restored["statusLine"]["command"], "echo old");
+    assert!(restored["statusLine"].get("refreshInterval").is_none());
+}
+
+#[test]
+fn claude_preserves_a_user_owned_refresh_interval_on_first_install() {
+    let directory = tempdir().unwrap();
+    let settings = directory.path().join("settings.json");
+    let state = directory.path().join("state");
+    let executable = directory.path().join("herdr-agent-quota");
+    fs::write(
+        &settings,
+        r#"{"statusLine":{"type":"command","command":"echo old","refreshInterval":15}}"#,
+    )
+    .unwrap();
+
+    claude::apply_at(&settings, &state, &executable).unwrap();
+    let installed: Value = serde_json::from_slice(&fs::read(&settings).unwrap()).unwrap();
+    assert_eq!(installed["statusLine"]["refreshInterval"], 15);
+
+    claude::uninstall_at(&settings, &state).unwrap();
+    let restored: Value = serde_json::from_slice(&fs::read(&settings).unwrap()).unwrap();
+    assert_eq!(restored["statusLine"]["refreshInterval"], 15);
+}
+
+#[test]
 fn repair_migrates_a_previous_backup_from_the_old_state_directory() {
     let directory = tempdir().unwrap();
     let settings = directory.path().join("settings.json");


### PR DESCRIPTION
## Summary
- align Claude's plugin-owned native `statusLine.refreshInterval` with the unified watcher (default 60s; custom intervals update safely)
- render 5h and 7d quota values on one compact, independently colored Herdr row
- keep the existing reset/summary formatter for dashboard and custom summary tokens
- preserve user-owned refresh intervals and restore settings on uninstall

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo clippy --release --all-targets --all-features --locked -- -D warnings`
- `cargo build --release --locked`
- local configure/reload/refresh verified `refreshInterval: 60`, one combined quota row, and Claude metadata `5h 16% due` / `7d 16% 5d23h`
