### PR TITLE
fix: drop Grok quota cache after account switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Grok no longer sticks at `week 0%` after `grok login` switches accounts. A
+  fresh SuperGrok week omits `creditUsagePercent` (proto3 JSON drops zeros),
+  which the parser treated as an unsupported response and then kept the previous
+  login's exhausted snapshot. Omitted/null percent is 0% used (100% remaining),
+  snapshots are stamped with the signed-in `user_id`, and a cache from another
+  account is not published. Codex has the same per-provider cache and now
+  stamps `tokens.account_id` from `~/.codex/auth.json` so a ChatGPT account
+  switch cannot keep the previous user's weekly percent. Claude and Agy read
+  the running CLI's statusLine, so they were not affected.
 - Claude/Agy statusLine collectors now publish atomic observations without
   waiting on refresh work. Provider refreshes use independent non-blocking
   leases, and chained user statusLine commands run in a bounded process group

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -296,6 +296,16 @@ impl CacheStore {
             .unwrap_or_default()
     }
 
+    pub fn file_mtime_unix(path: &Path) -> Option<u64> {
+        fs::metadata(path)
+            .ok()?
+            .modified()
+            .ok()?
+            .duration_since(UNIX_EPOCH)
+            .ok()
+            .map(|duration| duration.as_secs())
+    }
+
     pub fn now_millis() -> u64 {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/src/model.rs
+++ b/src/model.rs
@@ -334,6 +334,12 @@ pub struct ProviderSnapshot {
     pub context: Option<ContextUsage>,
     #[serde(default)]
     pub session_summaries: BTreeMap<String, String>,
+    /// Login identity the snapshot was fetched for (Grok `user_id`, Codex
+    /// `tokens.account_id`). Used to drop another account's cached quota after
+    /// `grok login` / Codex account switch. Absent on snapshots written before
+    /// this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
 }
 
 impl ProviderSnapshot {
@@ -345,12 +351,40 @@ impl ProviderSnapshot {
             windows,
             context: None,
             session_summaries: BTreeMap::new(),
+            account_id: None,
         }
     }
 
     pub fn with_context(mut self, context: Option<ContextUsage>) -> Self {
         self.context = context;
         self
+    }
+
+    pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
+        self.account_id = account_id;
+        self
+    }
+
+    /// Whether this cached snapshot still belongs to the signed-in account.
+    ///
+    /// A failed refresh must keep the last good value for the *current*
+    /// account, not a previous login. After an account switch:
+    /// - snapshots stamped with another `account_id` are unusable;
+    /// - legacy snapshots (no stamp) are unusable when the credential file is
+    ///   newer than `fetched_at_unix`, which is what `grok login` does.
+    pub fn usable_for_account(
+        &self,
+        current_account_id: Option<&str>,
+        credentials_mtime_unix: Option<u64>,
+    ) -> bool {
+        match (self.account_id.as_deref(), current_account_id) {
+            (Some(saved), Some(current)) => saved == current,
+            (Some(_), None) => false,
+            (None, Some(_)) => {
+                credentials_mtime_unix.is_none_or(|mtime| mtime <= self.fetched_at_unix)
+            }
+            (None, None) => true,
+        }
     }
 
     pub fn window(&self, kind: WindowKind) -> Option<&UsageWindow> {
@@ -474,6 +508,31 @@ mod tests {
         let context: ContextUsage = serde_json::from_str(r#"{"used_percent":23.5}"#).unwrap();
         assert_eq!(context.used_percent, 23.5);
         assert!(context.cache.is_none());
+    }
+
+    #[test]
+    fn cached_snapshot_from_another_account_is_not_usable() {
+        let snapshot = ProviderSnapshot::new(Provider::Grok, vec![], 100)
+            .with_account_id(Some("account-a".to_string()));
+        assert!(!snapshot.usable_for_account(Some("account-b"), Some(50)));
+        assert!(snapshot.usable_for_account(Some("account-a"), Some(200)));
+    }
+
+    #[test]
+    fn legacy_snapshot_is_dropped_when_credentials_are_newer_than_the_fetch() {
+        let snapshot = ProviderSnapshot::new(Provider::Grok, vec![], 100);
+        assert!(!snapshot.usable_for_account(Some("account-b"), Some(150)));
+        assert!(snapshot.usable_for_account(Some("account-b"), Some(100)));
+        assert!(snapshot.usable_for_account(Some("account-b"), Some(50)));
+    }
+
+    #[test]
+    fn old_snapshots_deserialize_without_account_id() {
+        let snapshot: ProviderSnapshot = serde_json::from_str(
+            r#"{"provider":"grok","source":"grok-cli-billing","fetched_at_unix":1,"windows":[]}"#,
+        )
+        .unwrap();
+        assert_eq!(snapshot.account_id, None);
     }
 
     #[test]

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -4,7 +4,9 @@ use crate::providers::ProviderError;
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::collections::BTreeMap;
+use std::fs;
 use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -147,6 +149,7 @@ fn fetch_from_process(
     let limits = read_rpc(output, 3)?;
     let mut snapshot =
         parse_rate_limits(&limits, CacheStore::now_unix()).map_err(anyhow::Error::from)?;
+    snapshot.account_id = current_account_id().or_else(|| account_id_from_rpc(&account));
 
     // Session previews come from Codex's local state database. This is one
     // bounded read in the same app-server process as the quota request; it
@@ -242,6 +245,45 @@ fn read_rpc(output: &mut BufReader<impl std::io::Read>, expected_id: u64) -> Res
     }
 }
 
+pub fn auth_path() -> Result<PathBuf> {
+    if let Some(path) = std::env::var_os("CODEX_AUTH_FILE") {
+        return Ok(PathBuf::from(path));
+    }
+    let home = std::env::var_os("HOME").context("HOME is not set")?;
+    let home = PathBuf::from(home);
+    let codex_home = std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".codex"));
+    Ok(codex_home.join("auth.json"))
+}
+
+pub fn current_account_id() -> Option<String> {
+    account_id_from_auth(&auth_path().ok()?)
+}
+
+pub fn auth_mtime_unix() -> Option<u64> {
+    CacheStore::file_mtime_unix(&auth_path().ok()?)
+}
+
+pub fn account_id_from_auth(path: &Path) -> Option<String> {
+    let value: Value = serde_json::from_slice(&fs::read(path).ok()?).ok()?;
+    value
+        .pointer("/tokens/account_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn account_id_from_rpc(value: &Value) -> Option<String> {
+    let result = value.get("result").unwrap_or(value);
+    let account = result.get("account").unwrap_or(result);
+    ["accountId", "account_id", "chatgptAccountId", "id"]
+        .iter()
+        .find_map(|key| account.get(*key).and_then(Value::as_str))
+        .filter(|value| !value.is_empty() && *value != "chatgpt")
+        .map(str::to_string)
+}
+
 pub fn account_is_chatgpt(value: &Value) -> bool {
     let result = value.get("result").unwrap_or(value);
     let account = result.get("account").unwrap_or(result);
@@ -289,6 +331,18 @@ mod tests {
             "primary": {"usedPercent": 20.0, "windowDurationMins": 300}
         }}});
         assert!(parse_rate_limits(&value, 1).is_err());
