### PR TITLE
Compact cache diagnostics into one sidebar row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   requests.
 - Quota rows now show compact `5h`/`7d` window labels with minutes below one
   hour, hours and minutes below one day, and days plus hours for longer windows.
+- Cache hit rate and remaining cache TTL now share one short, color-separated
+  sidebar row; the verbose last-activity text is no longer shown.
 - Claude's plugin-owned statusLine now receives the configured global watcher
   interval as its native `refreshInterval`, keeping idle-session reset times
   fresh without an API call or model request; existing user-owned intervals are
@@ -100,8 +102,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - The context row now uses a dedicated violet accent immediately after the
-  provider name. Cache hit and last-activity/TTL rows use separate teal and
-  amber accents, while metadata publication remains capped at sixteen tokens.
+  provider name. Cache hit rate and remaining TTL share one row with separate
+  teal and amber accents, while metadata publication remains capped at sixteen
+  tokens.
 - Quota formatting is centralized in one presentation module shared by the
   sidebar, dashboard, and statusLine fallbacks. Codex remains weekly-only.
 - Five-hour and weekly quota windows now share one compact sidebar row. Herdr

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Agy/Antigravity subscription usage, in Herdr's agent sidebar.
 ● Owner · Claude
   hi                     ← what that pane is actually working on
   context 23%             ← provider-native context percentage
-  cache 99.6% hit         ← cumulative for this session
-  cache last 2m ago · ttl≈58m
+  cache 99.6% · ttl≈58m    ← session hit rate · remaining cache TTL
   5h 100% 3h07m · 7d 31% 2d3h
 ```
 
@@ -188,12 +187,12 @@ not quota token counts. The two Claude windows use compact `5h` and `7d`
 labels on one row; each still keeps its own dynamic health color. Claude and
 Agy also show provider-reported context percentage. When a statusLine transcript
 and session id are available,
-`cache N.N% hit` is the cumulative main-session ratio
-(`read / (fresh + creation + read)`), not the latest turn. The next row shows
-how long ago the latest cache-bearing response arrived and, for Claude, a
-`ttl≈...` estimate from the provider's 5-minute/1-hour bucket. This is local
-diagnostic math, not a server-confirmed expiry; the first session update reads
-the existing transcript once, then later updates read only appended bytes.
+`cache N.N%` is the cumulative main-session ratio
+(`read / (fresh + creation + read)`), not the latest turn. The same row shows,
+for Claude, a `ttl≈...` estimate from the provider's 5-minute/1-hour bucket.
+This is local diagnostic math, not a server-confirmed expiry; the first session
+update reads the existing transcript once, then later updates read only
+appended bytes.
 Codex shows a short session preview from its local state database; its live
 context and cache fields are not queried because the current safe app-server
 connection is quota-only and does not attach to an active thread. Grok's
@@ -226,8 +225,10 @@ row_gap = 1 # herdr-agent-quota
 rows = [
   ["state_icon", "tab", { token = "$quota_provider", bold = true, dim = false }, { token = "$quota_context", fg = "#9b8fd8", bold = true, dim = false }],
   [{ token = "$quota_topic", dim = false }],
-  [{ token = "$quota_cache", fg = "#6fb5b7", bold = true, dim = false }],
-  [{ token = "$quota_cache_ttl", fg = "#cdaa65", bold = true, dim = false }],
+  [
+    { token = "$quota_cache", fg = "#6fb5b7", bold = true, dim = false },
+    { token = "$quota_cache_ttl", fg = "#cdaa65", bold = true, dim = false },
+  ],
   [
     { token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false },
     { token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false },
@@ -251,10 +252,9 @@ rows = [
 - `$quota_context` is the provider-reported context **used** percentage and sits
   directly after the provider name. `$quota_cache` is the cumulative hit rate
   for the main session transcript, not a per-turn value; it is shown to one
-  decimal place so `99.6%` is not rounded to `100%`. `$quota_cache_ttl` shows
-  the elapsed time since the latest cache-bearing assistant response and, when
-  Claude exposes a 5m/1h bucket, the remaining `ttl≈...` estimate. Missing
-  fields are hidden instead of guessed.
+  decimal place so `99.6%` is not rounded to `100%`. `$quota_cache_ttl` is the
+  remaining approximate TTL when Claude exposes a 5m/1h bucket. Both cache
+  values share one row; missing fields are hidden instead of guessed.
 - The context row uses a violet accent (`#9b8fd8`) so context pressure is easy
   to distinguish from the green/amber/red quota runway colors.
 - Each window publishes exactly one styled variant. Herdr renders adjacent

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,8 +15,7 @@ Claude Code、Codex、Grok 和 Agy/Antigravity 的订阅额度。
 ● Owner · Claude
   hi                     ← 这个 pane 当前在做什么
   context 23%             ← provider 原生 context 百分比
