### PR TITLE
fix: make statusline collection fail open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Claude/Agy statusLine collectors now publish atomic observations without
+  waiting on refresh work. Provider refreshes use independent non-blocking
+  leases, and chained user statusLine commands run in a bounded process group
+  so a stalled command cannot leak processes or wedge later invocations.
 - Topic extraction now reads the pane's visible screen instead of rebuilding its
   wrapped scrollback. The old `--source recent` read took 4.45s and repainted the
   pane once per call, which is what the user saw as scrolling; `--source visible`

--- a/README.md
+++ b/README.md
@@ -137,9 +137,11 @@ HERDR_AGENT_QUOTA_WATCH_INTERVAL_SECONDS=300 \
   herdr plugin action invoke herdr-agent-quota.configure
 ```
 
-Each poll uses one global coordination lock and one `herdr agent list` call.
-Provider network fetches are independently capped at one per 60 seconds by the
-existing refresh markers, even if a shorter custom poll interval is requested.
+Each poll uses one non-blocking watcher lease and one `herdr agent list` call.
+Provider refreshes use independent non-blocking leases, so a slow provider
+cannot stall another provider or a statusLine collector. Network fetches are
+independently capped at one per 60 seconds by the existing refresh markers, even
+if a shorter custom poll interval is requested.
 The watcher never sends prompts, starts a new login, refreshes credentials, or
 consumes model/chat tokens; a manual `--force` refresh is the explicit exception.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -116,8 +116,9 @@ HERDR_AGENT_QUOTA_WATCH_INTERVAL_SECONDS=300 \
   herdr plugin action invoke herdr-agent-quota.configure
 ```
 
