### PR TITLE
fix: handle expired cache and weekly-only quota displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   plugin-owned copies are removed during configure because the single global
   watcher now covers active and settled turns without spawning one command per
   tool call.
+- Expired cache TTL estimates now render as a red `no cached` diagnostic, and
+  Claude payloads without quota fields clear stale window values instead of
+  leaving an old weekly reset on the sidebar.
+- Weekly-only providers now use the readable `week ... reset ...` label; the
+  compact `5h`/`7d` form remains for providers that expose both windows.
 
 - Agent topics now come only from the latest user prompt in pane output. Native
   `Thinking`/`Executing` titles and other AI status text are no longer published

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ rows = [
   [
     { token = "$quota_cache", fg = "#6fb5b7", bold = true, dim = false },
     { token = "$quota_cache_ttl", fg = "#cdaa65", bold = true, dim = false },
+    { token = "$quota_error", fg = "#ca6470", bold = true, dim = false },
   ],
   [
     { token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false },
@@ -253,8 +254,9 @@ rows = [
   directly after the provider name. `$quota_cache` is the cumulative hit rate
   for the main session transcript, not a per-turn value; it is shown to one
   decimal place so `99.6%` is not rounded to `100%`. `$quota_cache_ttl` is the
-  remaining approximate TTL when Claude exposes a 5m/1h bucket. Both cache
-  values share one row; missing fields are hidden instead of guessed.
+  remaining approximate TTL when Claude exposes a 5m/1h bucket; when it reaches
+  zero, the red `$quota_error` token says `no cached`. Both cache values share
+  one row; missing fields are hidden instead of guessed.
 - The context row uses a violet accent (`#9b8fd8`) so context pressure is easy
   to distinguish from the green/amber/red quota runway colors.
 - Each window publishes exactly one styled variant. Herdr renders adjacent

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -201,6 +201,7 @@ rows = [
   [
     { token = "$quota_cache", fg = "#6fb5b7", bold = true, dim = false },
     { token = "$quota_cache_ttl", fg = "#cdaa65", bold = true, dim = false },
+    { token = "$quota_error", fg = "#ca6470", bold = true, dim = false },
   ],
   [
     { token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false },
@@ -223,8 +224,8 @@ rows = [
 - `$quota_context` 显示 provider 报告的 context **已用**百分比，并紧跟在 provider
   名称后面。`$quota_cache` 是主 session transcript 的累计命中率，不是每一轮的比例；
   固定保留一位小数，避免 `99.6%` 被显示成 `100%`。`$quota_cache_ttl` 是 Claude
-  提供 5m/1h 缓存桶时的剩余近似 TTL。两个 cache 值共用一行；字段缺失时隐藏，
-  不做猜测。
+  提供 5m/1h 缓存桶时的剩余近似 TTL；TTL 归零时用红色 `$quota_error` 显示
+  `no cached`。两个 cache 值共用一行；字段缺失时隐藏，不做猜测。
 - context 行使用紫色强调色（`#9b8fd8`），与额度续航的绿/琥珀/红色区分开。
 - 每个窗口只发布一个样式 token。Herdr 会把同一行相邻 token 自动用 `·`
   分隔，并在 token 缺失时移除对应分隔符，所以 5h/7d 会紧凑地显示在一行，

--- a/docs/plans/herdr-agent-quota-implementation.md
+++ b/docs/plans/herdr-agent-quota-implementation.md
@@ -108,6 +108,8 @@ longer sent as a separate metadata value:
   transcript when a session boundary is available.
 - `$quota_cache_ttl`: the remaining approximate provider TTL when supported;
   it shares the sidebar row with `$quota_cache`.
+- `$quota_error`: short red diagnostics such as `no cached` when an estimated
+  cache TTL has expired.
 - `$quota_5h`: compact five-hour remaining value and reset ETA when exposed.
 - `$quota_week`: compact weekly remaining value and reset ETA.
 - `$quota_summary`: window-driven compact remaining values and reset ETAs.

--- a/docs/research/cache-observability-open-source.md
+++ b/docs/research/cache-observability-open-source.md
@@ -116,8 +116,8 @@ Antigravity CLI v1.1.7 起在 `json`/`stream-json` usage 中增加 `cache_read_t
 ### 有界 TTL 诊断层
 
 本项目采用 ilia 项目的 bucket/timestamp 口径：session 首次建立累计时读取 transcript，之后每次只读新增字节；TTL token 显示
-`ttl≈54m` 这类带剩余时间的本地估算（5m/1h bucket），不显示“expires in”或最近发送时间。任何解析失败、compact、字段缺失
-都不生成新估算；跨 session 不继承旧 TTL，避免误报。该扫描发生在已有 statusLine hook 内，不是全局 watcher，也不读取 pane。
+`ttl≈54m` 这类带剩余时间的本地估算（5m/1h bucket），不显示“expires in”或最近发送时间；归零后改显示红色 `no cached`。
+任何解析失败、compact、字段缺失都不生成新估算；跨 session 不继承旧 TTL，避免误报。该扫描发生在已有 statusLine hook 内，不是全局 watcher，也不读取 pane。
 
 ### 明确不做
 

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Item, Table, Value};
 
-const QUOTA_ROW_MARKERS: [&str; 22] = [
+const QUOTA_ROW_MARKERS: [&str; 23] = [
     "$quota_badge",
     "$quota_state",
     "$quota_icon",
@@ -14,6 +14,7 @@ const QUOTA_ROW_MARKERS: [&str; 22] = [
     "$quota_context",
     "$quota_cache",
     "$quota_cache_ttl",
+    "$quota_error",
     "$quota_topic",
     "$quota_5h",
     "$quota_week",
@@ -534,6 +535,12 @@ fn append_cache_row(rows: &mut Array) {
             Some(true),
             Some(false),
         ),
+        styled_token(
+            "$quota_error",
+            Some(QUOTA_DANGER_COLOR),
+            Some(true),
+            Some(false),
+        ),
     ])));
 }
 
@@ -644,6 +651,23 @@ rows = [["state_icon", "agent"]]
                     .iter()
                     .any(|item| configured_token_name(item) == Some("$quota_cache_ttl"))
         }));
+    }
+
+    #[test]
+    fn gives_no_cached_a_red_token_without_spending_an_extra_metadata_slot() {
+        let updated =
+            add_quota_row("[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n").unwrap();
+        let document = updated.parse::<DocumentMut>().unwrap();
+        let rows = document["ui"]["sidebar"]["agents"]["rows"]
+            .as_array()
+            .unwrap();
+        assert!(rows.iter().any(|row| {
+            let items = row.as_array().unwrap();
+            items
+                .iter()
+                .any(|item| configured_token_name(item) == Some("$quota_error"))
+        }));
+        assert!(updated.contains("fg = \"#ca6470\""));
     }
 
     #[test]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -34,7 +34,7 @@ impl MetadataTokens {
             quota_context: sidebar_context(snapshot),
             quota_cache: sidebar_cache(snapshot),
             quota_cache_ttl: sidebar_cache_ttl(snapshot, now_unix),
-            quota_error: None,
+            quota_error: sidebar_cache_error(snapshot, now_unix),
         }
     }
 
@@ -93,7 +93,13 @@ fn summary(snapshot: &ProviderSnapshot, now_unix: u64, include_left: bool) -> St
 fn sidebar_window(snapshot: &ProviderSnapshot, kind: WindowKind, now_unix: u64) -> String {
     snapshot
         .window(kind)
-        .map(|window| format_compact_window(window, now_unix))
+        .map(|window| {
+            if kind == WindowKind::Weekly && snapshot.window(WindowKind::FiveHour).is_none() {
+                format_window(window, now_unix, false)
+            } else {
+                format_compact_window(window, now_unix)
+            }
+        })
         .unwrap_or_default()
 }
 
@@ -126,8 +132,19 @@ fn sidebar_cache_ttl(snapshot: &ProviderSnapshot, now_unix: u64) -> String {
     };
     cache
         .remaining_ttl_seconds(now_unix)
+        .filter(|remaining| *remaining > 0)
         .map(|remaining| format!("ttl≈{}", format_ttl(remaining)))
         .unwrap_or_default()
+}
+
+fn sidebar_cache_error(snapshot: &ProviderSnapshot, now_unix: u64) -> Option<String> {
+    snapshot
+        .context
+        .as_ref()
+        .and_then(|context| context.cache.as_ref())
+        .and_then(|cache| cache.remaining_ttl_seconds(now_unix))
+        .filter(|remaining| *remaining == 0)
+        .map(|_| "no cached".to_string())
 }
 
 fn format_window(window: &UsageWindow, now_unix: u64, include_left: bool) -> String {
@@ -310,6 +327,38 @@ mod tests {
         assert_eq!(values.quota_context, "context 24%");
         assert_eq!(values.quota_cache, "cache 80.0%");
         assert_eq!(values.quota_cache_ttl, "ttl≈1h");
+        assert_eq!(values.quota_error, None);
+    }
+
+    #[test]
+    fn expired_cache_ttl_is_reported_as_no_cached() {
+        let cache = crate::model::CacheUsage::from_token_counts(100, 800, 100)
+            .unwrap()
+            .with_ttl_estimate(60, 0)
+            .with_session_totals(
+                crate::model::CacheTotals::from_token_counts(100, 800, 100),
+                "session-1",
+                1,
+            );
+        let snapshot = ProviderSnapshot::new(Provider::Claude, vec![], 0).with_context(Some(
+            crate::model::ContextUsage::new(23.5)
+                .unwrap()
+                .with_cache(Some(cache)),
+        ));
+        let values = MetadataTokens::from_snapshot(&snapshot, 61);
+        assert_eq!(values.quota_cache_ttl, "");
+        assert_eq!(values.quota_error.as_deref(), Some("no cached"));
+    }
+
+    #[test]
+    fn weekly_only_sidebar_window_keeps_the_readable_reset_label() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Codex,
+            vec![window(WindowKind::Weekly, 31.0, 518_400)],
+            0,
+        );
+        let values = MetadataTokens::from_snapshot(&snapshot, 0);
+        assert_eq!(values.quota_week, "week 69% reset 6d0h");
     }
 
     #[test]

--- a/src/providers/claude.rs
+++ b/src/providers/claude.rs
@@ -8,9 +8,17 @@ pub fn parse_statusline(
     value: &Value,
     fetched_at_unix: u64,
 ) -> std::result::Result<ProviderSnapshot, ProviderError> {
-    let limits = value
-        .get("rate_limits")
-        .ok_or_else(|| ProviderError::UnsupportedResponse("missing rate_limits".to_string()))?;
+    let context = parse_context(
+        value
+            .get("context_window")
+            .or_else(|| value.get("contextWindow")),
+    )
+    .unwrap_or(None);
+    let Some(limits) = value.get("rate_limits") else {
+        return Ok(
+            ProviderSnapshot::new(Provider::Claude, vec![], fetched_at_unix).with_context(context),
+        );
+    };
     let mut windows = Vec::new();
     if let Some(window) = parse_window(limits.get("five_hour"), WindowKind::FiveHour)? {
         windows.push(window);
@@ -19,20 +27,11 @@ pub fn parse_statusline(
         windows.push(window);
     }
     if windows.is_empty() {
-        return Err(ProviderError::UnsupportedResponse(
-            "rate_limits has no supported windows".to_string(),
-        ));
+        return Ok(
+            ProviderSnapshot::new(Provider::Claude, vec![], fetched_at_unix).with_context(context),
+        );
     }
-    Ok(
-        ProviderSnapshot::new(Provider::Claude, windows, fetched_at_unix).with_context(
-            parse_context(
-                value
-                    .get("context_window")
-                    .or_else(|| value.get("contextWindow")),
-            )
-            .unwrap_or(None),
-        ),
-    )
+    Ok(ProviderSnapshot::new(Provider::Claude, windows, fetched_at_unix).with_context(context))
 }
 
 fn parse_window(
@@ -167,11 +166,25 @@ mod tests {
     #[test]
     fn allows_a_missing_claude_window() {
         let value = json!({"rate_limits": {"five_hour": null}});
-        assert!(parse_statusline(&value, 1).is_err());
+        assert!(parse_statusline(&value, 1).unwrap().windows.is_empty());
         let value = json!({
             "rate_limits": {"seven_day": {"used_percentage": 25.0}}
         });
         assert_eq!(parse_statusline(&value, 1).unwrap().windows.len(), 1);
+    }
+
+    #[test]
+    fn accepts_a_payload_without_rate_limits_to_clear_a_stale_quota() {
+        let value = json!({"context_window": {"used_percentage": 43.0}});
+        let snapshot = parse_statusline(&value, 1).unwrap();
+        assert!(snapshot.windows.is_empty());
+        assert_eq!(
+            snapshot
+                .context
+                .as_ref()
+                .map(|context| context.used_percent),
+            Some(43.0)
+        );
     }
 
     #[test]

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -200,6 +200,31 @@ fn claude_cache_is_published_by_refresh_event() {
 }
 
 #[test]
+fn claude_statusline_without_rate_limits_clears_stale_quota_windows() {
+    let state = tempdir().unwrap();
+    let (herdr_stub, _herdr_log) = install_herdr_stub(
+        state.path(),
+        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1"}]}}"#,
+    );
+    run_claude_collector(
+        state.path(),
+        &herdr_stub,
+        include_bytes!("fixtures/claude/statusline-both.json"),
+    );
+    run_claude_collector(
+        state.path(),
+        &herdr_stub,
+        br#"{"context_window":{"used_percentage":43.0}}"#,
+    );
+
+    let snapshot: serde_json::Value =
+        serde_json::from_slice(&fs::read(state.path().join("claude-statusline.json")).unwrap())
+            .unwrap();
+    assert_eq!(snapshot["windows"].as_array().unwrap().len(), 0);
+    assert_eq!(snapshot["context"]["used_percent"], 43.0);
+}
+
+#[test]
 fn statusline_without_context_keeps_the_last_context_snapshot() {
     let state = tempdir().unwrap();
     let (herdr_stub, herdr_log) = install_herdr_stub(
@@ -223,7 +248,7 @@ fn statusline_without_context_keeps_the_last_context_snapshot() {
     run_claude_refresh(state.path(), &herdr_stub);
     let report = fs::read_to_string(herdr_log).unwrap();
     assert!(report.contains("quota_context=context 24%"));
-    assert!(report.contains("quota_week=7d 72%"));
+    assert!(report.contains("quota_week=week 72%"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- render expired cache TTL as a red `no cached` token while keeping cache hit rate and TTL in one row
- clear stale Claude quota windows when a valid statusLine payload omits `rate_limits`
- use readable `week ... reset ...` labels for weekly-only providers; keep compact `5h`/`7d` for two-window providers
- keep the Herdr configuration migration idempotent and document the new token

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo clippy --release --all-targets --all-features --locked -- -D warnings`
- local release configure/refresh smoke check