+    }
+
+    #[test]
+    fn reads_codex_account_id_from_local_auth_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("auth.json");
+        fs::write(
+            &path,
+            r#"{"auth_mode":"chatgpt","tokens":{"account_id":"acc-1","access_token":"secret"}}"#,
+        )
+        .unwrap();
+        assert_eq!(account_id_from_auth(&path).as_deref(), Some("acc-1"));
     }
 
     #[test]

--- a/src/providers/grok.rs
+++ b/src/providers/grok.rs
@@ -38,7 +38,9 @@ pub fn fetch() -> Result<ProviderSnapshot> {
     let value: Value = response
         .into_json()
         .context("decode Grok billing response")?;
-    parse_billing_response(&value, CacheStore::now_unix()).map_err(anyhow::Error::from)
+    parse_billing_response(&value, CacheStore::now_unix())
+        .map(|snapshot| snapshot.with_account_id(credentials.user_id.clone()))
+        .map_err(anyhow::Error::from)
 }
 
 pub fn auth_path() -> Result<PathBuf> {
@@ -57,29 +59,94 @@ pub fn read_credentials(path: &Path) -> std::result::Result<GrokCredentials, Pro
     let bytes = fs::read(path).map_err(|_| ProviderError::MissingCredentials)?;
     let value: Value = serde_json::from_slice(&bytes)
         .map_err(|_| ProviderError::Unavailable("Grok auth file is not valid JSON".to_string()))?;
-    find_credentials(&value).ok_or(ProviderError::MissingCredentials)
+    select_credentials(collect_credentials(&value)).ok_or(ProviderError::MissingCredentials)
 }
 