-每轮只使用一个全局协调锁和一次 `herdr agent list`。各 provider 的网络查询仍由
-原有刷新标记独立限制为每 60 秒最多一次，即使用户把轮询间隔设得更短也不会突破。
+每轮只使用一个非阻塞 watcher lease 和一次 `herdr agent list`。各 provider 使用
+独立的非阻塞刷新 lease，慢 provider 不会阻塞其他 provider 或 statusLine 采集器。
+网络查询仍由原有刷新标记独立限制为每 60 秒最多一次，即使用户把轮询间隔设得更短也不会突破。
 watcher 不发送 prompt、不重新登录、不刷新凭证，也不会消耗模型/对话 token；只有用户
 明确执行手动 `--force` 刷新时才绕过这层去抖。
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,6 +1,8 @@
-use crate::model::{Provider, ProviderSnapshot};
+use crate::model::{ContextUsage, Provider, ProviderSnapshot};
 use anyhow::{Context, Result};
 use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::fs::{self, File, OpenOptions, TryLockError};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -14,6 +16,12 @@ const WATCH_INTERVAL_FILE: &str = "watch-interval-seconds";
 #[derive(Debug, Clone)]
 pub struct CacheStore {
     root: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatuslineObservation {
+    pub snapshot: ProviderSnapshot,
+    pub payload: Value,
 }
 
 impl CacheStore {
@@ -61,20 +69,64 @@ impl CacheStore {
             std::process::id()
         ));
         let bytes = serde_json::to_vec_pretty(snapshot).context("serialize quota snapshot")?;
-        fs::write(&temporary, bytes).with_context(|| format!("write {}", temporary.display()))?;
-        if let Err(error) = fs::rename(&temporary, &destination) {
-            // Otherwise a failed rename leaves the scratch file behind, and
-            // every later refresh adds another one.
-            let _ = fs::remove_file(&temporary);
-            return Err(error).with_context(|| {
-                format!(
-                    "atomically replace {} with {}",
-                    destination.display(),
-                    temporary.display()
-                )
-            });
+        Self::atomic_replace(&destination, &temporary, bytes)
+    }
+
+    /// Store the latest statusLine observation without coordinating with a
+    /// refresh. The statusLine hook is a latency-sensitive producer; its only
+    /// shared-state operation is an atomic last-observation replacement.
+    pub fn save_statusline_observation(
+        &self,
+        provider: Provider,
+        mut snapshot: ProviderSnapshot,
+        observation: &Value,
+    ) -> Result<()> {
+        self.ensure()?;
+        let session_id = observation
+            .get("session_id")
+            .or_else(|| observation.get("sessionId"))
+            .and_then(Value::as_str);
+        if let Some(session_id) = session_id {
+            if let Some(cache) = snapshot
+                .context
+                .as_mut()
+                .and_then(|context| context.cache.as_mut())
+            {
+                cache.session_id = Some(session_id.to_string());
+            }
         }
-        Ok(())
+        let previous = self
+            .load_statusline_observation(provider)
+            .ok()
+            .flatten()
+            .and_then(|observation| observation.snapshot.context);
+        merge_preserved_context(&mut snapshot, previous, session_id);
+        let saved = StatuslineObservation {
+            snapshot,
+            payload: observation.clone(),
+        };
+        let destination = self.statusline_observation_path(provider);
+        let temporary = self.root.join(format!(
+            ".{}.observation.{}.tmp",
+            provider.source(),
+            std::process::id()
+        ));
+        let bytes = serde_json::to_vec(&saved).context("serialize statusLine observation")?;
+        Self::atomic_replace(&destination, &temporary, bytes)
+    }
+
+    pub fn load_statusline_observation(
+        &self,
+        provider: Provider,
+    ) -> Result<Option<StatuslineObservation>> {
+        let path = self.statusline_observation_path(provider);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let bytes = fs::read(&path).with_context(|| format!("read {}", path.display()))?;
+        let observation = serde_json::from_slice(&bytes)
+            .with_context(|| format!("parse {} observation", provider.source()))?;
+        Ok(Some(observation))
     }
 
     /// StatusLine payloads may temporarily omit context (before the first
@@ -103,101 +155,13 @@ impl CacheStore {
         }
         // A malformed/temporarily unreadable old snapshot must not prevent a
         // fresh statusLine value from replacing it.
-        if let Some(previous) = self
+        let previous = self
             .load(snapshot.provider)
             .ok()
             .flatten()
-            .and_then(|snapshot| snapshot.context)
-        {
-            match (&mut snapshot.context, previous) {
-                (None, mut previous) => {
-                    let same_session = session_id.is_some_and(|session_id| {
-                        previous
-                            .cache
-                            .as_ref()
-                            .and_then(|cache| cache.session_id.as_deref())
-                            == Some(session_id)
-                    });
-                    if !same_session {
-                        if let Some(cache) = previous.cache.as_mut() {
-                            let clear_ttl = cache.session_id.is_some() || session_id.is_some();
-                            strip_session_cache_state(cache, clear_ttl);
-                        }
-                    }
-                    snapshot.context = Some(previous);
-                }
-                (Some(current), previous) => {
-                    if current.cache.is_none() {
-                        let same_session = session_id.is_some_and(|session_id| {
-                            previous
-                                .cache
-                                .as_ref()
-                                .and_then(|cache| cache.session_id.as_deref())
-                                == Some(session_id)
-                        });
-                        let mut previous_cache = previous.cache;
-                        if !same_session {
-                            if let Some(cache) = previous_cache.as_mut() {
-                                strip_session_cache_state(
-                                    cache,
-                                    cache.session_id.is_some() || session_id.is_some(),
-                                );
-                            }
-                        }
-                        current.cache = previous_cache;
-                    } else if let (Some(cache), Some(previous_cache)) =
-                        (&mut current.cache, previous.cache)
-                    {
-                        let same_session = cache.session_id.is_some()
-                            && cache.session_id == previous_cache.session_id
-                            && session_id.is_none_or(|session_id| {
-                                cache.session_id.as_deref() == Some(session_id)
-                            });
-                        if same_session {
-                            if cache.session_totals.is_none() {
-                                cache.session_totals = previous_cache.session_totals;
-                            }
-                            if cache.transcript_offset == 0 {
-                                cache.transcript_offset = previous_cache.transcript_offset;
-                            }
-                        }
-                        let can_preserve_ttl = same_session
-                            || (session_id.is_none()
-                                && cache.session_id.is_none()
-                                && previous_cache.session_id.is_none());
-                        if can_preserve_ttl {
-                            if cache.ttl_seconds.is_none() {
-                                cache.ttl_seconds = previous_cache.ttl_seconds;
-                            }
-                            if cache.last_activity_unix.is_none() {
-                                cache.last_activity_unix = previous_cache.last_activity_unix;
-                            }
-                        }
-                    }
-                }
-            }
-        }
+            .and_then(|snapshot| snapshot.context);
+        merge_preserved_context(&mut snapshot, previous, session_id);
         self.save(&snapshot)
-    }
-
-    pub fn with_lock<T>(&self, operation: impl FnOnce() -> Result<T>) -> Result<T> {
-        self.ensure()?;
-        let path = self.root.join("refresh.lock");
-        let file = OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .truncate(false)
-            .open(&path)
-            .with_context(|| format!("open {}", path.display()))?;
-        file.lock().context("lock refresh state")?;
-        let result = operation();
-        let unlock_result = file.unlock().context("unlock refresh state");
-        match (result, unlock_result) {
-            (Ok(value), Ok(())) => Ok(value),
-            (Err(error), _) => Err(error),
-            (Ok(_), Err(error)) => Err(error),
-        }
     }
 
     /// Try to claim a named long-running coordination lock.