-  cache 99.6% hit         ← 整个 session 累计命中率
-  cache last 2m ago · ttl≈58m
+  cache 99.6% · ttl≈58m    ← session 命中率 · 剩余缓存时间
   5h 100% 3h07m · 7d 31% 2d3h
 ```
 
@@ -158,11 +157,10 @@ usage、topic 三类 token，不会覆盖官方 agent 指示。卸载 action 会
 侧栏显示的是**额度剩余百分比**和距离下次额度重置的时间，不是额度 token 数量。
 Claude 的两个窗口会用紧凑的 `5h` 和 `7d` 标签放在同一行，但仍各自保留动态健康色。
 Claude 和 Agy 的 statusLine 有 context 字段时，还会显示当前 context **已用**百分比。
-如果有 statusLine transcript 和 session id，`cache N.N% hit` 是主 session 的累计命中率
-（`read / (fresh + creation + read)`），不是最新一轮；下一行显示最近一次有缓存响应
-距离现在多久。Claude 如果还有明确的 5 分钟/1 小时缓存桶，会显示 `ttl≈...`，这是本地
-近似，不是服务端确认的过期时间。首次 session 更新会读取一次已有 transcript，之后只读
-新增字节。Codex 会显示本地 state database 里的短会话预览；
+如果有 statusLine transcript 和 session id，`cache N.N%` 是主 session 的累计命中率
+（`read / (fresh + creation + read)`），不是最新一轮；同一行在 Claude 有明确的
+5 分钟/1 小时缓存桶时显示剩余 `ttl≈...`，这是本地近似，不是服务端确认的过期时间。
+首次 session 更新会读取一次已有 transcript，之后只读新增字节。Codex 会显示本地 state database 里的短会话预览；
 当前安全的 app-server 连接只查额度，没有绑定活动 thread，因此不猜测 Codex context
 或缓存字段。Grok 当前的 billing 来源没有 context 或缓存字段。没有证据的字段会隐藏，
 不会伪造 `cached expires`：
@@ -171,8 +169,7 @@ Claude 和 Agy 的 statusLine 有 context 字段时，还会显示当前 context
 ● Owner · Claude
   hi
   context 23%
-  cache 99.6% hit
-  cache last 2m ago · ttl≈58m
+  cache 99.6% · ttl≈58m
   5h 100% 3h07m · 7d 31% 2d3h
 ```
 