-fn find_credentials(value: &Value) -> Option<GrokCredentials> {
+pub fn auth_mtime_unix(path: &Path) -> Option<u64> {
+    CacheStore::file_mtime_unix(path)
+}
+
+fn collect_credentials(value: &Value) -> Vec<CredentialCandidate> {
+    let mut credentials = Vec::new();
+    collect_credentials_into(value, &mut credentials);
+    credentials
+}
+
+fn collect_credentials_into(value: &Value, credentials: &mut Vec<CredentialCandidate>) {
     match value {
         Value::Object(map) => {
             if let Some(key) = map.get("key").and_then(Value::as_str) {
                 if !key.trim().is_empty() {
-                    let user_id = map
-                        .get("user_id")
-                        .and_then(Value::as_str)
-                        .map(str::to_string);
-                    return Some(GrokCredentials {
-                        key: key.to_string(),
-                        user_id,
+                    credentials.push(CredentialCandidate {
+                        credentials: GrokCredentials {
+                            key: key.to_string(),
+                            user_id: map
+                                .get("user_id")
+                                .and_then(Value::as_str)
+                                .filter(|value| !value.is_empty())
+                                .map(str::to_string),
+                        },
+                        expires_at: map
+                            .get("expires_at")
+                            .and_then(Value::as_str)
+                            .and_then(ResetAt::parse_rfc3339)
+                            .map(ResetAt::unix_seconds),
+                        create_time: map
+                            .get("create_time")
+                            .and_then(Value::as_str)
+                            .and_then(ResetAt::parse_rfc3339)
+                            .map(ResetAt::unix_seconds),
                     });
+                    return;
                 }
             }
-            map.values().find_map(find_credentials)
+            for child in map.values() {
+                collect_credentials_into(child, credentials);
+            }
         }
-        Value::Array(values) => values.iter().find_map(find_credentials),
-        _ => None,
+        Value::Array(values) => {
+            for child in values {
+                collect_credentials_into(child, credentials);
+            }
+        }
+        _ => {}
     }
+}
+
+fn select_credentials(candidates: Vec<CredentialCandidate>) -> Option<GrokCredentials> {
+    if candidates.is_empty() {
+        return None;
+    }
+    let now = CacheStore::now_unix();
+    let unexpired = candidates
+        .iter()
+        .filter(|candidate| {
+            candidate
+                .expires_at
+                .is_none_or(|expires_at| expires_at > now)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let pool = if unexpired.is_empty() {
+        candidates
+    } else {
+        unexpired
+    };
+    pool.into_iter()
+        .max_by_key(|candidate| {
+            (
+                candidate.create_time.unwrap_or(0),
+                candidate.expires_at.unwrap_or(0),
+            )
+        })
+        .map(|candidate| candidate.credentials)
+}
+
+#[derive(Debug, Clone)]
+struct CredentialCandidate {
+    credentials: GrokCredentials,
+    expires_at: Option<u64>,
+    create_time: Option<u64>,
 }
 
 pub fn parse_billing_response(
@@ -89,12 +156,16 @@ pub fn parse_billing_response(
     let config = value
         .get("config")
         .ok_or_else(|| ProviderError::UnsupportedResponse("missing config".to_string()))?;
-    let usage = config
-        .get("creditUsagePercent")
-        .and_then(Value::as_f64)
-        .ok_or_else(|| {
-            ProviderError::UnsupportedResponse("missing config.creditUsagePercent".to_string())
-        })?;
+    // proto3 JSON omits zero scalars, so a fresh SuperGrok week with 0% used
+    // arrives without `creditUsagePercent`. That is unused, not "unsupported".
+    let usage = match config.get("creditUsagePercent") {
+        None | Some(Value::Null) => 0.0,
+        Some(value) => value.as_f64().ok_or_else(|| {
+            ProviderError::UnsupportedResponse(
+                "config.creditUsagePercent is not a number".to_string(),
+            )
+        })?,
+    };
     let period = config
         .get("currentPeriod")
         .ok_or_else(|| ProviderError::UnsupportedResponse("missing currentPeriod".to_string()))?;
@@ -196,6 +267,75 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             "provider credentials are unavailable"
+        );
+    }
+
+    #[test]
+    fn omitted_credit_usage_percent_is_zero_used_not_a_parse_error() {
+        let value = json!({
+            "config": {
+                "currentPeriod": {
+                    "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                    "end": "2026-08-31T14:23:46Z"
+                }
+            }
+        });
+        let snapshot = parse_billing_response(&value, 1).unwrap();
+        let weekly = snapshot.window(WindowKind::Weekly).unwrap();
+        assert_eq!(weekly.used_percent, 0.0);
+        assert_eq!(weekly.remaining_percent, 100.0);
+        assert_eq!(
+            weekly.resets_at,
+            Some(ResetAt::from_unix_seconds(1_788_186_226))
+        );
+    }
+
+    #[test]
+    fn explicit_zero_credit_usage_percent_is_full_remaining() {
+        let value = json!({
+            "config": {
+                "creditUsagePercent": 0.0,
+                "currentPeriod": {"type": "USAGE_PERIOD_TYPE_WEEKLY"}
+            }
+        });
+        assert_eq!(
+            parse_billing_response(&value, 1)
+                .unwrap()
+                .window(WindowKind::Weekly)
+                .unwrap()
+                .remaining_percent,
+            100.0
+        );
+    }
+
+    #[test]
+    fn prefers_the_newest_unexpired_login_when_auth_json_still_has_another_account() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("auth.json");
+        fs::write(
+            &path,
+            r#"{
+                "https://auth.x.ai::old": {
+                    "key": "old-token",
+                    "user_id": "u-old",
+                    "expires_at": "2099-12-01T00:00:00Z",
+                    "create_time": "2020-01-01T00:00:00Z"
+                },
+                "https://auth.x.ai::new": {
+                    "key": "new-token",
+                    "user_id": "u-new",
+                    "expires_at": "2099-06-01T00:00:00Z",
+                    "create_time": "2026-08-25T00:56:20Z"
+                }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            read_credentials(&path).unwrap(),
+            GrokCredentials {
+                key: "new-token".to_string(),
+                user_id: Some("u-new".to_string())
+            }
         );
     }
 }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -191,10 +191,10 @@ fn refresh_provider(
     force: bool,
 ) -> Result<ProviderOutcome> {
     let now = CacheStore::now_unix();
-    if !force && cache.should_debounce(provider, now, 60)? {
+    if should_skip_fetch(cache, provider, force, now)? {
         return Ok(ProviderOutcome {
             provider,
-            available: cache.load(provider)?.is_some(),
+            available: load_usable_snapshot(cache, provider)?.is_some(),
             from_cache: true,
             error: None,
         });
@@ -202,7 +202,7 @@ fn refresh_provider(
     let Some(_lease) = cache.try_lock_provider_refresh(provider)? else {
         return Ok(ProviderOutcome {
             provider,
-            available: cache.load(provider)?.is_some(),
+            available: load_usable_snapshot(cache, provider)?.is_some(),
             from_cache: true,
             error: Some("refresh already in progress".to_string()),
         });
@@ -235,10 +235,57 @@ fn refresh_provider(
         }
         Err(error) => Ok(ProviderOutcome {
             provider,
-            available: cache.load(provider)?.is_some(),
+            available: load_usable_snapshot(cache, provider)?.is_some(),
             from_cache: true,
             error: Some(error.to_string()),
         }),
+    }
+}
+
+fn should_skip_fetch(
+    cache: &CacheStore,
+    provider: Provider,
+    force: bool,
+    now_unix: u64,
+) -> Result<bool> {
+    if force || !cache.should_debounce(provider, now_unix, 60)? {
+        return Ok(false);
+    }
+    if load_usable_snapshot(cache, provider)?.is_some() {
+        return Ok(true);
+    }
+    // No snapshot at all: keep debounce so missing credentials do not hammer
+    // the provider. A snapshot for another account must not debounce — fetch
+    // the signed-in identity now.
+    Ok(cache.load(provider)?.is_none())
+}
+
+fn load_usable_snapshot(
+    cache: &CacheStore,
+    provider: Provider,
+) -> Result<Option<ProviderSnapshot>> {
+    let Some(snapshot) = cache.load(provider)? else {
+        return Ok(None);
+    };
+    let (account_id, mtime) = current_account_gate(provider);
+    Ok(snapshot
+        .usable_for_account(account_id.as_deref(), mtime)
+        .then_some(snapshot))
+}
+
+fn current_account_gate(provider: Provider) -> (Option<String>, Option<u64>) {
+    match provider {
+        Provider::Grok => {
+            let path = grok::auth_path().ok();
+            let account_id = path
+                .as_ref()
+                .and_then(|path| grok::read_credentials(path).ok())
+                .and_then(|credentials| credentials.user_id);
+            let mtime = path.as_ref().and_then(|path| grok::auth_mtime_unix(path));
+            (account_id, mtime)
+        }
+        Provider::Codex => (codex::current_account_id(), codex::auth_mtime_unix()),
+        Provider::Claude | Provider::Agy => (None, None),
     }
 }
 
@@ -293,7 +340,11 @@ fn publish(
     let now = CacheStore::now_unix();
     for provider in providers {
         let snapshot = cache.load(*provider)?;
-        if let Some(snapshot) = snapshot.as_ref() {
+        let (account_id, mtime) = current_account_gate(*provider);
+        let usable = snapshot
+            .as_ref()
+            .filter(|snapshot| snapshot.usable_for_account(account_id.as_deref(), mtime));
+        if let Some(snapshot) = usable {
             for pane in panes.iter_mut().filter(|pane| pane.provider == *provider) {
                 if let Some(session_id) = pane.session_id.as_deref() {
                     if let Some(summary) = snapshot.session_summaries.get(session_id) {
@@ -302,7 +353,8 @@ fn publish(
                 }
             }
         }
-        if let Some(values) = tokens_for_provider(snapshot.as_ref(), now) {
+        if let Some(values) = tokens_for_loaded_snapshot(*provider, snapshot.as_ref(), usable, now)
+        {
             tokens.push((*provider, values));
         }
     }
@@ -373,6 +425,22 @@ fn tokens_for_provider(
     snapshot.map(|snapshot| MetadataTokens::from_snapshot(snapshot, now_unix))
 }
 
+fn tokens_for_loaded_snapshot(
+    provider: Provider,
+    raw: Option<&ProviderSnapshot>,
+    usable: Option<&ProviderSnapshot>,
+    now_unix: u64,
+) -> Option<MetadataTokens> {
+    match (usable, raw) {
+        (Some(snapshot), _) => tokens_for_provider(Some(snapshot), now_unix),
+        (None, Some(_)) => Some(MetadataTokens::unavailable(
+            provider,
+            "signed-in account changed",
+        )),
+        (None, None) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -396,6 +464,40 @@ mod tests {
     fn missing_snapshot_does_not_overwrite_sidebar_with_unavailable() {
         let values = tokens_for_provider(None, 1);
         assert!(values.is_none());
+    }
+
+    #[test]
+    fn other_account_snapshot_is_not_shown_as_the_current_quota() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Grok,
+            vec![UsageWindow::new(WindowKind::Weekly, 100.0, None).unwrap()],
+            1,
+        )
+        .with_account_id(Some("old-account".to_string()));
+        let values = tokens_for_loaded_snapshot(Provider::Grok, Some(&snapshot), None, 1).unwrap();
+        assert_eq!(values.quota_summary, "unavailable");
+        assert_eq!(
+            values.quota_error.as_deref(),
+            Some("signed-in account changed")
+        );
+    }
+
+    #[test]
+    fn debounce_does_not_keep_another_accounts_grok_snapshot() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let snapshot = ProviderSnapshot::new(
+            Provider::Grok,
+            vec![UsageWindow::new(WindowKind::Weekly, 100.0, None).unwrap()],
+            1,
+        )
+        .with_account_id(Some("old-account".to_string()));
+        cache.save(&snapshot).unwrap();
+        cache.mark_refresh(Provider::Grok, 100).unwrap();
+        assert!(
+            !should_skip_fetch(&cache, Provider::Grok, false, 120).unwrap(),
+            "a snapshot for another Grok login must be fetched even inside the debounce window"
+        );
     }
 
     // Reading a pane repaints it, which visibly scrolls the agent's terminal.

--- a/tests/fixtures/grok/credits-omitted-percent.json
+++ b/tests/fixtures/grok/credits-omitted-percent.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "currentPeriod": {
+      "type": "USAGE_PERIOD_TYPE_WEEKLY",
+      "start": "2026-08-24T14:23:46.259558+00:00",
+      "end": "2026-08-31T14:23:46.259558+00:00"
+    },
+    "prepaidBalance": { "val": 0 },
+    "isUnifiedBillingUser": true
+  }
+}

--- a/tests/provider_contracts.rs
+++ b/tests/provider_contracts.rs
@@ -37,6 +37,15 @@ fn grok_fixture_requires_explicit_weekly_period() {
     );
     let monthly = fixture(include_str!("fixtures/grok/credits-monthly.json"));
     assert!(grok::parse_billing_response(&monthly, 1).is_err());
+    let omitted = fixture(include_str!("fixtures/grok/credits-omitted-percent.json"));
+    assert_eq!(
+        grok::parse_billing_response(&omitted, 1)
+            .unwrap()
+            .window(WindowKind::Weekly)
+            .unwrap()
+            .remaining_percent,
+        100.0
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Why

After `grok login` on another account, the sidebar stayed at `week 0%` even though the new SuperGrok week was unused.

## Cause

1. proto3 JSON omits zero scalars, so a fresh week has no `creditUsagePercent`. The parser rejected that and kept the previous login's 100% used snapshot.
2. Quota cache is per provider, not per account, so a failed fetch after login kept publishing the old 0%.

## Fix

- Treat omitted/null `creditUsagePercent` as 0% used (100% remaining).
- Stamp Grok snapshots with `user_id` and Codex snapshots with `tokens.account_id`.
- Prefer the newest unexpired Grok login when `auth.json` still has another account.
- Do not debounce or publish another account's cache.

Claude and Agy were not affected: they read the running CLI statusLine.

## Verify

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features --locked`
- Local Herdr panes now show the signed-in Grok week remaining, with `account_id` on the snapshot.