@@ -221,6 +185,12 @@ impl CacheStore {
             Err(TryLockError::WouldBlock) => Ok(None),
             Err(error) => Err(error).with_context(|| format!("lock {}", path.display())),
         }
+    }
+
+    /// Claim a provider refresh lease without making a statusLine or event
+    /// caller wait behind another provider's slow I/O.
+    pub fn try_lock_provider_refresh(&self, provider: Provider) -> Result<Option<File>> {
+        self.try_lock_named(&format!("{}.refresh.lock", provider.source()))
     }
 
     pub fn stop_turn_watchers(&self) -> Result<()> {
@@ -337,6 +307,28 @@ impl CacheStore {
         self.root.join(format!("{}.json", provider.source()))
     }
 
+    fn statusline_observation_path(&self, provider: Provider) -> PathBuf {
+        self.root
+            .join(format!("{}.observation.json", provider.source()))
+    }
+
+    fn atomic_replace(destination: &Path, temporary: &Path, bytes: Vec<u8>) -> Result<()> {
+        fs::write(temporary, bytes).with_context(|| format!("write {}", temporary.display()))?;
+        if let Err(error) = fs::rename(temporary, destination) {
+            // Otherwise a failed rename leaves the scratch file behind, and
+            // every later refresh adds another one.
+            let _ = fs::remove_file(temporary);
+            return Err(error).with_context(|| {
+                format!(
+                    "atomically replace {} with {}",
+                    destination.display(),
+                    temporary.display()
+                )
+            });
+        }
+        Ok(())
+    }
+
     fn refresh_marker_path(&self, provider: Provider) -> PathBuf {
         self.root.join(format!("{}.refresh", provider.source()))
     }
@@ -362,10 +354,77 @@ fn strip_session_cache_state(cache: &mut crate::model::CacheUsage, clear_ttl: bo
     }
 }
 
