### PR TITLE
fix: restore Codex five-hour quota window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Codex quota parsing now keeps both provider-reported five-hour and seven-day
+  windows. It identifies each window by duration instead of assuming that
+  `primary` or `secondary` has a fixed meaning, so the restored five-hour limit
+  appears in the sidebar again.
 - Grok no longer sticks at `week 0%` after `grok login` switches accounts. A
   fresh SuperGrok week omits `creditUsagePercent` (proto3 JSON drops zeros),
   which the parser treated as an unsupported response and then kept the previous
@@ -124,7 +128,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   teal and amber accents, while metadata publication remains capped at sixteen
   tokens.
 - Quota formatting is centralized in one presentation module shared by the
-  sidebar, dashboard, and statusLine fallbacks. Codex remains weekly-only.
+  sidebar, dashboard, and statusLine fallbacks. Codex now publishes both its
+  five-hour and weekly windows when the provider reports them.
 - Five-hour and weekly quota windows now share one compact sidebar row. Herdr
   elides missing tokens and their separators, while each window keeps its own
   dynamic health color.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Agy/Antigravity subscription usage, in Herdr's agent sidebar.
 
 [![CI](https://github.com/levi-qiao/herdr-agent-quota/actions/workflows/ci.yml/badge.svg)](https://github.com/levi-qiao/herdr-agent-quota/actions/workflows/ci.yml)
 [![Rust](https://img.shields.io/badge/built%20with-Rust-dea584?logo=rust&logoColor=white)](https://www.rust-lang.org/)
-[![Herdr plugin](https://img.shields.io/badge/Herdr-plugin-0.8%2B-5b6ee1)](https://herdr.dev/docs/plugins/)
+[![Herdr plugin](https://img.shields.io/badge/Herdr-plugin-supported-5b6ee1)](https://herdr.dev/docs/plugins/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/levi-qiao/herdr-agent-quota?style=social)](https://github.com/levi-qiao/herdr-agent-quota)
 
@@ -21,11 +21,12 @@ Agy/Antigravity subscription usage, in Herdr's agent sidebar.
 
 ![Live Herdr agent sidebar](docs/screenshots/herdr-sidebar-live.png)
 
-*A real Herdr workspace: Claude shows five-hour and weekly reset ETAs on one
-compact row, Codex and Grok show their weekly windows, and each agent card uses
+*A real Herdr workspace: Claude and Codex show five-hour and weekly reset ETAs
+on one compact row, Grok shows its weekly window, and each agent card uses
 the latest user prompt rather than an AI-generated status.*
 
-- **Four CLIs, one sidebar** — Claude Code, Codex, Grok, Agy/Antigravity.
+- **Four providers, one sidebar** — Claude Code, OpenAI Codex, Grok, and
+  Agy/Antigravity.
 - **Compact, capability-aware cards** — provider, prompt/session summary,
   supported context usage, and quota windows. Unsupported rows are hidden.
 - **Local only** — no usage data uploaded, no browser cookies, no keychain
@@ -73,8 +74,8 @@ every provider adapter; only the window data differs.
 
 ## Quick start
 
-Requirements: Herdr `0.8.0+`, Rust `1.95+`, macOS or Linux, and at least one
-supported CLI. If you downloaded this repository, the one-step installer does
+Requirements: Herdr, a Rust toolchain, macOS or Linux, and at least one
+supported provider CLI. If you downloaded this repository, the one-step installer does
 the build, link, enable, and reversible configuration for you:
 
 ```sh
@@ -114,7 +115,7 @@ the same action from a shell with:
 herdr plugin action invoke herdr-agent-quota.refresh
 ```
 
-Herdr plugin v1 does not currently let plugins add buttons to the native agent
+The Herdr plugin API does not currently let plugins add buttons to the native agent
 group header, so the shortcut is the closest stable one-step entry point.
 Selecting a pane also runs a provider-only refresh, debounced to once per
 minute. While any agent is working, one global background watcher polls the
@@ -171,18 +172,14 @@ Claude and Agy statusLine commands. Older plugin-owned Grok response hooks are
 removed during configure; the single global watcher now covers Grok as well, so
 long turns no longer start one refresh command per tool call.
 
-## Supported CLIs
+## Supported providers
 
-| CLI | Sidebar windows | Local collection path | Extra setup |
+| Provider | Sidebar windows | Local collection path | Extra setup |
 | --- | --- | --- | --- |
-| Claude Code `2.1.233` | `5h` + `7d` + context + cache hit/approx. TTL | Official `statusLine` JSON: `rate_limits`, `context_window`, and `transcript_path` | The configure action installs/chains it and keeps its refresh interval current |
-| OpenAI Codex `0.147.0` | `week` + local session summary | One-shot local `codex app-server --stdio`: quota and bounded `thread/list` | ChatGPT subscription login; API-key mode is shown as unavailable |
-| Grok CLI / Grok Build `1.0.4` | `week` | Local `~/.grok/auth.json` and the billing contract used by the official CLI | Covered by the unified watcher; no response hook is installed |
-| Agy / Antigravity CLI `1.1.13` | `5h` + `week` + context + cache hit | Official `statusLine` JSON: `quota` and `context_window` | The configure action installs and chains it automatically |
-
-Versions above were checked on the development machine on 2026-08-15. The
-parser follows the provider fields rather than hard-coding these version
-strings, so newer compatible CLI releases can continue to work.
+| Claude Code | `5h` + `7d` + context + cache hit/approx. TTL | Official `statusLine` JSON: `rate_limits`, `context_window`, and `transcript_path` | The configure action installs/chains it and keeps its refresh interval current |
+| OpenAI Codex | `5h` + `7d` + local session summary | One-shot local `codex app-server --stdio`: quota and bounded `thread/list` | ChatGPT subscription login; API-key mode is shown as unavailable |
+| Grok CLI / Grok Build | `week` | Local `~/.grok/auth.json` and the billing contract used by the official CLI | Covered by the unified watcher; no response hook is installed |
+| Agy / Antigravity CLI | `5h` + `week` + context + cache hit | Official `statusLine` JSON: `quota` and `context_window` | The configure action installs and chains it automatically |
 
 The sidebar shows **percentage remaining** and the time until each quota reset,
 not quota token counts. The two Claude windows use compact `5h` and `7d`
@@ -195,10 +192,11 @@ for Claude, a `ttl≈...` estimate from the provider's 5-minute/1-hour bucket.
 This is local diagnostic math, not a server-confirmed expiry; the first session
 update reads the existing transcript once, then later updates read only
 appended bytes.
-Codex shows a short session preview from its local state database; its live
-context and cache fields are not queried because the current safe app-server
-connection is quota-only and does not attach to an active thread. Grok's
-current billing source has neither context nor cache fields. During a working
+Codex shows five-hour and weekly windows plus a short session preview from its
+local state database; its live context and cache fields are not queried because
+the current safe app-server connection is quota-only and does not attach to an
+active thread. Grok's current billing source has neither context nor cache
+fields. During a working
 turn, one short-lived global watcher polls once per configured interval,
 coalesces active fetches, and exits when all selected providers settle. The
 sidebar does not run a permanent daemon.
@@ -275,8 +273,8 @@ rows = [
   cache-expiry value. Herdr reports no more than sixteen metadata tokens; old
   `$quota_icon`/`$quota_status` fields are cleaned up during migration.
 
-Herdr 0.8 only accepts fixed hex colors for styled tokens, not semantic theme
-colors. The default palette uses soft, high-luminance green, amber, and red
+Herdr accepts fixed hex colors for styled tokens, not semantic theme colors.
+The default palette uses soft, high-luminance green, amber, and red
 tones to reduce eye strain on Herdr's dark sidebar while keeping each health
 state easy to scan.
 
@@ -284,7 +282,7 @@ Provider styling uses Herdr's static `rows_by_agent` projection, while quota
 health remains dynamic metadata. This keeps branding and health logic separate
 and avoids spending additional metadata-token capacity on static labels.
 
-Herdr plugin v1 accepts text tokens, not provider image components. For that
+The Herdr plugin API accepts text tokens, not provider image components. For that
 reason the default layout uses the readable provider name and keeps Herdr's
 native dot instead of adding low-recognition Unicode or SVG markers. The
 checked-in [`docs/icons/`](docs/icons/) assets are optional visual references;
@@ -299,12 +297,12 @@ such as `Thinking` or `Executing`. It does not show the working directory.
 
 - **Codex:** the local official [app-server JSON-RPC](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)
   rate-limit response plus one bounded, state-database-only `thread/list` for
-  session previews. The plugin accepts the seven-day window by duration, rather
-  than assuming which field is primary. API-key authentication is intentionally
-  not mislabeled as a ChatGPT subscription quota. It does not resume threads or
-  read rollout JSONL, so it cannot claim a live context percentage. Only the
-  first non-empty line of at most 50 previews is retained, truncated to 80
-  characters.
+  session previews. The plugin maps the provider-reported five-hour and
+  seven-day windows by duration, rather than assuming which field is primary.
+  API-key authentication is intentionally not mislabeled as a ChatGPT
+  subscription quota. It does not resume threads or read rollout JSONL, so it
+  cannot claim a live context percentage. Only the first non-empty line of at
+  most 50 previews is retained, truncated to 80 characters.
 - **Grok:** the local `~/.grok/auth.json` login key is read in memory and sent
   to the weekly billing endpoint used by the Grok CLI. The response is accepted
   only when it identifies a weekly period. This is SuperGrok usage, not xAI

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@ Claude Code、Codex、Grok 和 Agy/Antigravity 的订阅额度。
 
 [![CI](https://github.com/levi-qiao/herdr-agent-quota/actions/workflows/ci.yml/badge.svg)](https://github.com/levi-qiao/herdr-agent-quota/actions/workflows/ci.yml)
 [![Rust](https://img.shields.io/badge/built%20with-Rust-dea584?logo=rust&logoColor=white)](https://www.rust-lang.org/)
-[![Herdr plugin](https://img.shields.io/badge/Herdr-plugin-0.8%2B-5b6ee1)](https://herdr.dev/docs/plugins/)
+[![Herdr plugin](https://img.shields.io/badge/Herdr-plugin-supported-5b6ee1)](https://herdr.dev/docs/plugins/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/levi-qiao/herdr-agent-quota?style=social)](https://github.com/levi-qiao/herdr-agent-quota)
 
@@ -21,11 +21,11 @@ Claude Code、Codex、Grok 和 Agy/Antigravity 的订阅额度。
 
 ![Herdr 左侧额度截图](docs/screenshots/herdr-sidebar-live.png)
 
-*真实的 Herdr 工作区：Claude 在一行紧凑显示 5 小时和 7 天额度及其重置倒计时，
-Codex、Grok 显示周额度；每张 agent 卡片的话题来自用户最后一次输入，
+*真实的 Herdr 工作区：Claude 和 Codex 在一行紧凑显示 5 小时和 7 天额度及其重置倒计时，
+Grok 显示周额度；每张 agent 卡片的话题来自用户最后一次输入，
 不会使用 AI 生成的状态标题。*
 
-- **四个 CLI，一个侧栏** —— Claude Code、Codex、Grok、Agy/Antigravity。
+- **四个 provider，一个侧栏** —— Claude Code、OpenAI Codex、Grok、Agy/Antigravity。
 - **按能力显示的紧凑卡片** —— provider、当前输入/会话摘要、可用的 context
   百分比和额度窗口；不支持的行自动隐藏。
 - **全本地** —— 不上传任何用量数据，不读浏览器 cookie 和系统钥匙串，
@@ -66,8 +66,8 @@ Codex、Grok 显示周额度；每张 agent 卡片的话题来自用户最后一
 
 ## 快速开始
 
-要求：Herdr `0.8.0+`、Rust `1.95+`、macOS 或 Linux，以及至少一个支持的
-CLI。下载仓库后，在目录中执行下面的一键安装命令即可完成构建、链接、启用和
+要求：Herdr、Rust 工具链、macOS 或 Linux，以及至少一个支持的 provider CLI。
+下载仓库后，在目录中执行下面的一键安装命令即可完成构建、链接、启用和
 可恢复配置：
 
 ```sh
@@ -143,17 +143,14 @@ action 完成后，如需连插件注册也删除，再执行
 usage、topic 三类 token，不会覆盖官方 agent 指示。卸载 action 会删除插件
 添加的行，并恢复原来的 Claude/Agy `statusLine`。
 
-## 支持的 CLI
+## 支持的 provider
 
-| CLI | 侧栏显示 | 本地数据来源 | 额外配置 |
+| Provider | 侧栏显示 | 本地数据来源 | 额外配置 |
 | --- | --- | --- | --- |
-| Claude Code `2.1.233` | `5h` + `7d` + context + 缓存命中率/近似 TTL | 官方 `statusLine` JSON：`rate_limits`、`context_window`、`transcript_path` | 配置 action 自动安装/串联，并保持原生刷新间隔与 watcher 一致 |
-| OpenAI Codex `0.147.0` | `week` + 本地会话摘要 | 一次性的 `codex app-server --stdio`：额度和有上限的 `thread/list` | 使用 ChatGPT 订阅登录；API key 模式显示为不可用；不会 resume thread |
-| Grok CLI / Grok Build `1.0.4` | `week` | `~/.grok/auth.json` 和官方 CLI 使用的额度接口 | 由统一 watcher 处理，不再安装回复 hook |
-| Agy / Antigravity CLI `1.1.13` | `5h` + `week` + context + 缓存命中率 | 官方 `statusLine` JSON 的 `quota` 和 `context_window` | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
-
-上面的版本是 2026-08-15 在开发机上实际检查的版本。解析器按照供应商的
-字段工作，不会把这些版本号写死；兼容的新版本可以继续使用。
+| Claude Code | `5h` + `7d` + context + 缓存命中率/近似 TTL | 官方 `statusLine` JSON：`rate_limits`、`context_window`、`transcript_path` | 配置 action 自动安装/串联，并保持原生刷新间隔与 watcher 一致 |
+| OpenAI Codex | `5h` + `7d` + 本地会话摘要 | 一次性的 `codex app-server --stdio`：额度和有上限的 `thread/list` | 使用 ChatGPT 订阅登录；API key 模式显示为不可用；不会 resume thread |
+| Grok CLI / Grok Build | `week` | `~/.grok/auth.json` 和官方 CLI 使用的额度接口 | 由统一 watcher 处理，不再安装回复 hook |
+| Agy / Antigravity CLI | `5h` + `week` + context + 缓存命中率 | 官方 `statusLine` JSON 的 `quota` 和 `context_window` | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
 
 侧栏显示的是**额度剩余百分比**和距离下次额度重置的时间，不是额度 token 数量。
 Claude 的两个窗口会用紧凑的 `5h` 和 `7d` 标签放在同一行，但仍各自保留动态健康色。
@@ -161,7 +158,8 @@ Claude 和 Agy 的 statusLine 有 context 字段时，还会显示当前 context
 如果有 statusLine transcript 和 session id，`cache N.N%` 是主 session 的累计命中率
 （`read / (fresh + creation + read)`），不是最新一轮；同一行在 Claude 有明确的
 5 分钟/1 小时缓存桶时显示剩余 `ttl≈...`，这是本地近似，不是服务端确认的过期时间。
-首次 session 更新会读取一次已有 transcript，之后只读新增字节。Codex 会显示本地 state database 里的短会话预览；
+首次 session 更新会读取一次已有 transcript，之后只读新增字节。Codex 会显示 5 小时和
+7 天额度，以及本地 state database 里的短会话预览；
 当前安全的 app-server 连接只查额度，没有绑定活动 thread，因此不猜测 Codex context
 或缓存字段。Grok 当前的 billing 来源没有 context 或缓存字段。没有证据的字段会隐藏，
 不会伪造 `cached expires`：
@@ -174,7 +172,8 @@ Claude 和 Agy 的 statusLine 有 context 字段时，还会显示当前 context
   5h 100% 3h07m · 7d 31% 2d3h
 ```
 
-Codex 和 Grok 提供周额度；Claude Code 和 Agy 提供 5 小时额度与周额度。
+Codex 提供 5 小时和周额度；Grok 提供周额度；Claude Code 和 Agy 提供 5 小时额度与
+周额度。
 不到一小时显示分钟，不到一天显示小时和分钟，超过一天显示天和小时。
 侧栏数值在 agent 事件、working turn 的短生命周期刷新脉冲或手动刷新时重新计算，
 不是常驻的逐分钟跳动倒计时。
@@ -241,7 +240,7 @@ rows = [
   Herdr metadata 始终不超过 16 个 token；升级时会清理旧的 `$quota_icon`/
   `$quota_status` 字段。
 
-Herdr 0.8 的样式只接受固定十六进制颜色，不支持跟随主题的语义色。
+Herdr 的样式只接受固定十六进制颜色，不支持跟随主题的语义色。
 默认的绿色、琥珀色和红色采用高明度柔和色阶并加粗，降低 Herdr 深色侧栏
 长时间阅读的视觉疲劳，同时保持状态辨识度。
 
@@ -249,7 +248,7 @@ Provider 品牌样式通过 Herdr 静态 `rows_by_agent` 投影实现，额度�
 使用动态 metadata。两者相互独立，也不会为静态名称额外占用 metadata token
 容量。
 
-Herdr plugin v1 只支持文本 token，不能由插件向原生 Agent renderer 注入
+Herdr plugin API 只支持文本 token，不能由插件向原生 Agent renderer 注入
 品牌 SVG/PNG。因此默认使用清晰的 provider 名称和 Herdr 原生圆点，不再
 添加辨识度不高的 Unicode 图标。仓库中的 [`docs/icons/`](docs/icons/) 只
 作为可选视觉参考，不会被注入左侧原生 sidebar。
@@ -263,9 +262,10 @@ Herdr plugin v1 只支持文本 token，不能由插件向原生 Agent renderer 
 - **Codex：** 使用本地官方
   [app-server JSON-RPC](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)
   的 rate-limit 响应，并在同一进程里做一次有上限、只读 state database 的
-  `thread/list` 获取会话预览，按窗口时长识别周额度。不会 resume thread，也不读
-  rollout JSONL，因此不会声称拿到了实时 context 百分比。只保留最多 50 个预览的首个
-  非空行，并截断到 80 个字符。API key 登录不会被误标记为 ChatGPT 订阅额度。
+  `thread/list` 获取会话预览，按窗口时长识别 5 小时和 7 天额度，不依赖
+  `primary`/`secondary` 的位置。不会 resume thread，也不读 rollout JSONL，因此不会
+  声称拿到了实时 context 百分比。只保留最多 50 个预览的首个非空行，并截断到 80 个
+  字符。API key 登录不会被误标记为 ChatGPT 订阅额度。
 - **Grok：** 在内存中读取本地 `~/.grok/auth.json` 登录 key，访问 Grok CLI
   使用的周额度接口。只有明确标记为 weekly 的响应才会接受。这是
   SuperGrok 订阅额度，不是 xAI 开发者/API team 账单。统一 watcher 配合原有

--- a/docs/research/quota-reset-capability.md
+++ b/docs/research/quota-reset-capability.md
@@ -3,7 +3,7 @@
 > 研究日期：2026-08-15（Asia/Shanghai）  
 > 范围：本仓库现有四个 provider（Codex、Grok、Claude Code、Agy/Antigravity）。  
 > 来源约束：只使用供应商官方文档/官方 CLI 源码，以及本仓库已有 parser、fixture 和类型；没有用二手文章推断供应商字段。
-> 产品决策：虽然 Codex 5h 窗口在能力上可推导，本次实施按需求仍只展示 Codex weekly。
+> 产品决策：Codex 按供应商返回的窗口时长展示 5h 和 weekly，不依赖 primary/secondary 的字段位置。
 
 ## 结论先行
 
@@ -11,7 +11,7 @@
 
 | CLI | 5h 窗口 | weekly 窗口 | 一手字段 | 当前实现结论 |
 | --- | --- | --- | --- | --- |
-| OpenAI Codex | `inferred`：官方 schema 支持按 `windowDurationMins` 描述窗口；仓库 fixture 使用 300 分钟 | `confirmed`：仓库 fixture 使用 10080 分钟，官方 schema 说明窗口时长与 reset 字段 | `resetsAt`，Unix epoch 秒（绝对时间） | 已实施 weekly-only，数字 reset 已归一化 |
+| OpenAI Codex | `inferred`：官方 schema 支持按 `windowDurationMins` 描述窗口；仓库 fixture 使用 300 分钟 | `confirmed`：仓库 fixture 使用 10080 分钟，官方 schema 说明窗口时长与 reset 字段 | `resetsAt`，Unix epoch 秒（绝对时间） | 已按窗口时长读取 5h 与 weekly，数字 reset 已归一化 |
 | Claude Code | `confirmed` | `confirmed` | `rate_limits.*.resets_at`，文档为 Unix 秒，2.1.233 statusLine 实现也可输出 RFC 3339 | 两种时间类型均已归一化 |
 | Grok CLI / Grok Build | `unsupported`：官方 credits config 只有当前 weekly/monthly period，没有 5h bucket | `confirmed` | `config.currentPeriod.end`，RFC 3339（绝对时间） | weekly `end` 已正确读取；不要从 weekly 猜造 5h |
 | Agy / Antigravity | `confirmed`（仓库已有 `gemini-5h`/`3p-5h` 合同） | `confirmed`（仓库已有 `gemini-weekly`/`3p-weekly` 合同） | `quota[*].reset_time`（绝对时间）或可选 `reset_in_seconds`（相对时长） | 5h/weekly 绝对字段已读取；相对字段未读取 |
@@ -40,7 +40,10 @@ Codex `app-server` 的官方 v0.147.0 文档在 `account/rateLimits/read` 中给
 
 本仓库的 Codex fixture 给出了实际选择所需的 300 分钟（5h）和 10080 分钟（7d）窗口（[`tests/fixtures/codex/rate-limits-weekly.json`](../../tests/fixtures/codex/rate-limits-weekly.json#L4-L13)）。因此建议把“按 duration 映射”视为仓库已验证合同，把 5h 的上游稳定性标成 `inferred`，不要按对象位置猜测。
 
-**当前 parser：** [`src/providers/codex.rs`](../../src/providers/codex.rs#L29-L58) 只保留 `duration >= 10_000` 的 weekly，并且 `resetsAt` 通过 `Value::as_str` 读取。官方数字 Unix 秒会被静默转换成 `None`；5h 被有意丢弃。也就是说，Codex **可以支持 weekly 的精确 reset，也能按官方 schema 支持 5h，但当前代码尚未支持这两件事的完整组合**。
+**当前 parser：** [`src/providers/codex.rs`](../../src/providers/codex.rs) 按
+`windowDurationMins` 将 300/10080 分钟分别映射为 5h/weekly，并兼容数字或文本
+形式的 `resetsAt`。因此 Codex 的两个窗口都会进入同一个快照，且不依赖
+`primary`/`secondary` 的位置。
 
 **实现边界：**
 
@@ -137,7 +140,7 @@ ResetAt(i64)                 # Unix 秒，统一绝对时间
 
 第一版不需要增加 `$quota_5h_reset`/`$quota_week_reset`。让 presentation module 统一生成现有 `$quota_5h`、`$quota_week`和 `$quota_summary`，即可同时满足默认布局、dashboard 和已有自定义布局。只有当第二种布局真的需要独立 reset 时，再扩大 token interface。
 
-这个 module 应根据 `snapshot.windows` 中实际存在的窗口按 `5h -> week` 排序，不再 `match Provider`来决定展示哪些窗口。因此 Codex 增加 5h 只是 adapter 多输出一个 window，Grok 仍只输出 week，presentation 代码不需要改。
+这个 module 应根据 `snapshot.windows` 中实际存在的窗口按 `5h -> week` 排序，不再 `match Provider`来决定展示哪些窗口。因此 Codex 输出两个窗口只需由 adapter 提供两个 window，Grok 仍只输出 week，presentation 代码不需要按 provider 分支。
 
 ### 4. 明确刷新语义
 
@@ -152,7 +155,7 @@ ResetAt(i64)                 # Unix 秒，统一绝对时间
 
 1. **先修合同：** 把 Codex/Claude fixture 改为官方 Unix 数字；Codex 增加 300/10080 分钟双窗口断言，Agy 增加仅 `reset_in_seconds` 样例。验证目标是先让现有 parser 在真实 schema 测试下暴露失败。
 2. **再建时间 seam：** 把 `UsageWindow.resets_at: Option<String>` 改为 typed `Option<ResetAt>`；Unix 数字直接归一化，RFC 3339 只在共享的小型解析 helper 中处理。现有依赖没有 RFC 3339 parser，实现时建议只增加一个轻量 `time` 依赖的 parsing 能力，不引入 async/runtime 或时区数据库。
-3. **逐个改 adapter：** Codex 按 duration 只输出 week；Claude 读 Unix reset；Grok 严格解析 weekly RFC 3339 end；Agy 保留最低池聚合并增加 relative fallback。每个提交都可以用该 adapter 的纯 parser 测试独立验证。
+3. **逐个改 adapter：** Codex 按 duration 输出 5h/week；Claude 读 Unix reset；Grok 严格解析 weekly RFC 3339 end；Agy 保留最低池聚合并增加 relative fallback。每个提交都可以用该 adapter 的纯 parser 测试独立验证。
 4. **最后接展示：** 引入共享 presentation module，让 metadata 和 dashboard 通过同一 interface 生成文本；删除重复的 provider-specific summary 分支，但不改 Herdr 布局和 token 名。
 
 这个顺序把 schema 正确性、内部模型、供应商 adapter 和 UI 变更分开；出问题时能直接定位在对应 module，不需要同时理解四家原始 JSON 与 Herdr 字符串布局。

--- a/src/model.rs
+++ b/src/model.rs
@@ -393,8 +393,8 @@ impl ProviderSnapshot {
 
     pub fn severity(&self, now_unix: u64) -> Severity {
         let relevant = match self.provider {
-            Provider::Codex | Provider::Grok => self.window(WindowKind::Weekly),
-            Provider::Claude | Provider::Agy => self
+            Provider::Grok => self.window(WindowKind::Weekly),
+            Provider::Codex | Provider::Claude | Provider::Agy => self
                 .window(WindowKind::FiveHour)
                 .or_else(|| self.window(WindowKind::Weekly)),
         };
@@ -565,6 +565,36 @@ mod tests {
         assert_eq!(Severity::for_window(&healthy, now), Severity::Normal);
         assert_eq!(Severity::for_window(&behind, now), Severity::Warning);
         assert_eq!(Severity::for_window(&danger, now), Severity::Danger);
+    }
+
+    #[test]
+    fn codex_severity_prefers_the_five_hour_window_when_available() {
+        let now = 1_000_000;
+        let snapshot = ProviderSnapshot::new(
+            Provider::Codex,
+            vec![
+                UsageWindow::new(
+                    WindowKind::FiveHour,
+                    90.0,
+                    Some(ResetAt::after(
+                        now,
+                        WindowKind::FiveHour.duration_seconds() / 2,
+                    )),
+                )
+                .unwrap(),
+                UsageWindow::new(
+                    WindowKind::Weekly,
+                    10.0,
+                    Some(ResetAt::after(
+                        now,
+                        WindowKind::Weekly.duration_seconds() / 2,
+                    )),
+                )
+                .unwrap(),
+            ],
+            now,
+        );
+        assert_eq!(snapshot.severity(now), Severity::Danger);
     }
 
     #[test]

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -16,6 +16,8 @@ use std::time::Duration;
 use std::os::unix::process::CommandExt;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+const FIVE_HOUR_WINDOW_MINUTES: u64 = 5 * 60;
+const WEEKLY_WINDOW_MINUTES: u64 = 7 * 24 * 60;
 
 pub fn parse_rate_limits(
     value: &Value,
@@ -26,38 +28,65 @@ pub fn parse_rate_limits(
         .get("rateLimits")
         .or_else(|| result.get("rate_limits"))
         .ok_or_else(|| ProviderError::UnsupportedResponse("missing rateLimits".to_string()))?;
-    let objects = [limits.get("primary"), limits.get("secondary")]
+    let mut windows = Vec::new();
+    for candidate in [limits.get("primary"), limits.get("secondary")]
         .into_iter()
-        .flatten();
-    let weekly = objects
-        .filter_map(|candidate| {
-            let duration = candidate
-                .get("windowDurationMins")
-                .or_else(|| candidate.get("window_duration_mins"))
-                .and_then(Value::as_u64)?;
-            if duration != 10_080 {
-                return None;
-            }
-            let used = candidate
-                .get("usedPercent")
-                .or_else(|| candidate.get("used_percent"))
-                .and_then(Value::as_f64)?;
-            let reset = candidate
-                .get("resetsAt")
-                .or_else(|| candidate.get("resets_at"))
-                .and_then(Value::as_u64)
-                .map(ResetAt::from_unix_seconds);
-            Some((used, reset))
-        })
-        .next()
-        .ok_or_else(|| ProviderError::UnsupportedResponse("no seven-day rate limit".to_string()))?;
-    let window = UsageWindow::new(WindowKind::Weekly, weekly.0, weekly.1)
-        .map_err(|error| ProviderError::UnsupportedResponse(error.to_string()))?;
+        .flatten()
+    {
+        let Some(kind) = candidate
+            .get("windowDurationMins")
+            .or_else(|| candidate.get("window_duration_mins"))
+            .and_then(Value::as_u64)
+            .and_then(window_kind)
+        else {
+            continue;
+        };
+        if windows
+            .iter()
+            .any(|window: &UsageWindow| window.kind == kind)
+        {
+            continue;
+        }
+        let Some(used) = candidate
+            .get("usedPercent")
+            .or_else(|| candidate.get("used_percent"))
+            .and_then(Value::as_f64)
+        else {
+            continue;
+        };
+        let reset = candidate
+            .get("resetsAt")
+            .or_else(|| candidate.get("resets_at"))
+            .and_then(parse_reset);
+        let window = UsageWindow::new(kind, used, reset)
+            .map_err(|error| ProviderError::UnsupportedResponse(error.to_string()))?;
+        windows.push(window);
+    }
+    if windows.is_empty() {
+        return Err(ProviderError::UnsupportedResponse(
+            "no supported rate limit windows".to_string(),
+        ));
+    }
     Ok(ProviderSnapshot::new(
         Provider::Codex,
-        vec![window],
+        windows,
         fetched_at_unix,
     ))
+}
+
+fn window_kind(duration_minutes: u64) -> Option<WindowKind> {
+    match duration_minutes {
+        FIVE_HOUR_WINDOW_MINUTES => Some(WindowKind::FiveHour),
+        WEEKLY_WINDOW_MINUTES => Some(WindowKind::Weekly),
+        _ => None,
+    }
+}
+
+fn parse_reset(value: &Value) -> Option<ResetAt> {
+    value
+        .as_u64()
+        .map(ResetAt::from_unix_seconds)
+        .or_else(|| value.as_str().and_then(ResetAt::parse))
 }
 
 pub fn fetch() -> Result<ProviderSnapshot> {
@@ -311,7 +340,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn selects_weekly_codex_window_by_duration_not_position() {
+    fn selects_codex_windows_by_duration_not_position() {
         let value = json!({
             "result": {"rateLimits": {
                 "primary": {"usedPercent": 20.0, "windowDurationMins": 300, "resetsAt": 1786795200},
@@ -319,6 +348,11 @@ mod tests {
             }}
         });
         let snapshot = parse_rate_limits(&value, 1).unwrap();
+        assert_eq!(snapshot.windows.len(), 2);
+        assert_eq!(
+            snapshot.window(WindowKind::FiveHour).unwrap().resets_at,
+            Some(ResetAt::from_unix_seconds(1_786_795_200))
+        );
         assert_eq!(
             snapshot.window(WindowKind::Weekly).unwrap().resets_at,
             Some(ResetAt::from_unix_seconds(1_787_400_000))
@@ -326,9 +360,19 @@ mod tests {
     }
 
     #[test]
-    fn rejects_codex_response_without_seven_day_window() {
+    fn accepts_a_codex_response_with_only_the_five_hour_window() {
         let value = json!({"result": {"rateLimits": {
             "primary": {"usedPercent": 20.0, "windowDurationMins": 300}
+        }}});
+        let snapshot = parse_rate_limits(&value, 1).unwrap();
+        assert_eq!(snapshot.windows.len(), 1);
+        assert!(snapshot.window(WindowKind::FiveHour).is_some());
+    }
+
+    #[test]
+    fn rejects_codex_response_without_supported_windows() {
+        let value = json!({"result": {"rateLimits": {
+            "primary": {"usedPercent": 20.0, "windowDurationMins": 60}
         }}});
         assert!(parse_rate_limits(&value, 1).is_err());
     }

--- a/tests/provider_contracts.rs
+++ b/tests/provider_contracts.rs
@@ -7,10 +7,17 @@ fn fixture(value: &str) -> Value {
 }
 
 #[test]
-fn codex_fixture_exposes_only_the_weekly_contract() {
+fn codex_fixture_exposes_the_five_hour_and_weekly_contracts() {
     let value = fixture(include_str!("fixtures/codex/rate-limits-weekly.json"));
     let snapshot = codex::parse_rate_limits(&value, 1).unwrap();
-    assert_eq!(snapshot.windows.len(), 1);
+    assert_eq!(snapshot.windows.len(), 2);
+    assert_eq!(
+        snapshot
+            .window(WindowKind::FiveHour)
+            .unwrap()
+            .remaining_percent,
+        80.0
+    );
     assert_eq!(
         snapshot
             .window(WindowKind::Weekly)


### PR DESCRIPTION
## Summary
- parse Codex rate-limit windows by duration and publish both five-hour and seven-day limits
- prefer Codex five-hour health for the overall status when available
- update English/Chinese README provider guidance without concrete CLI version numbers
- align changelog and quota reset research notes

## Verification
- cargo fmt --all -- --check
- cargo test --all-targets --all-features --locked
- cargo clippy --release --all-targets --all-features --locked -- -D warnings
- cargo build --release --locked

Observed locally from Codex app-server: primary=300 minutes and secondary=10080 minutes.