@@ -201,8 +198,10 @@ row_gap = 1 # herdr-agent-quota
 rows = [
   ["state_icon", "tab", { token = "$quota_provider", bold = true, dim = false }, { token = "$quota_context", fg = "#9b8fd8", bold = true, dim = false }],
   [{ token = "$quota_topic", dim = false }],
-  [{ token = "$quota_cache", fg = "#6fb5b7", bold = true, dim = false }],
-  [{ token = "$quota_cache_ttl", fg = "#cdaa65", bold = true, dim = false }],
+  [
+    { token = "$quota_cache", fg = "#6fb5b7", bold = true, dim = false },
+    { token = "$quota_cache_ttl", fg = "#cdaa65", bold = true, dim = false },
+  ],
   [
     { token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false },
     { token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false },
@@ -223,9 +222,9 @@ rows = [
   其他 provider 仍保持空白。
 - `$quota_context` 显示 provider 报告的 context **已用**百分比，并紧跟在 provider
   名称后面。`$quota_cache` 是主 session transcript 的累计命中率，不是每一轮的比例；
-  固定保留一位小数，避免 `99.6%` 被显示成 `100%`。`$quota_cache_ttl` 显示最近一次
-  有缓存响应距离现在多久；Claude 提供 5m/1h 缓存桶时还会显示剩余的 `ttl≈...`。
-  字段缺失时隐藏，不做猜测。
+  固定保留一位小数，避免 `99.6%` 被显示成 `100%`。`$quota_cache_ttl` 是 Claude
+  提供 5m/1h 缓存桶时的剩余近似 TTL。两个 cache 值共用一行；字段缺失时隐藏，
+  不做猜测。
 - context 行使用紫色强调色（`#9b8fd8`），与额度续航的绿/琥珀/红色区分开。
 - 每个窗口只发布一个样式 token。Herdr 会把同一行相邻 token 自动用 `·`
   分隔，并在 token 缺失时移除对应分隔符，所以 5h/7d 会紧凑地显示在一行，

--- a/docs/plans/herdr-agent-quota-implementation.md
+++ b/docs/plans/herdr-agent-quota-implementation.md
@@ -106,8 +106,8 @@ longer sent as a separate metadata value:
 - `$quota_context`: provider-reported context-used percentage when available.
 - `$quota_cache`: one-decimal cumulative cache hit rate for the main session
   transcript when a session boundary is available.
-- `$quota_cache_ttl`: elapsed time since the latest cache-bearing response and
-  an explicitly approximate provider TTL estimate when supported.
+- `$quota_cache_ttl`: the remaining approximate provider TTL when supported;
+  it shares the sidebar row with `$quota_cache`.
 - `$quota_5h`: compact five-hour remaining value and reset ETA when exposed.
 - `$quota_week`: compact weekly remaining value and reset ETA.
 - `$quota_summary`: window-driven compact remaining values and reset ETAs.

--- a/docs/research/cache-observability-open-source.md
+++ b/docs/research/cache-observability-open-source.md
@@ -18,7 +18,7 @@
 
 3. **“缓存还剩几分钟”只有 Claude 可以做一个近似显示，而且不应作为准确 expiry。** Claude API 返回 5m/1h 写入桶，官方说明缓存使用时会刷新，且 TTL 从请求开始计时；statusLine 本身没有 entry 的 `created_at`/`expires_at`。开源项目通过读取当前会话 transcript 的尾部推断 TTL 桶和最近 timestamp，但这仍是近似值，不能代表多个 cache breakpoint 的统一到期时间。
 4. **Codex/OpenAI、Agy、Grok 当前没有可供本插件诚实显示的动态 cache-entry expiry。** OpenAI 的 `prompt_cache_options.ttl` 是请求策略（不是活动 cache entry 的剩余时间）；Agy/Grok status payload 只有 token 计数；Codex token-usage event 也没有 expiry timestamp。
-5. **实现把 context、session cache 命中率、最近发送距今与 TTL 估算拆成三行。** `$quota_context` 紧跟 provider 名称；`$quota_cache` 显示整个主 session 的累计命中率（固定一位小数，避免 99.6% 被四舍五入成 100%）；`$quota_cache_ttl` 显示 `cache last 2m ago · ttl≈58m`。计数来自正在运行的 CLI/statusLine 输入和本地 transcript，不联网、不登录、不消耗模型 token。Claude 在 statusLine 同时提供明确 5m/1h bucket 时显示带 `≈` 的 TTL；证据不足只显示已知的 last 时间或隐藏未知部分。
+5. **实现把 context 与 cache 诊断拆开，但 cache 命中率和剩余 TTL 共用一行。** `$quota_context` 紧跟 provider 名称；`$quota_cache` 显示整个主 session 的累计命中率（固定一位小数，避免 99.6% 被四舍五入成 100%）；`$quota_cache_ttl` 只显示 `ttl≈58m`。计数来自正在运行的 CLI/statusLine 输入和本地 transcript，不联网、不登录、不消耗模型 token。Claude 在 statusLine 同时提供明确 5m/1h bucket 时显示带 `≈` 的 TTL；证据不足就隐藏未知部分。
 
 ## 四个 provider 的可获取字段
 
@@ -115,8 +115,8 @@ Antigravity CLI v1.1.7 起在 `json`/`stream-json` usage 中增加 `cache_read_t
 
 ### 有界 TTL 诊断层
 
-本项目采用 ilia 项目的 bucket/timestamp 口径：session 首次建立累计时读取 transcript，之后每次只读新增字节；TTL 行显示
-`cache last 2m ago · ttl≈54m` 这类带剩余时间的本地估算（5m/1h bucket），不显示“expires in”。任何解析失败、compact、字段缺失
+本项目采用 ilia 项目的 bucket/timestamp 口径：session 首次建立累计时读取 transcript，之后每次只读新增字节；TTL token 显示
+`ttl≈54m` 这类带剩余时间的本地估算（5m/1h bucket），不显示“expires in”或最近发送时间。任何解析失败、compact、字段缺失
 都不生成新估算；跨 session 不继承旧 TTL，避免误报。该扫描发生在已有 statusLine hook 内，不是全局 watcher，也不读取 pane。
 
 ### 明确不做

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -520,21 +520,21 @@ fn append_quota_rows(rows: &mut Array) {
         Some(false),
     )));
 
-    rows.push(Value::Array(styled_row(
-        "$quota_cache",
-        Some(CACHE_COLOR),
-        Some(true),
-        Some(false),
-    )));
-
-    rows.push(Value::Array(styled_row(
-        "$quota_cache_ttl",
-        Some(CACHE_TTL_COLOR),
-        Some(true),
-        Some(false),
-    )));
+    append_cache_row(rows);
 
     append_window_row(rows);
+}
+
+fn append_cache_row(rows: &mut Array) {
+    rows.push(Value::Array(Array::from_iter([
+        styled_token("$quota_cache", Some(CACHE_COLOR), Some(true), Some(false)),
+        styled_token(
+            "$quota_cache_ttl",
+            Some(CACHE_TTL_COLOR),
+            Some(true),
+            Some(false),
+        ),
+    ])));
 }
 
 fn append_window_row(rows: &mut Array) {
@@ -624,6 +624,25 @@ rows = [["state_icon", "agent"]]
                 && items
                     .iter()
                     .any(|item| configured_token_name(item) == Some("$quota_week_normal"))
+        }));
+    }
+
+    #[test]
+    fn puts_cache_rate_and_remaining_ttl_on_one_row() {
+        let updated =
+            add_quota_row("[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n").unwrap();
+        let document = updated.parse::<DocumentMut>().unwrap();
+        let rows = document["ui"]["sidebar"]["agents"]["rows"]
+            .as_array()
+            .unwrap();
+        assert!(rows.iter().any(|row| {
+            let items = row.as_array().unwrap();
+            items
+                .iter()
+                .any(|item| configured_token_name(item) == Some("$quota_cache"))
+                && items
+                    .iter()
+                    .any(|item| configured_token_name(item) == Some("$quota_cache_ttl"))
         }));
     }
 

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -113,7 +113,7 @@ fn sidebar_cache(snapshot: &ProviderSnapshot) -> String {
     else {
         return String::new();
     };
-    format!("cache {:.1}% hit", totals.hit_percent)
+    format!("cache {:.1}%", totals.hit_percent)
 }
 
 fn sidebar_cache_ttl(snapshot: &ProviderSnapshot, now_unix: u64) -> String {
@@ -124,16 +124,10 @@ fn sidebar_cache_ttl(snapshot: &ProviderSnapshot, now_unix: u64) -> String {
     else {
         return String::new();
     };
-    let Some(last_activity) = cache.last_activity_unix else {
-        return String::new();
-    };
-    let elapsed = now_unix.saturating_sub(last_activity);
-    let mut value = format!("cache last {} ago", format_elapsed(elapsed));
-    if let Some(remaining) = cache.remaining_ttl_seconds(now_unix) {
-        value.push_str(" · ttl≈");
-        value.push_str(&format_ttl(remaining));
-    }
-    value
+    cache
+        .remaining_ttl_seconds(now_unix)
+        .map(|remaining| format!("ttl≈{}", format_ttl(remaining)))
+        .unwrap_or_default()
 }
 
 fn format_window(window: &UsageWindow, now_unix: u64, include_left: bool) -> String {
@@ -185,13 +179,6 @@ fn format_ttl(seconds: u64) -> String {
     let minutes = seconds / 60;
     if (60..24 * 60).contains(&minutes) && minutes.is_multiple_of(60) {
         return format!("{}h", minutes / 60);
-    }
-    format_duration(seconds)
-}
-
-fn format_elapsed(seconds: u64) -> String {
-    if seconds < 60 {
-        return "<1m".to_string();
     }
     format_duration(seconds)
 }
@@ -321,8 +308,8 @@ mod tests {
         .with_context(Some(context));
         let values = MetadataTokens::from_snapshot(&snapshot, 0);
         assert_eq!(values.quota_context, "context 24%");
-        assert_eq!(values.quota_cache, "cache 80.0% hit");
-        assert_eq!(values.quota_cache_ttl, "cache last <1m ago · ttl≈1h");
+        assert_eq!(values.quota_cache, "cache 80.0%");
+        assert_eq!(values.quota_cache_ttl, "ttl≈1h");
     }
 
     #[test]
@@ -340,6 +327,6 @@ mod tests {
                 .with_cache(Some(cache)),
         ));
         let values = MetadataTokens::from_snapshot(&snapshot, 0);
-        assert_eq!(values.quota_cache, "cache 99.2% hit");
+        assert_eq!(values.quota_cache, "cache 99.2%");
     }
 }


### PR DESCRIPTION
## Summary
- combine `$quota_cache` and `$quota_cache_ttl` into one styled Herdr row
- shorten the visible values to `cache 96.9% · ttl≈1m`
- remove verbose `cache last ... ago` text while retaining the bounded local TTL estimate
- keep missing cache fields hidden and preserve the separate teal/amber token colors

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo clippy --release --all-targets --all-features --locked -- -D warnings`
- `cargo build --release --locked`
- local configure/reload/refresh verified one cache row and metadata `cache 96.9%` + `ttl≈0m`