+fn merge_preserved_context(
+    snapshot: &mut ProviderSnapshot,
+    previous: Option<ContextUsage>,
+    session_id: Option<&str>,
+) {
+    let Some(previous_context) = previous else {
+        return;
+    };
+    match (&mut snapshot.context, previous_context) {
+        (None, mut previous_context) => {
+            if let Some(cache) = previous_context.cache.as_mut() {
+                let same_session = session_id
+                    .is_some_and(|session_id| cache.session_id.as_deref() == Some(session_id));
+                if !same_session {
+                    let clear_ttl = cache.session_id.is_some() || session_id.is_some();
+                    strip_session_cache_state(cache, clear_ttl);
+                }
+            }
+            snapshot.context = Some(previous_context);
+        }
+        (Some(current), previous_context) if current.cache.is_none() => {
+            let mut previous_cache = previous_context.cache.clone();
+            let same_session = session_id.is_some_and(|session_id| {
+                previous_cache
+                    .as_ref()
+                    .and_then(|cache| cache.session_id.as_deref())
+                    == Some(session_id)
+            });
+            if !same_session {
+                if let Some(cache) = previous_cache.as_mut() {
+                    let clear_ttl = cache.session_id.is_some() || session_id.is_some();
+                    strip_session_cache_state(cache, clear_ttl);
+                }
+            }
+            current.cache = previous_cache;
+        }
+        (Some(current), previous_context) => {
+            let Some(current_cache) = current.cache.as_mut() else {
+                return;
+            };
+            let Some(previous_cache) = previous_context.cache.as_ref() else {
+                return;
+            };
+            let same_session = current_cache.session_id.is_some()
+                && current_cache.session_id == previous_cache.session_id
+                && session_id.is_none_or(|session_id| {
+                    current_cache.session_id.as_deref() == Some(session_id)
+                });
+            if same_session {
+                if current_cache.session_totals.is_none() {
+                    current_cache.session_totals = previous_cache.session_totals.clone();
+                }
+                if current_cache.transcript_offset == 0 {
+                    current_cache.transcript_offset = previous_cache.transcript_offset;
+                }
+                if current_cache.ttl_seconds.is_none() {
+                    current_cache.ttl_seconds = previous_cache.ttl_seconds;
+                }
+                if current_cache.last_activity_unix.is_none() {
+                    current_cache.last_activity_unix = previous_cache.last_activity_unix;
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::model::{CacheUsage, ContextUsage, Provider, UsageWindow, WindowKind};
+    use serde_json::json;
     use tempfile::tempdir;
 
     fn snapshot() -> ProviderSnapshot {
@@ -382,6 +441,41 @@ mod tests {
         let cache = CacheStore::new(directory.path());
         cache.save(&snapshot()).unwrap();
         assert_eq!(cache.load(Provider::Grok).unwrap(), Some(snapshot()));
+    }
+
+    #[test]
+    fn statusline_observation_preserves_context_when_the_next_payload_omits_it() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let previous = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![UsageWindow::new(WindowKind::Weekly, 27.0, None).unwrap()],
+            1,
+        )
+        .with_context(Some(ContextUsage::new(23.5).unwrap()));
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                previous,
+                &json!({"session_id": "session-1"}),
+            )
+            .unwrap();
+
+        let latest = ProviderSnapshot::new(Provider::Claude, vec![], 2);
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                latest,
+                &json!({"session_id": "session-1"}),
+            )
+            .unwrap();
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap();
+        assert_eq!(saved.snapshot.windows.len(), 0);
+        assert_eq!(saved.snapshot.context.as_ref().unwrap().used_percent, 23.5);
     }
 
     #[test]
@@ -495,6 +589,22 @@ mod tests {
         assert!(second.is_none());
         drop(first);
         assert!(cache.try_lock_named("codex.turn.lock").unwrap().is_some());
+    }
+
+    #[test]
+    fn provider_refresh_lease_is_non_blocking_and_scoped_to_one_provider() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let first = cache.try_lock_provider_refresh(Provider::Claude).unwrap();
+        assert!(first.is_some());
+        assert!(cache
+            .try_lock_provider_refresh(Provider::Claude)
+            .unwrap()
+            .is_none());
+        assert!(cache
+            .try_lock_provider_refresh(Provider::Agy)
+            .unwrap()
+            .is_some());
     }
 
     #[test]

--- a/src/configure/agy.rs
+++ b/src/configure/agy.rs
@@ -2,12 +2,10 @@ use super::statusline::{settings_path, Adapter};
 use crate::cache::CacheStore;
 use crate::model::Provider;
 use crate::providers::agy::parse_statusline;
-use crate::providers::statusline::enrich_cache_session;
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::io::{Read, Write};
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 const CONFIG: Adapter = Adapter {
     label: "Agy",
@@ -54,44 +52,23 @@ pub fn run_statusline_hook() -> Result<()> {
     let mut input = Vec::new();
     std::io::stdin().read_to_end(&mut input)?;
     if let Ok(value) = serde_json::from_slice::<Value>(&input) {
-        if let Ok(mut snapshot) = parse_statusline(&value, CacheStore::now_unix()) {
+        if let Ok(snapshot) = parse_statusline(&value, CacheStore::now_unix()) {
             if let Ok(cache) = CacheStore::from_env() {
-                let _ = cache.with_lock(|| {
-                    let previous_cache = cache
-                        .load(Provider::Agy)
-                        .ok()
-                        .flatten()
-                        .and_then(|snapshot| snapshot.context)
-                        .and_then(|context| context.cache);
-                    enrich_cache_session(&mut snapshot, &value, previous_cache.as_ref());
-                    let session_id = value
-                        .get("session_id")
-                        .or_else(|| value.get("sessionId"))
-                        .and_then(Value::as_str);
-                    cache.save_preserving_context_for_session(snapshot, session_id)
-                });
+                let _ = cache.save_statusline_observation(Provider::Agy, snapshot, &value);
             }
         }
     }
     let cache = CacheStore::from_env()?;
-    let Some(command) = CONFIG.previous_command(cache.root())? else {
+    let Some(output) = CONFIG.run_previous(cache.root(), &input)? else {
         return Ok(());
     };
-    let mut child = Command::new("sh")
-        .args(["-c", &command])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()
-        .context("run previous Agy statusLine")?;
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(&input)?;
+    if output.timed_out {
+        return Ok(());
     }
-    let output = child.wait_with_output()?;
     std::io::stdout().write_all(&output.stdout)?;
     std::io::stdout().flush()?;
-    if !output.status.success() {
-        std::process::exit(output.status.code().unwrap_or(1));
+    if output.exit_code != Some(0) {
+        std::process::exit(output.exit_code.unwrap_or(1));
     }
     Ok(())
 }

--- a/src/configure/claude.rs
+++ b/src/configure/claude.rs
@@ -2,12 +2,10 @@ use super::statusline::{settings_path, Adapter};
 use crate::cache::{CacheStore, DEFAULT_WATCH_INTERVAL_SECONDS};
 use crate::model::Provider;
 use crate::providers::claude::parse_statusline;
-use crate::providers::statusline::enrich_cache_session;
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::io::{Read, Write};
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 const CONFIG: Adapter = Adapter {
     label: "Claude",
@@ -73,44 +71,23 @@ pub fn run_statusline_hook() -> Result<()> {
     let mut input = Vec::new();
     std::io::stdin().read_to_end(&mut input)?;
     if let Ok(value) = serde_json::from_slice::<Value>(&input) {
-        if let Ok(mut snapshot) = parse_statusline(&value, CacheStore::now_unix()) {
+        if let Ok(snapshot) = parse_statusline(&value, CacheStore::now_unix()) {
             if let Ok(cache) = CacheStore::from_env() {
-                let _ = cache.with_lock(|| {
-                    let previous_cache = cache
-                        .load(Provider::Claude)
-                        .ok()
-                        .flatten()
-                        .and_then(|snapshot| snapshot.context)
-                        .and_then(|context| context.cache);
-                    enrich_cache_session(&mut snapshot, &value, previous_cache.as_ref());
-                    let session_id = value
-                        .get("session_id")
-                        .or_else(|| value.get("sessionId"))
-                        .and_then(Value::as_str);
-                    cache.save_preserving_context_for_session(snapshot, session_id)
-                });
+                let _ = cache.save_statusline_observation(Provider::Claude, snapshot, &value);
             }
         }
     }
     let cache = CacheStore::from_env()?;
-    let Some(command) = CONFIG.previous_command(cache.root())? else {
+    let Some(output) = CONFIG.run_previous(cache.root(), &input)? else {
         return Ok(());
     };
-    let mut child = Command::new("sh")
-        .args(["-c", &command])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()
-        .context("run previous Claude statusLine")?;
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(&input)?;
+    if output.timed_out {
+        return Ok(());
     }
-    let output = child.wait_with_output()?;
     std::io::stdout().write_all(&output.stdout)?;
     std::io::stdout().flush()?;
-    if !output.status.success() {
-        std::process::exit(output.status.code().unwrap_or(1));
+    if output.exit_code != Some(0) {
+        std::process::exit(output.exit_code.unwrap_or(1));
     }
     Ok(())
 }

--- a/src/configure/statusline.rs
+++ b/src/configure/statusline.rs
@@ -1,3 +1,4 @@
+use crate::process::{run_shell_with_deadline, CommandOutput, STATUSLINE_COMMAND_BUDGET};
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::fs;
@@ -136,6 +137,13 @@ impl Adapter {
                 .map(str::to_string),
             _ => None,
         })
+    }
+
+    pub(crate) fn run_previous(&self, state: &Path, input: &[u8]) -> Result<Option<CommandOutput>> {
+        let Some(command) = self.previous_command(state)? else {
+            return Ok(None);
+        };
+        run_shell_with_deadline(&command, input, STATUSLINE_COMMAND_BUDGET).map(Some)
     }
 
     fn is_installed(&self, status_line: Option<&Value>) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cache;
 pub mod cli;
 pub mod model;
 pub mod presentation;
+pub mod process;
 
 pub mod configure;
 pub mod dashboard;

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,131 @@
+use anyhow::{Context, Result};
+use std::io::{Read, Write};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
+/// A statusLine command must never consume the refresh interval itself.
+pub const STATUSLINE_COMMAND_BUDGET: Duration = Duration::from_secs(2);
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct CommandOutput {
+    pub stdout: Vec<u8>,
+    pub exit_code: Option<i32>,
+    pub timed_out: bool,
+}
+
+/// Run a user-owned shell command with a hard wall-clock budget.
+///
+/// The child owns a process group so a timeout removes the shell and any
+/// helper it started. stdout is drained concurrently, while the caller keeps
+/// ownership of the child and can therefore kill and reap it without a pid
+/// reuse race.
+pub fn run_shell_with_deadline(
+    command: &str,
+    input: &[u8],
+    budget: Duration,
+) -> Result<CommandOutput> {
+    let mut child = Command::new("sh");
+    child
+        .args(["-c", command])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    #[cfg(unix)]
+    unsafe {
+        child.pre_exec(|| {
+            if libc::setpgid(0, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let mut child = child.spawn().context("run previous statusLine")?;
+    let stdin = child
+        .stdin
+        .take()
+        .context("open previous statusLine stdin")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("open previous statusLine stdout")?;
+    let input = input.to_vec();
+    let writer = thread::spawn(move || {
+        let mut stdin = stdin;
+        let _ = stdin.write_all(&input);
+    });
+
+    let child = Arc::new(Mutex::new(Some(child)));
+    let timed_out = Arc::new(AtomicBool::new(false));
+    let (cancel, cancelled) = mpsc::channel();
+    let watchdog_child = Arc::clone(&child);
+    let watchdog_timed_out = Arc::clone(&timed_out);
+    let watchdog = thread::spawn(move || {
+        if cancelled.recv_timeout(budget).is_err() {
+            watchdog_timed_out.store(true, Ordering::Release);
+            let _ = terminate_and_reap(&watchdog_child);
+        }
+    });
+
+    let mut stdout = stdout;
+    let mut output = Vec::new();
+    let read_result = stdout.read_to_end(&mut output);
+    let _ = cancel.send(());
+    let status = terminate_and_reap(&child)?;
+    let _ = watchdog.join();
+
+    let _ = writer.join();
+    read_result.context("read previous statusLine output")?;
+
+    Ok(CommandOutput {
+        stdout: output,
+        exit_code: status.and_then(|status| status.code()),
+        timed_out: timed_out.load(Ordering::Acquire),
+    })
+}
+
+fn terminate_and_reap(child: &Mutex<Option<Child>>) -> Result<Option<ExitStatus>> {
+    let mut slot = child
+        .lock()
+        .map_err(|_| anyhow::anyhow!("lock previous statusLine child"))?;
+    let Some(mut child) = slot.take() else {
+        return Ok(None);
+    };
+    #[cfg(unix)]
+    unsafe {
+        // setpgid in the child setup makes this include shell descendants.
+        let _ = libc::killpg(child.id() as libc::pid_t, libc::SIGKILL);
+    }
+    let _ = child.kill();
+    child.wait().map(Some).context("reap previous statusLine")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    fn captures_a_completed_command() {
+        let result =
+            run_shell_with_deadline("printf done", b"ignored", Duration::from_secs(1)).unwrap();
+        assert_eq!(result.stdout, b"done");
+        assert_eq!(result.exit_code, Some(0));
+        assert!(!result.timed_out);
+    }
+
+    #[test]
+    fn kills_a_command_that_exceeds_its_budget() {
+        let started = Instant::now();
+        let result =
+            run_shell_with_deadline("sleep 20 & wait", b"", Duration::from_millis(100)).unwrap();
+        assert!(result.timed_out);
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+}

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -3,8 +3,9 @@ use crate::herdr::{
     current_agent_provider, list_agent_panes, list_agent_state, publish_tokens, refresh_pane_topic,
     AgentPane,
 };
-use crate::model::Provider;
+use crate::model::{Provider, ProviderSnapshot};
 use crate::presentation::MetadataTokens;
+use crate::providers::statusline::enrich_cache_session;
 use crate::providers::{codex, grok};
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -34,11 +35,13 @@ pub fn run(providers: &[Provider], force: bool, json: bool) -> Result<()> {
 /// Refresh selected providers until their agents leave the working state.
 ///
 /// This command is normally launched detached by `event` and is deliberately
-/// quota-only: it never reads a pane. Claude/Agy statusLine hooks keep writing
-/// snapshots to the same cache, while Codex/Grok use their normal providers'
-/// fetchers. One global watcher reads Herdr's agent inventory once per poll
-/// and refreshes every selected provider that is working. The existing
-/// provider-level debounce remains the lower bound for network requests.
+/// quota-only: it never reads a pane. Claude/Agy statusLine hooks publish
+/// observations to the local mailbox, while Codex/Grok use their normal
+/// providers' fetchers. One global watcher reads Herdr's agent inventory once
+/// per poll and refreshes every selected provider that is working. Each
+/// provider has its own non-blocking refresh lease, so slow I/O never stalls a
+/// statusLine hook or another provider. The existing provider-level debounce
+/// remains the lower bound for network requests.
 pub fn watch(providers: &[Provider], interval_seconds: Option<u64>) -> Result<()> {
     let cache = CacheStore::from_env()?;
     let interval_seconds = interval_seconds
@@ -103,7 +106,7 @@ fn refresh_and_publish(
     force: bool,
     panes: &[AgentPane],
 ) -> Result<()> {
-    cache.with_lock(|| refresh_locked(cache, providers, force))?;
+    refresh_selected(cache, providers, force)?;
     publish(cache, providers, None, Some(panes))
 }
 
@@ -114,7 +117,7 @@ fn run_internal(
     topic_pane: Option<&str>,
 ) -> Result<()> {
     let cache = CacheStore::from_env()?;
-    let outcomes = cache.with_lock(|| refresh_locked(&cache, providers, force))?;
+    let outcomes = refresh_selected(&cache, providers, force)?;
     publish(&cache, providers, topic_pane, None)?;
     if json {
         println!("{}", serde_json::to_string_pretty(&outcomes)?);
@@ -153,61 +156,120 @@ pub fn focus() -> Result<()> {
     run(&[provider], false, false)
 }
 
-fn refresh_locked(
+#[derive(Debug)]
+struct FetchedSnapshot {
+    snapshot: ProviderSnapshot,
+    preserve_context: bool,
+    session_id: Option<String>,
+}
+
+impl FetchedSnapshot {
+    fn direct(snapshot: ProviderSnapshot) -> Self {
+        Self {
+            snapshot,
+            preserve_context: false,
+            session_id: None,
+        }
+    }
+}
+
+fn refresh_selected(
     cache: &CacheStore,
     providers: &[Provider],
     force: bool,
 ) -> Result<Vec<ProviderOutcome>> {
+    providers
+        .iter()
+        .copied()
+        .map(|provider| refresh_provider(cache, provider, force))
+        .collect()
+}
+
+fn refresh_provider(
+    cache: &CacheStore,
+    provider: Provider,
+    force: bool,
+) -> Result<ProviderOutcome> {
     let now = CacheStore::now_unix();
-    let mut outcomes = Vec::new();
-    for provider in providers {
-        if !force && cache.should_debounce(*provider, now, 60)? {
-            outcomes.push(ProviderOutcome {
-                provider: *provider,
-                available: cache.load(*provider)?.is_some(),
-                from_cache: true,
-                error: None,
-            });
-            continue;
-        }
-        let fetched = match provider {
-            Provider::Codex => codex::fetch(),
-            Provider::Grok => grok::fetch(),
-            Provider::Claude => match cache.load(Provider::Claude)? {
-                Some(snapshot) => Ok(snapshot),
-                None => Err(anyhow::anyhow!(
-                    "Claude usage is collected by the Claude statusLine hook"
-                )),
-            },
-            Provider::Agy => match cache.load(Provider::Agy)? {
-                Some(snapshot) => Ok(snapshot),
-                None => Err(anyhow::anyhow!(
-                    "Agy usage is collected by the Agy statusLine hook"
-                )),
-            },
-        };
-        cache.mark_refresh(*provider, now)?;
-        match fetched {
-            Ok(snapshot) => {
-                if !matches!(provider, Provider::Claude | Provider::Agy) {
-                    cache.save(&snapshot)?;
-                }
-                outcomes.push(ProviderOutcome {
-                    provider: *provider,
-                    available: true,
-                    from_cache: false,
-                    error: None,
-                });
-            }
-            Err(error) => outcomes.push(ProviderOutcome {
-                provider: *provider,
-                available: cache.load(*provider)?.is_some(),
-                from_cache: true,
-                error: Some(error.to_string()),
-            }),
-        }
+    if !force && cache.should_debounce(provider, now, 60)? {
+        return Ok(ProviderOutcome {
+            provider,
+            available: cache.load(provider)?.is_some(),
+            from_cache: true,
+            error: None,
+        });
     }
-    Ok(outcomes)
+    let Some(_lease) = cache.try_lock_provider_refresh(provider)? else {
+        return Ok(ProviderOutcome {
+            provider,
+            available: cache.load(provider)?.is_some(),
+            from_cache: true,
+            error: Some("refresh already in progress".to_string()),
+        });
+    };
+
+    let fetched = match provider {
+        Provider::Codex => codex::fetch().map(FetchedSnapshot::direct),
+        Provider::Grok => grok::fetch().map(FetchedSnapshot::direct),
+        Provider::Claude | Provider::Agy => load_statusline_snapshot(cache, provider),
+    };
+    cache.mark_refresh(provider, now)?;
+    match fetched {
+        Ok(fetched) => {
+            let FetchedSnapshot {
+                snapshot,
+                preserve_context,
+                session_id,
+            } = fetched;
+            if preserve_context {
+                cache.save_preserving_context_for_session(snapshot, session_id.as_deref())?;
+            } else {
+                cache.save(&snapshot)?;
+            }
+            Ok(ProviderOutcome {
+                provider,
+                available: true,
+                from_cache: false,
+                error: None,
+            })
+        }
+        Err(error) => Ok(ProviderOutcome {
+            provider,
+            available: cache.load(provider)?.is_some(),
+            from_cache: true,
+            error: Some(error.to_string()),
+        }),
+    }
+}
+
+fn load_statusline_snapshot(cache: &CacheStore, provider: Provider) -> Result<FetchedSnapshot> {
+    let observation = cache
+        .load_statusline_observation(provider)?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} usage is collected by the statusLine hook",
+                provider.source()
+            )
+        })?;
+    let mut snapshot = observation.snapshot;
+    let value = observation.payload;
+    let previous_cache = cache
+        .load(provider)
+        .ok()
+        .flatten()
+        .and_then(|snapshot| snapshot.context)
+        .and_then(|context| context.cache);
+    enrich_cache_session(&mut snapshot, &value, previous_cache.as_ref());
+    let session_id = value
+        .get("session_id")
+        .or_else(|| value.get("sessionId"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    Ok(FetchedSnapshot {
+        snapshot,
+        preserve_context: true,
+        session_id,
+    })
 }
 
 fn publish(

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -4,6 +4,8 @@ use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 use tempfile::tempdir;
 
 fn install_herdr_stub(state: &Path, agent_list: &str) -> (PathBuf, PathBuf) {
@@ -36,6 +38,55 @@ fn run_claude_collector(state: &Path, herdr: &Path, input: &[u8]) {
         .unwrap();
     child.stdin.take().unwrap().write_all(input).unwrap();
     assert!(child.wait_with_output().unwrap().status.success());
+}
+
+fn run_claude_collector_with_timeout(state: &Path, input: &[u8], timeout: Duration) -> bool {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_herdr-agent-quota"))
+        .arg("claude-statusline")
+        .env("HERDR_PLUGIN_STATE_DIR", state)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(input).unwrap();
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            return status.success();
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return false;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn hold_refresh_lock_in_child(state: &Path) -> std::process::Child {
+    let lock_path = state.join("refresh.lock");
+    let ready_path = state.join("refresh.lock.ready");
+    let locker = Command::new("perl")
+        .args([
+            "-e",
+            r#"use Fcntl qw(:flock); open my $f, '+>', $ARGV[0] or die $!; flock($f, LOCK_EX) or die $!; open my $r, '>', $ARGV[1] or die $!; print $r 'locked'; close $r; sleep 20"#,
+            lock_path.to_str().unwrap(),
+            ready_path.to_str().unwrap(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !ready_path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "refresh lock helper did not start"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+    locker
 }
 
 fn run_claude_refresh(state: &Path, herdr: &Path) {
@@ -158,6 +209,42 @@ fn claude_collector_is_silent_without_a_previous_statusline() {
 }
 
 #[test]
+fn claude_collector_does_not_wait_for_a_refresh_lock() {
+    let state = tempdir().unwrap();
+    let mut locker = hold_refresh_lock_in_child(state.path());
+
+    assert!(run_claude_collector_with_timeout(
+        state.path(),
+        include_bytes!("fixtures/claude/statusline-both.json"),
+        Duration::from_secs(2),
+    ));
+    assert!(state
+        .path()
+        .join("claude-statusline.observation.json")
+        .exists());
+    let _ = locker.kill();
+    let _ = locker.wait();
+}
+
+#[test]
+fn claude_collector_bounds_a_hanging_previous_statusline() {
+    let state = tempdir().unwrap();
+    fs::write(
+        state.path().join("claude-statusline.original.json"),
+        r#"{"type":"command","command":"sleep 20"}"#,
+    )
+    .unwrap();
+
+    let started = Instant::now();
+    assert!(run_claude_collector_with_timeout(
+        state.path(),
+        include_bytes!("fixtures/claude/statusline-both.json"),
+        Duration::from_secs(4),
+    ));
+    assert!(started.elapsed() < Duration::from_secs(4));
+}
+
+#[test]
 fn agy_collector_is_silent_without_a_previous_statusline() {
     let state = tempdir().unwrap();
     let mut child = Command::new(env!("CARGO_BIN_EXE_herdr-agent-quota"))
@@ -216,6 +303,7 @@ fn claude_statusline_without_rate_limits_clears_stale_quota_windows() {
         &herdr_stub,
         br#"{"context_window":{"used_percentage":43.0}}"#,
     );
+    run_claude_refresh(state.path(), &herdr_stub);
 
     let snapshot: serde_json::Value =
         serde_json::from_slice(&fs::read(state.path().join("claude-statusline.json")).unwrap())


### PR DESCRIPTION
## Summary

- remove the blocking `refresh.lock` from the statusLine render path; hooks atomically publish per-provider observations instead
- give each provider refresh its own non-blocking lease, so slow refresh work cannot stall statusLine or another provider
- run chained user statusLine commands in a bounded process group, suppress stderr, and kill/reap descendants on timeout
- preserve context/session diagnostics while keeping quota windows sourced from the newest observation

Fixes #18

## Verification

- `cargo fmt --all`
- `cargo test --locked`
- `cargo clippy --release --all-targets --all-features --locked -- -D warnings`
- `cargo build --release --locked`
- release smoke: held legacy `refresh.lock` and confirmed immediate observation; hung chained command returned in ~2s with its child reaped