### PR TITLE
fix: compact provider identity and isolate session diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Context now follows the provider name, while cache diagnostics use two
-  dedicated rows: a one-decimal cumulative session hit rate and the elapsed
-  time since the latest cache-bearing response plus an explicitly approximate
-  TTL estimate when the provider exposes a cache bucket. Claude/Agy collectors
-  use local statusLine/transcript data only; they do not log in or start model
-  requests.
+- Provider rows now use one compact `$quota_provider_model` identity token
+  (`Provider/Model`, with the model omitted when unavailable); provider and
+  model share the provider's brand color. Context is the penultimate row,
+  while cache diagnostics use a dedicated row: a one-decimal cumulative
+  session hit rate and the elapsed time
+  since the latest cache-bearing response plus an explicitly approximate TTL
+  estimate when the provider exposes a cache bucket or Codex supplies a
+  timestamped cache-bearing rollout event. Claude/Agy collectors use local
+  statusLine/transcript data only; they do not log in or start model requests.
+- Codex now reads the bounded tail of each matching local rollout to publish
+  per-session model, current context, and cumulative cache diagnostics. Grok
+  supplements its billing snapshot with bounded local `signals.json` and
+  `updates.jsonl` session metadata, so both providers expose context/cache when
+  the local session files contain those fields; missing data remains hidden.
+- Grok's weekly-only limit is placed beside context in its provider-specific
+  row, and Claude/Agy statusLine diagnostics are keyed by session so a fresh
+  session cannot inherit another session's cache. All per-session maps are
+  bounded to 128 entries.
 - Quota rows now show compact `5h`/`7d` window labels with minutes below one
   hour, hours and minutes below one day, and days plus hours for longer windows.
 - Cache hit rate and remaining cache TTL now share one short, color-separated
   sidebar row; the verbose last-activity text is no longer shown.
+- Cache, TTL, and context diagnostics now share one muted blue-gray style;
+  provider/model keep their brand color, while green/amber/red are reserved
+  for quota runway health and explicit errors.
 - Claude's plugin-owned statusLine now receives the configured global watcher
   interval as its native `refreshInterval`, keeping idle-session reset times
   fresh without an API call or model request; existing user-owned intervals are
@@ -71,6 +86,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   leaving an old weekly reset on the sidebar.
 - Weekly-only providers now use the readable `week ... reset ...` label; the
   compact `5h`/`7d` form remains for providers that expose both windows.
+- Grok local-session enrichment now checks only the pane-matched two-level
+  session paths, with a bounded newest-session fallback for direct refreshes;
+  it no longer recursively scans the entire historical session tree.
 
 - Agent topics now come only from the latest user prompt in pane output. Native
   `Thinking`/`Executing` titles and other AI status text are no longer published

--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ Agy/Antigravity subscription usage, in Herdr's agent sidebar.
 中文文档：[README.zh-CN.md](README.zh-CN.md)
 
 ```text
-● Owner · Claude
+● Owner · Claude/Sonnet
   hi                     ← what that pane is actually working on
-  context 23%             ← provider-native context percentage
   cache 99.6% · ttl≈58m    ← session hit rate · remaining cache TTL
+  context 23%             ← provider-native context percentage
   5h 100% 3h07m · 7d 31% 2d3h
 ```
 
 ![Live Herdr agent sidebar](docs/screenshots/herdr-sidebar-live.png)
 
 *A real Herdr workspace: Claude and Codex show five-hour and weekly reset ETAs
-on one compact row, Grok shows its weekly window, and each agent card uses
+on one compact row, Grok shows its weekly window beside context, and each agent card uses
 the latest user prompt rather than an AI-generated status.*
 
 - **Four providers, one sidebar** — Claude Code, OpenAI Codex, Grok, and
@@ -176,15 +176,15 @@ long turns no longer start one refresh command per tool call.
 
 | Provider | Sidebar windows | Local collection path | Extra setup |
 | --- | --- | --- | --- |
-| Claude Code | `5h` + `7d` + context + cache hit/approx. TTL | Official `statusLine` JSON: `rate_limits`, `context_window`, and `transcript_path` | The configure action installs/chains it and keeps its refresh interval current |
-| OpenAI Codex | `5h` + `7d` + local session summary | One-shot local `codex app-server --stdio`: quota and bounded `thread/list` | ChatGPT subscription login; API-key mode is shown as unavailable |
-| Grok CLI / Grok Build | `week` | Local `~/.grok/auth.json` and the billing contract used by the official CLI | Covered by the unified watcher; no response hook is installed |
-| Agy / Antigravity CLI | `5h` + `week` + context + cache hit | Official `statusLine` JSON: `quota` and `context_window` | The configure action installs and chains it automatically |
+| Claude Code | model + `5h` + `7d` + context + cache hit/approx. TTL | Official `statusLine` JSON: `model`, `rate_limits`, `context_window`, and `transcript_path` | The configure action installs/chains it and keeps its refresh interval current |
+| OpenAI Codex | model + `5h` + `7d` + context + cache + approx. TTL + local session summary | One-shot local `codex app-server --stdio` plus a bounded tail read of matching `~/.codex` rollout JSONL | ChatGPT subscription login; API-key mode is shown as unavailable |
+| Grok CLI / Grok Build | model + `week` + context + cache | Local `~/.grok/auth.json` billing plus bounded reads of `signals.json`/`updates.jsonl` session metadata | Covered by the unified watcher; no response hook is installed |
+| Agy / Antigravity CLI | model + `5h` + `week` + context + cache hit | Official `statusLine` JSON: `model`, `quota`, and `context_window` | The configure action installs and chains it automatically |
 
 The sidebar shows **percentage remaining** and the time until each quota reset,
 not quota token counts. The two Claude windows use compact `5h` and `7d`
 labels on one row; each still keeps its own dynamic health color. Claude and
-Agy also show provider-reported context percentage. When a statusLine transcript
+Agy also show the provider-reported model display name and context percentage. When a statusLine transcript
 and session id are available,
 `cache N.N%` is the cumulative main-session ratio
 (`read / (fresh + creation + read)`), not the latest turn. The same row shows,
@@ -192,14 +192,19 @@ for Claude, a `ttl≈...` estimate from the provider's 5-minute/1-hour bucket.
 This is local diagnostic math, not a server-confirmed expiry; the first session
 update reads the existing transcript once, then later updates read only
 appended bytes.
-Codex shows five-hour and weekly windows plus a short session preview from its
-local state database; its live context and cache fields are not queried because
-the current safe app-server connection is quota-only and does not attach to an
-active thread. Grok's current billing source has neither context nor cache
-fields. During a working
+Codex supplements its five-hour/weekly windows and short session preview with
+the latest `last_token_usage` context from the matching rollout tail and a
+cumulative cache ratio from its local token counters. When a cache-bearing
+rollout event has a timestamp, it also shows an explicitly approximate
+one-hour upper-bound TTL; Codex does not persist an exact expiry timestamp.
+Grok supplements its weekly billing window with model/context signals and the
+latest cache counters from the matching local session files. During a working
 turn, one short-lived global watcher polls once per configured interval,
 coalesces active fetches, and exits when all selected providers settle. The
 sidebar does not run a permanent daemon.
+
+Grok has only a weekly quota window, so its provider-specific row places that
+limit beside context instead of leaving an empty slot on the right.
 
 A failed refresh never replaces a successful cached value with `unavailable`;
 a provider without any successful snapshot is shown as `N/A` until its first
@@ -223,13 +228,14 @@ once:
 [ui.sidebar.agents]
 row_gap = 1 # herdr-agent-quota
 rows = [
-  ["state_icon", "tab", { token = "$quota_provider", bold = true, dim = false }, { token = "$quota_context", fg = "#9b8fd8", bold = true, dim = false }],
+  ["state_icon", "tab", { token = "$quota_provider_model", bold = true, dim = false }],
   [{ token = "$quota_topic", dim = false }],
   [
-    { token = "$quota_cache", fg = "#6fb5b7", bold = true, dim = false },
-    { token = "$quota_cache_ttl", fg = "#cdaa65", bold = true, dim = false },
+    { token = "$quota_cache", fg = "#9aa7b8", bold = true, dim = false },
+    { token = "$quota_cache_ttl", fg = "#9aa7b8", bold = true, dim = false },
     { token = "$quota_error", fg = "#ca6470", bold = true, dim = false },
   ],
+  [{ token = "$quota_context", fg = "#9aa7b8", bold = true, dim = false }],
   [
     { token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false },
     { token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false },
@@ -242,7 +248,13 @@ rows = [
 ```
 
 - `state_icon` and `tab` are Herdr's built-in status and plane labels.
-- `$quota_provider` is `Claude`, `Codex`, `Grok`, or `Agy`.
+- `$quota_provider_model` is the compact identity label `Provider/Model`, for
+  example `Claude/Sonnet`. When the model is unavailable it contains only the
+  provider name. `$quota_provider` and `$quota_model` remain available for
+  custom layouts and older configurations.
+- Model and provider values are tracked per session, so same-provider panes can
+  show different models; Codex and Grok hide the model only when their local
+  session data is unavailable.
 - Default provider labels use recognizable brand colors without affecting quota
   health: Claude soft orange, Codex pastel blue, Grok soft white, and an
   Antigravity-inspired mint for Agy.
@@ -250,15 +262,34 @@ rows = [
   then resource status.
 - For Codex, an empty/default prompt falls back to the short thread preview from
   the local app-server state database; other providers keep the prompt empty.
-- `$quota_context` is the provider-reported context **used** percentage and sits
-  directly after the provider name. `$quota_cache` is the cumulative hit rate
+- Codex context uses the latest rollout `last_token_usage` against its reported
+  model window; Codex cache uses the session token counters. If the latest
+  cache-bearing rollout event has a timestamp, `$quota_cache_ttl` shows an
+  explicitly approximate one-hour upper-bound estimate based on that activity;
+  it is not an exact server expiry. Grok context comes from `signals.json`, and
+  Grok cache from the latest usage update. These are local diagnostics, not
+  quota-window percentages; missing session fields stay hidden.
+- `$quota_context` is the provider-reported context **used** percentage and is
+  the penultimate row, immediately above the quota limits. `$quota_cache` is the cumulative hit rate
   for the main session transcript, not a per-turn value; it is shown to one
   decimal place so `99.6%` is not rounded to `100%`. `$quota_cache_ttl` is the
-  remaining approximate TTL when Claude exposes a 5m/1h bucket; when it reaches
-  zero, the red `$quota_error` token says `no cached`. Both cache values share
-  one row; missing fields are hidden instead of guessed.
-- The context row uses a violet accent (`#9b8fd8`) so context pressure is easy
-  to distinguish from the green/amber/red quota runway colors.
+  remaining approximate TTL when Claude exposes a 5m/1h bucket or Codex has a
+  timestamped cache-bearing rollout event; when it reaches zero, the red
+  `$quota_error` token says `no cached`. Both cache values share one row;
+  missing fields are hidden instead of guessed.
+- The provider and model share each provider's brand color so same-provider
+  cards are easy to scan. Cache, TTL, and context share one muted diagnostic
+  color (`#9aa7b8`); only quota runway health and explicit errors use green,
+  amber, and red.
+- For Grok's weekly-only quota, `rows_by_agent.grok` puts the weekly limit on
+  the context row because there is no five-hour value to occupy a separate
+  slot. Other providers keep context as the penultimate row and limits as the
+  final row.
+- Claude and Agy statusLine diagnostics are keyed by session. A new session
+  starts without the previous session's cache/context values; Codex and Grok
+  read only visible session files. Per-session diagnostic maps are capped at
+  128 entries, and the watcher uses one metadata-only Herdr inventory call per
+  poll, so historical sessions cannot grow memory without bound.
 - Each window publishes exactly one styled variant. Herdr renders adjacent
   values on the same row with `·` separators and removes separators for missing
   values, so 5h/7d stay compact while retaining independent colors. Color
@@ -297,15 +328,17 @@ such as `Thinking` or `Executing`. It does not show the working directory.
 
 - **Codex:** the local official [app-server JSON-RPC](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)
   rate-limit response plus one bounded, state-database-only `thread/list` for
-  session previews. The plugin maps the provider-reported five-hour and
-  seven-day windows by duration, rather than assuming which field is primary.
-  API-key authentication is intentionally not mislabeled as a ChatGPT
-  subscription quota. It does not resume threads or read rollout JSONL, so it
-  cannot claim a live context percentage. Only the first non-empty line of at
-  most 50 previews is retained, truncated to 80 characters.
+  session previews. For those returned thread ids, the plugin reads only the
+  tail of the matching `~/.codex/sessions`/`archived_sessions` rollout JSONL:
+  `last_token_usage` supplies current context and the cumulative token bucket
+  supplies cache hit rate. It never resumes a thread or starts a model turn.
+  API-key authentication is intentionally not mislabeled as a ChatGPT quota;
+  only the first non-empty line of at most 50 previews is retained.
 - **Grok:** the local `~/.grok/auth.json` login key is read in memory and sent
   to the weekly billing endpoint used by the Grok CLI. The response is accepted
-  only when it identifies a weekly period. This is SuperGrok usage, not xAI
+  only when it identifies a weekly period. A bounded scan of the newest local
+  session metadata (`signals.json` and the tail of `updates.jsonl`) supplements
+  model, context, and cache counters. This is SuperGrok usage, not xAI
   developer/API-team billing. The unified watcher and the existing 60-second
   debounce limit active requests; it never logs in or refreshes the key.
 - **Claude Code:** the official [`statusLine` JSON hook](https://code.claude.com/docs/en/statusline)
@@ -320,6 +353,11 @@ such as `Thinking` or `Executing`. It does not show the working directory.
   transcript once and later updates read only appended lines. A cache bucket
   gives the explicitly approximate `ttl≈...`; there is no network request or
   model turn.
+- **OpenAI Codex:** the matching rollout tail supplies token counters and event
+  timestamps. The adapter uses the latest cache-bearing event to show a local
+  approximate one-hour upper-bound TTL, following [OpenAI's prompt-cache
+  retention guidance](https://openai.com/index/api-prompt-caching/); the rollout
+  does not expose an exact expiry timestamp.
 - **Agy/Antigravity:** the official [`/usage` and statusline docs](https://antigravity.google/docs/cli/commands/usage?app=antigravity-ide)
   supply Gemini and third-party pools plus context-used percentage and cache
   counters. When both pools exist, the sidebar uses the lowest remaining
@@ -368,6 +406,10 @@ The cache/context field investigation and open-source comparison are documented
 in [`docs/research/cache-observability-open-source.md`](docs/research/cache-observability-open-source.md).
 The Grok source investigation is documented in
 [`docs/research/codexbar-grok-usage.md`](docs/research/codexbar-grok-usage.md),
+and the Codex/Grok local context-cache comparison is in
+[`docs/research/codex-grok-context-cache.md`](docs/research/codex-grok-context-cache.md),
+the issue-22 display/session design is in
+[`docs/research/issue-22-model-display.md`](docs/research/issue-22-model-display.md),
 and the implementation contract is in
 [`docs/plans/herdr-agent-quota-implementation.md`](docs/plans/herdr-agent-quota-implementation.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,17 +12,17 @@ Claude Code、Codex、Grok 和 Agy/Antigravity 的订阅额度。
 [English README](README.md)
 
 ```text
-● Owner · Claude
+● Owner · Claude/Sonnet
   hi                     ← 这个 pane 当前在做什么
-  context 23%             ← provider 原生 context 百分比
   cache 99.6% · ttl≈58m    ← session 命中率 · 剩余缓存时间
+  context 23%             ← provider 原生 context 百分比
   5h 100% 3h07m · 7d 31% 2d3h
 ```
 
 ![Herdr 左侧额度截图](docs/screenshots/herdr-sidebar-live.png)
 
 *真实的 Herdr 工作区：Claude 和 Codex 在一行紧凑显示 5 小时和 7 天额度及其重置倒计时，
-Grok 显示周额度；每张 agent 卡片的话题来自用户最后一次输入，
+Grok 把周额度放在 context 旁边；每张 agent 卡片的话题来自用户最后一次输入，
 不会使用 AI 生成的状态标题。*
 
 - **四个 provider，一个侧栏** —— Claude Code、OpenAI Codex、Grok、Agy/Antigravity。
@@ -147,28 +147,29 @@ usage、topic 三类 token，不会覆盖官方 agent 指示。卸载 action 会
 
 | Provider | 侧栏显示 | 本地数据来源 | 额外配置 |
 | --- | --- | --- | --- |
-| Claude Code | `5h` + `7d` + context + 缓存命中率/近似 TTL | 官方 `statusLine` JSON：`rate_limits`、`context_window`、`transcript_path` | 配置 action 自动安装/串联，并保持原生刷新间隔与 watcher 一致 |
-| OpenAI Codex | `5h` + `7d` + 本地会话摘要 | 一次性的 `codex app-server --stdio`：额度和有上限的 `thread/list` | 使用 ChatGPT 订阅登录；API key 模式显示为不可用；不会 resume thread |
-| Grok CLI / Grok Build | `week` | `~/.grok/auth.json` 和官方 CLI 使用的额度接口 | 由统一 watcher 处理，不再安装回复 hook |
-| Agy / Antigravity CLI | `5h` + `week` + context + 缓存命中率 | 官方 `statusLine` JSON 的 `quota` 和 `context_window` | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
+| Claude Code | model + `5h` + `7d` + context + 缓存命中率/近似 TTL | 官方 `statusLine` JSON：`model`、`rate_limits`、`context_window`、`transcript_path` | 配置 action 自动安装/串联，并保持原生刷新间隔与 watcher 一致 |
+| OpenAI Codex | model + `5h` + `7d` + context + cache + 近似 TTL + 本地会话摘要 | 一次性的 `codex app-server --stdio`，加上按 thread 匹配的 `~/.codex` rollout 尾部 | 使用 ChatGPT 订阅登录；API key 模式显示为不可用；不会 resume thread |
+| Grok CLI / Grok Build | model + `week` + context + cache | `~/.grok/auth.json` 额度接口，加上有上限的 `signals.json`/`updates.jsonl` 会话元数据 | 由统一 watcher 处理，不再安装回复 hook |
+| Agy / Antigravity CLI | model + `5h` + `week` + context + 缓存命中率 | 官方 `statusLine` JSON 的 `model`、`quota` 和 `context_window` | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
 
 侧栏显示的是**额度剩余百分比**和距离下次额度重置的时间，不是额度 token 数量。
 Claude 的两个窗口会用紧凑的 `5h` 和 `7d` 标签放在同一行，但仍各自保留动态健康色。
-Claude 和 Agy 的 statusLine 有 context 字段时，还会显示当前 context **已用**百分比。
+Claude、Agy，以及本地会话文件有对应字段的 Codex/Grok，会显示当前模型显示名和 context **已用**百分比。
 如果有 statusLine transcript 和 session id，`cache N.N%` 是主 session 的累计命中率
 （`read / (fresh + creation + read)`），不是最新一轮；同一行在 Claude 有明确的
 5 分钟/1 小时缓存桶时显示剩余 `ttl≈...`，这是本地近似，不是服务端确认的过期时间。
-首次 session 更新会读取一次已有 transcript，之后只读新增字节。Codex 会显示 5 小时和
-7 天额度，以及本地 state database 里的短会话预览；
-当前安全的 app-server 连接只查额度，没有绑定活动 thread，因此不猜测 Codex context
-或缓存字段。Grok 当前的 billing 来源没有 context 或缓存字段。没有证据的字段会隐藏，
+Codex 在最新 cache-bearing rollout 事件有时间戳时，也会按 OpenAI 文档的最长 1 小时
+保留上限显示近似 TTL；它不是精确的服务端过期时间。首次 session 更新会读取一次已有 transcript，之后只读新增字节。Codex 会显示 5 小时和
+7 天额度，以及本地 state database 里的短会话预览；对应 rollout 尾部的
+`last_token_usage` 提供当前 context，累计 token bucket 提供 cache 命中率。Grok 的
+`signals.json`/`updates.jsonl` 提供模型、context 和 cache。没有证据的字段会隐藏，
 不会伪造 `cached expires`：
 
 ```text
-● Owner · Claude
+● Owner · Claude/Sonnet
   hi
-  context 23%
   cache 99.6% · ttl≈58m
+  context 23%
   5h 100% 3h07m · 7d 31% 2d3h
 ```
 
@@ -196,13 +197,14 @@ Agy 通过原生的一次性 `statusLine` hook 把额度 JSON 传给插件。配
 [ui.sidebar.agents]
 row_gap = 1 # herdr-agent-quota
 rows = [
-  ["state_icon", "tab", { token = "$quota_provider", bold = true, dim = false }, { token = "$quota_context", fg = "#9b8fd8", bold = true, dim = false }],
+  ["state_icon", "tab", { token = "$quota_provider_model", bold = true, dim = false }],
   [{ token = "$quota_topic", dim = false }],
   [
-    { token = "$quota_cache", fg = "#6fb5b7", bold = true, dim = false },
-    { token = "$quota_cache_ttl", fg = "#cdaa65", bold = true, dim = false },
+    { token = "$quota_cache", fg = "#9aa7b8", bold = true, dim = false },
+    { token = "$quota_cache_ttl", fg = "#9aa7b8", bold = true, dim = false },
     { token = "$quota_error", fg = "#ca6470", bold = true, dim = false },
   ],
+  [{ token = "$quota_context", fg = "#9aa7b8", bold = true, dim = false }],
   [
     { token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false },
     { token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false },
@@ -215,18 +217,33 @@ rows = [
 ```
 
 - `state_icon`、`tab` 是 Herdr 内置的状态和 plane 标签。
-- `$quota_provider` 是 `Claude`、`Codex`、`Grok` 或 `Agy`。
+- `$quota_provider_model` 是紧凑的 `Provider/Model` 身份标签，例如
+  `Claude/Sonnet`；模型不可用时只显示 provider 名称。`$quota_provider` 和
+  `$quota_model` 仍保留给自定义布局和旧配置使用。
+- provider 和 model 都按 session 保存，因此同一 provider 的多个 pane 也能显示各自模型；
+  Codex/Grok 的本地会话数据不可用时才隐藏 model。
 - 默认 provider 名称使用易辨识的柔和品牌色，并且不影响额度健康色：
   Claude 柔橘、Codex 粉彩蓝、Grok 柔白、Agy 使用 Antigravity 风格薄荷绿。
 - `$quota_topic` 放在额度上方，阅读顺序是 agent、当前任务、资源状态。
 - Codex 的空/默认 prompt 会回退为本地 app-server state database 的短会话预览；
   其他 provider 仍保持空白。
-- `$quota_context` 显示 provider 报告的 context **已用**百分比，并紧跟在 provider
-  名称后面。`$quota_cache` 是主 session transcript 的累计命中率，不是每一轮的比例；
+- Codex context 使用 rollout 的最新 `last_token_usage` 与模型窗口计算，cache 使用
+  session token counters；如果最新 cache-bearing rollout 事件有时间戳，`$quota_cache_ttl`
+  会显示按最长 1 小时保留上限计算的近似值，不冒充精确过期时间。Grok context 使用
+  `signals.json`，cache 使用最新 usage update。这些是本地诊断值，不是额度窗口百分比。
+- `$quota_context` 显示 provider 报告的 context **已用**百分比，位于倒数第二行、
+  额度 limit 行之前。`$quota_cache` 是主 session transcript 的累计命中率，不是每一轮的比例；
   固定保留一位小数，避免 `99.6%` 被显示成 `100%`。`$quota_cache_ttl` 是 Claude
-  提供 5m/1h 缓存桶时的剩余近似 TTL；TTL 归零时用红色 `$quota_error` 显示
-  `no cached`。两个 cache 值共用一行；字段缺失时隐藏，不做猜测。
-- context 行使用紫色强调色（`#9b8fd8`），与额度续航的绿/琥珀/红色区分开。
+  提供 5m/1h 缓存桶，或 Codex 有带时间戳的 cache-bearing rollout 事件时的剩余近似 TTL；
+  TTL 归零时用红色 `$quota_error` 显示 `no cached`。两个 cache 值共用一行；字段缺失时隐藏，
+  不做猜测。
+- provider 和 model 共用各自 provider 的品牌色，方便快速识别；cache、TTL 和 context
+  共用一套低饱和诊断色（`#9aa7b8`），只有额度 limit 和明确错误使用绿/琥珀/红色。
+- Grok 只有周额度，因此 `rows_by_agent.grok` 会把周 limit 放到 context 同一行，
+  避免右侧留下空位；其他 provider 仍保持 context 倒数第二行、limit 最后一行。
+- Claude/Agy 的 statusLine 诊断按 session 隔离，新 session 不会继承上一 session 的
+  cache/context。Codex/Grok 只读取可匹配的本地会话文件；每个 provider 的 session
+  诊断最多保留 128 条，watcher 每轮只读取一次 Herdr 元数据，不会让历史会话无限增长。
 - 每个窗口只发布一个样式 token。Herdr 会把同一行相邻 token 自动用 `·`
   分隔，并在 token 缺失时移除对应分隔符，所以 5h/7d 会紧凑地显示在一行，
   但仍各自保留颜色。颜色按额度续航动态判断，不再使用固定余额阈值：将剩余
@@ -263,13 +280,15 @@ Herdr plugin API 只支持文本 token，不能由插件向原生 Agent renderer
   [app-server JSON-RPC](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)
   的 rate-limit 响应，并在同一进程里做一次有上限、只读 state database 的
   `thread/list` 获取会话预览，按窗口时长识别 5 小时和 7 天额度，不依赖
-  `primary`/`secondary` 的位置。不会 resume thread，也不读 rollout JSONL，因此不会
-  声称拿到了实时 context 百分比。只保留最多 50 个预览的首个非空行，并截断到 80 个
-  字符。API key 登录不会被误标记为 ChatGPT 订阅额度。
+  `primary`/`secondary` 的位置。对返回的 thread id 只读取匹配 rollout JSONL 的尾部：
+  `last_token_usage` 用于当前 context，累计 token bucket 用于 cache；不会 resume thread
+  或发起模型 turn。只保留最多 50 个预览的首个非空行，并截断到 80 个字符。API key
+  登录不会被误标记为 ChatGPT 订阅额度。
 - **Grok：** 在内存中读取本地 `~/.grok/auth.json` 登录 key，访问 Grok CLI
   使用的周额度接口。只有明确标记为 weekly 的响应才会接受。这是
   SuperGrok 订阅额度，不是 xAI 开发者/API team 账单。统一 watcher 配合原有
-  60 秒去抖查询额度，不会反复登录、刷新登录 key，也不会消耗对话 token。
+  60 秒去抖查询额度；另外有上限地读取最新会话的 `signals.json` 和 `updates.jsonl`
+  尾部，补充 model/context/cache，不会反复登录、刷新登录 key，也不会消耗对话 token。
 - **Claude Code：** 使用官方
   [`statusLine` JSON hook](https://code.claude.com/docs/en/statusline) 提供
   5 小时、7 天额度、context 已用百分比和最新缓存计数。原有 statusLine 会被备份、
@@ -277,6 +296,9 @@ Herdr plugin API 只支持文本 token，不能由插件向原生 Agent renderer
   间隔（默认 60 秒），因此空闲会话也会刷新绝对 reset 时间；用户已有的刷新间隔会
   保留。当输入提供 transcript 路径和 session id 时，采集器首次读取一次已有主会话
   并按 offset 增量累计，之后只读新增行；明确缓存桶才推断 `ttl≈...`，不联网、不发模型请求。
+- **OpenAI Codex：** 读取匹配 rollout 尾部的 token counters 与事件时间戳；最新一次
+  cache-bearing 事件按 OpenAI 的缓存保留说明显示最长 1 小时的本地近似 TTL，rollout
+  本身没有精确过期时间。[OpenAI prompt caching](https://openai.com/index/api-prompt-caching/)
 - **Agy/Antigravity：** 使用官方
   [`/usage` 和 statusline 文档](https://antigravity.google/docs/cli/commands/usage?app=antigravity-ide)
   中的 Gemini、第三方额度池、context 已用百分比和最新缓存计数。两个额度池同时存在时，
@@ -322,6 +344,10 @@ cargo build --release --locked
 [`docs/research/cache-observability-open-source.md`](docs/research/cache-observability-open-source.md)。
 Grok 调研记录见
 [`docs/research/codexbar-grok-usage.md`](docs/research/codexbar-grok-usage.md)，
+Codex/Grok 本地 context/cache 调研见
+[`docs/research/codex-grok-context-cache.md`](docs/research/codex-grok-context-cache.md)，
+issue #22 的显示与 session 设计见
+[`docs/research/issue-22-model-display.md`](docs/research/issue-22-model-display.md)，
 实现约定见
 [`docs/plans/herdr-agent-quota-implementation.md`](docs/plans/herdr-agent-quota-implementation.md)。
 

--- a/docs/plans/herdr-agent-quota-implementation.md
+++ b/docs/plans/herdr-agent-quota-implementation.md
@@ -101,6 +101,8 @@ longer sent as a separate metadata value:
 - `$quota_icon`: retired cleanup marker; native Herdr state plus provider name
   replaces this redundant value.
 - `$quota_provider`: `Codex`, `Grok`, `Claude`, or `Agy` for custom layouts.
+- `$quota_provider_model`: compact `Provider/Model` identity label used by the
+  default row; it falls back to provider-only when the session model is absent.
 - `$quota_status`: retired cleanup marker; quota window rows carry the visible
   health color.
 - `$quota_context`: provider-reported context-used percentage when available.
@@ -361,9 +363,10 @@ requests on the user's behalf.
 3. Back up the original once with a deterministic adjacent name.
 4. Retain Herdr's official `state_icon`/`tab` row (without the directory),
    add the plugin-owned `$quota_topic` as its own row, add
-   `$quota_provider` to the plane row, and add one compact row containing the
+   `$quota_provider_model` to the plane row, and add one compact row containing the
    styled `$quota_5h` and `$quota_week` variants. Herdr elides missing tokens
-   and their separators for weekly-only agents.
+   and their separators for weekly-only agents. The Grok provider projection
+   joins its weekly limit to the context row because it has no five-hour value.
    The topic token is extracted from the latest user prompt on event refresh;
    it stays empty instead of falling back to AI status titles. This keeps every
    agent to three readable lines and shows the provider name only once. The

--- a/docs/research/codex-grok-context-cache.md
+++ b/docs/research/codex-grok-context-cache.md
@@ -1,0 +1,176 @@
+# Codex 与 Grok 的 context/cache 展示调研
+
+研究日期：2026-08-26（Asia/Shanghai）  
+范围：本插件当前的 Codex/Grok 采集链路、OpenAI Codex 官方 app-server/TUI、Grok Build 官方 status line，以及成熟的 CodexBar 本地用量实现。  
+目标：解释截图中 Codex 只有 quota、没有 `context`/`cache` 的原因，并确定哪些字段可以安全接入 Herdr。
+
+## 结论
+
+截图是当前实现的预期结果，不是 Herdr 丢字段：
+
+- Codex adapter 只请求 `account/rateLimits/read` 和只读的 `thread/list`，后者只用于会话摘要；它没有订阅活动 thread 的 token-usage 事件，也没有扫描 rollout JSONL，因此不会产生 context/cache 快照。[`src/providers/codex.rs`](../../src/providers/codex.rs)
+- Grok adapter 只请求 CLI billing endpoint。这个响应提供周额度和 reset 时间，不提供会话 context 或 cache；Grok 的 context/cache 在另一条 status-line 输入链路中。[`src/providers/grok.rs`](../../src/providers/grok.rs)
+- 两个 provider 的官方数据源实际上都存在，但来源不同：Codex 要绑定活动 thread，Grok 应消费 status-line stdin。不能把 quota 响应里的字段“推导”成 context/cache，也不应把历史累计当作当前窗口占用。
+
+推荐实现顺序：
+
+1. **Grok 先接 status-line hook。** 官方 payload 已直接给出 model、当前 context 百分比、session 累计 cache read/create；复用 Claude/Agy 的本地 observation/cache 机制，不额外发模型请求。
+2. **Codex 再接本地 rollout 增量读取，或等待可绑定的长连接事件。** 若现在就做，按 Herdr 的 `agent_session`（thread id）只定位对应 rollout，取最新 `last_token_usage`；必须用文件 offset/累计高水位去重。不要为了读指标 `thread/resume`，也不要每轮扫描所有 session。
+3. 字段缺失就隐藏，绝不显示 `0%`、伪造 `no cached` 或把 quota reset 当 cache expiry。成功快照失败时保留上次值，避免 sidebar repaint/churn。
+
+## 实现状态（2026-08-26）
+
+本轮已按上述边界完成短期方案：刷新时复用一次 `herdr agent list` 的
+`agent_session`，Codex 只读取匹配 rollout 的有上限尾部（必要时读取有限的文件头补
+`turn_context` 模型），Grok 只读取匹配的 `signals.json` 和 `updates.jsonl` 尾部；直接
+命令行刷新没有 pane id 时才回退到有上限的最近 Grok sessions。快照按 session 保存
+`model` 与 `ContextUsage`，未知 session 不借用其他 pane 的数据，临时缺失则保留同一
+账号的 last-good diagnostics。UI 仍保持 context 倒数第二行、limit 最后一行。
+
+Codex rollout 的 token counters 没有服务端过期时间。若最新一次
+`last_token_usage` 带有 cache read/write 且事件有时间戳，adapter 会按 OpenAI
+[Prompt Caching](https://openai.com/index/api-prompt-caching/) 文档中的“最长一小时”
+保留上限计算 `ttl≈...`；这只是本地上限估计，不是精确的 eviction deadline。Grok 的
+xAI 文档说明 cache entry 可因负载或重启随时驱逐，因此仍隐藏 TTL，不把 cache hit
+时间戳或 billing reset 当成过期时间。
+
+## Codex：官方可用字段与当前缺口
+
+### 官方 app-server token-usage contract
+
+OpenAI 的 `thread/tokenUsage/updated` schema 明确包含：
+
+- `last`：最近一次/当前活动 context 的 token breakdown；
+- `total`：线程累计 token breakdown；
+- `modelContextWindow`：模型 context window；
+- breakdown 中的 `inputTokens`、`cachedInputTokens`、`cacheWriteInputTokens`、`outputTokens`、`totalTokens`。
+
+来源：[官方 `ThreadTokenUsageUpdatedNotification` schema](https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/json/v2/ThreadTokenUsageUpdatedNotification.json)。
+
+官方 app-server README 说明 token usage 是独立的实时通知流：客户端在 turn 期间消费 `thread/tokenUsage/updated`；`thread/resume` 才会把已持久化的 usage replay 给新的连接。[官方 app-server README：turn events](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md#turn-events)、[官方 app-server README：resume/replay](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md#resuming-threads)
+
+因此，单独启动一个一次性 `codex app-server --stdio`、读取 `rateLimits` 后立即退出，无法知道另一个已在运行的 pane 的活动 thread usage。调用 `thread/resume` 会加载/重新加入 thread，属于有状态操作，不符合本插件 quota-only watcher 的边界。
+
+### 官方 TUI 的 context 口径
+
+官方 TUI 源码把 `last_token_usage.total_tokens` 解释为“当前 active context”，把 `total_token_usage.total_tokens` 解释为“累计 session total”；context 剩余百分比使用 `model_context_window`，并预留 12,000-token baseline。它还把 `cached_input_tokens` 作为 input 的子集显示为 `(+ N cached)`。[官方 TUI `token_usage.rs`](https://github.com/openai/codex/blob/main/codex-rs/tui/src/token_usage.rs)
+
+对 Herdr 的含义：
+
+```text
+current_context_used = last.total_tokens
+context_percent = (current_context_used - 12_000)
+                  / (model_context_window - 12_000) * 100
+cache_hit_percent = last.cached_input_tokens / last.input_tokens * 100
+```
+
+上式只有在 `modelContextWindow > 12_000` 且 `inputTokens > 0` 时才成立；百分比必须 clamp 到 0–100，并标记为 provider 原生口径。`cacheWriteInputTokens` 虽然在 app-server schema 中存在，但 Codex 当前 Responses 解析链路可能丢弃它，不能把 0 解释为“没有 cache write”。[Codex 官方 issue：`cache_write_tokens` telemetry gap](https://github.com/openai/codex/issues/32479)
+
+### 当前 `thread/list` 不能给 model/context
+
+当前 `Thread` schema 的线程元数据有 `modelProvider`，没有活动 model、token usage 或 context usage；`thread/list` 适合历史列表，不是实时 context API。[官方 `ThreadListResponse` schema 的 `Thread` 定义](https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json#L888-L1080)
+
+`thread/start`/`thread/resume` 的响应会有 model，但这不能解决现有 pane 的活动 thread 关联问题；活动 turn 的真实模型还可能通过 rollout 的 `turn_context` 发生切换。若以后读取 rollout，应以当前 turn 的 `turn_context.payload.model` 为准，而不是把全局默认 model 当成当前模型。
+
+### 高质量实现：CodexBar 的分层做法
+
+[CodexBar 的 `CodexStatusSnapshot`](https://github.com/steipete/CodexBar/blob/main/Sources/CodexBarCore/Providers/Codex/CodexStatusProbe.swift) 的 live snapshot 只保存 credits、5h/weekly 百分比和 reset 时间；它没有把 `/status` 结果伪装成 context/cache。
+
+CodexBar 的另一条 **可选、本地、历史用量** 路径才读取：
+
+- `~/.codex/sessions/YYYY/MM/DD/*.jsonl`；
+- `~/.codex/archived_sessions/*.jsonl`；
+- `event_msg` 的 `token_count` 和 `turn_context`；
+- 解析结果写入本地 cache，供 cost/history 使用。
+
+具体说明见 [CodexBar Codex usage 文档](https://github.com/shaneholloman/codexbar/blob/main/docs/codex.md#local-codex-cost-estimates)。这是一种值得借鉴的分层：live quota 与本地历史 cost 分开；它不是“每个 pane 的实时 context HUD”。
+
+如果 Herdr 要在当前版本显示 Codex context/cache，最小安全实现是只读与 pane `agent_session` 对应的 rollout 文件：
+
+1. 先按 thread id 找文件，不能把所有 rollout 聚合后显示到每个 pane；
+2. 从末尾反向读有限窗口，找到最新有效 `token_count`；
+3. 使用 `last_token_usage`，不是 `total_token_usage`；
+4. 以文件 offset 或累计 `total_token_usage` 高水位去重，因为 Codex 可能重复广播未变化的 token_count；
+5. 发现 fork/subagent 继承前缀时，不把父线程前缀重复计入子线程；
+6. 找不到活动文件、window 缺失、计数无效时隐藏字段并保留上次成功快照。
+
+这条路径读的是本地会话内容元数据，仍有隐私和 I/O 成本；它应是显式的 bounded local read，不应放进每个 pane 的高频全量 watcher。长期更优方案是接入官方 app-server 的活动 thread 长连接，让 `thread/tokenUsage/updated` 按 thread id 写入本地 observation。
+
+## Grok：官方 status-line 已经提供完整字段
+
+### 官方 status-line payload
+
+Grok Build 官方 status-line 文档给出的内置默认项就是 `cwd`、`model`、`context`，示例为 `Grok 4.5 │ 12% ctx`。命令型 status line 从 stdin 接收 JSON；它是事件驱动的，只有显式设置 `refresh_interval` 才增加定时运行。[Grok Build 官方 status-line 文档](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#status-line)
+
+可直接消费的字段包括：
+
+| 字段 | 语义 |
+| --- | --- |
+| `session_id` | 稳定的会话 id，用于本地缓存隔离 |
+| `model.id` / `model.display_name` | 当前模型标识和可读名称 |
+| `context_window.context_window_size` | 当前模型 context 上限 |
+| `context_window.context_tokens` | 当前窗口实际占用的 input tokens；compact 后会下降 |
+| `context_window.used_percentage` / `remaining_percentage` | 当前窗口已用/剩余百分比 |
+| `context_window.session_usage.input_tokens` | 整个 session 的累计 uncached input |
+| `context_window.session_usage.cache_creation_input_tokens` | session 累计 cache creation |
+| `context_window.session_usage.cache_read_input_tokens` | session 累计 cache read |
+| `transcript_path` | Grok 自己的 `updates.jsonl`，不是 Claude transcript |
+
+字段语义和“缺失就不发送”的规则见 [官方 status-line available data](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#available-data)。Grok 官方还说明 `session_usage` 是累计 session 口径，不是单次请求；`context_tokens` 才是当前窗口口径。
+
+建议的 Grok 展示：
+
+```text
+context = used_percentage
+cache_hit = cache_read_input_tokens
+             / (input_tokens + cache_creation_input_tokens + cache_read_input_tokens)
+```
+
+当分母为 0 或字段缺失时隐藏 cache。不要把 `session_input_tokens / context_window_size` 当 context：session 累计 token 会超过 100%，官方明确把它与当前 `context_tokens` 区分开。
+
+### 官方 status-line 的刷新/失败行为可直接借鉴
+
+官方文档规定：
+
+- command status line 的 `refresh_interval` 会把“上次 payload”再次传给脚本；定时触发时 payload 中的 session 数字不是新的，只有脚本主动取到的外部数据才新鲜；
+- 网络脚本应使用较长间隔并读本地 cache，避免忙碌 turn 形成请求风暴；
+- 定时运行失败会保留上次输出；
+- 字段不可用时省略，而不是发送 `null`/占位符。
+
+这与本插件的安全目标一致：让 Grok status-line hook 负责采集一次 payload，插件只保存 observation；watcher 只刷新现有快照，不再单独扫描 pane 或发额外模型请求。
+
+### Grok 本地 session 文件是可行但次优的 fallback
+
+Grok 官方 shell 文档公开了本地布局：`~/.grok/sessions/<encoded-cwd>/<session-id>/summary.json`、`updates.jsonl`、`signals.json` 等；`signals.json` 保存 token usage 等 session signals。[官方 Grok shell storage layout](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-shell/README.md#storage-layout)、[官方 sessions 文档](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/17-sessions.md#storage-layout)
+
+本地 `signals.json` 确实可以提供 context/model 相关的 session signals，但路径按 cwd 编码、session 目录会 fork/subagent，且这是 CLI 内部持久化格式。优先级应低于 status-line stdin：只有 status-line 没安装或历史恢复场景，才考虑按明确 session id 读取一个 signals 文件；不能扫描所有 Grok session 后把最新值广播给所有 pane。
+
+## 参照方案与本插件的落地边界
+
+| Provider | 最可靠的实时来源 | 可显示的 context | 可显示的 cache | 目前为何看不到 |
+| --- | --- | --- | --- | --- |
+| Codex | 活动 thread 的 `thread/tokenUsage/updated`；短期可 bounded-read 对应 rollout | `last.total_tokens / modelContextWindow`，按官方 12k baseline 计算 | `cachedInputTokens / inputTokens`；cache write 仅在明确非零时展示 | 当前只读 rate limits + thread list，不绑定活动 thread |
+| Grok | 官方 status-line stdin | `context_window.used_percentage` | session_usage 的 read/create/fresh 累计比率 | 当前只读 billing endpoint，没有安装 Grok status-line observation |
+
+实现时应保持以下边界：
+
+- 不 resume Codex thread、不启动 warm-up turn、不为了 context/cache 请求模型；
+- 不把 Codex `total_token_usage` 或 Grok `session_input_tokens` 当当前 context；
+- 不把 billing quota 的 reset 时间当 cache TTL；两者是不同资源；
+- context 的显示口径写清楚“used”，cache 写 `cache N.N%`，避免把剩余/已用混淆；
+- provider 快照按 session/thread 隔离，同一 provider 的多个 pane 不得互相覆盖；
+- `visible` Herdr pane 读取规则不变：指标采集走本地 statusline/文件，不为此读取 pane；
+- 任何缺失或不可靠字段都隐藏，保留 last-good snapshot，避免 metadata repaint。
+
+## 参考来源
+
+- [OpenAI Codex app-server README](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)
+- [OpenAI `ThreadTokenUsageUpdatedNotification` schema](https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/json/v2/ThreadTokenUsageUpdatedNotification.json)
+- [OpenAI Codex TUI token usage implementation](https://github.com/openai/codex/blob/main/codex-rs/tui/src/token_usage.rs)
+- [OpenAI `ThreadListResponse` schema](https://github.com/openai/codex/blob/main/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json)
+- [OpenAI cache-write telemetry issue](https://github.com/openai/codex/issues/32479)
+- [CodexBar live Codex status probe](https://github.com/steipete/CodexBar/blob/main/Sources/CodexBarCore/Providers/Codex/CodexStatusProbe.swift)
+- [CodexBar local Codex usage/cost scanner](https://github.com/shaneholloman/codexbar/blob/main/docs/codex.md#local-codex-cost-estimates)
+- [Grok Build status-line guide](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md)
+- [Grok Build session storage layout](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-shell/README.md#storage-layout)
+- [Grok Build sessions guide](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/17-sessions.md#storage-layout)

--- a/docs/research/issue-22-model-display.md
+++ b/docs/research/issue-22-model-display.md
@@ -1,0 +1,109 @@
+# Issue #22：活动模型显示名可观测性调研
+
+研究日期：2026-08-26（Asia/Shanghai）  
+范围：GitHub issue #22、Claude Code statusLine、Google Antigravity/Agy statusLine、Codex app-server v2 `thread/list`，以及 Grok Build 的官方 status-line 合同。  
+来源约束：优先使用供应商官方文档和官方源码；Codex 源码固定到 2026-08-26 访问时的 `main` commit `2764e83626efe55f64e04d153fc99a157327f3c2`，Grok Build 固定到 `77cd7eb675ba911c225c3aaeeece3a20cbccc426`。移动中的文档页只代表访问日合同，不代表本地 CLI 永远不会变。
+
+## 结论先行
+
+| Provider | 当前一手本地来源 | 活动模型显示名字段 | 对本插件的结论 |
+| --- | --- | --- | --- |
+| Claude Code | `statusLine` 命令的 stdin JSON | `model.display_name`（同时有 `model.id`） | `confirmed`：直接解析显示名；缺失时隐藏，不从 id 猜人类名称。 [官方字段表](https://code.claude.com/docs/en/statusline#available-data) |
+| Agy / Antigravity CLI | `statusLine` 命令的 stdin JSON | 顶层 `model.display_name`（同时有 `model.id`） | `confirmed`：与 Claude 使用同一层级的可读字段；按 `session_id`/`conversation_id` 保存。 [官方字段表](https://antigravity.google/docs/cli/statusline/#available-json-fields) |
+| Codex app-server v2 | `thread/list` 返回的 `Thread` 摘要 | 只有 `modelProvider`，没有 thread-level `model` | `unsupported`（对当前 `thread/list` 调用）：不能把 provider 当模型。`thread/start`/`turn/start` 的 `model` 是请求覆盖，不会令 `thread/list` 返回活动模型。 [官方 Thread 定义](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs#L199-L243) |
+| Grok Build | 可选的 Grok `status_line` command/builtin | `model.id`、`model.display_name`，无法读取时省略 | `confirmed`（若接入 Grok status-line）；但本插件当前 Grok adapter 只读 billing endpoint，因此现有 quota 快照没有模型字段。 [官方可用字段](https://github.com/xai-org/grok-build/blob/77cd7eb675ba911c225c3aaeeece3a20cbccc426/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#available-data) |
+
+这意味着 issue #22 的 `$quota_model` 可以可靠覆盖 Claude 与 Agy；Grok 需要另有 status-line 输入才能覆盖，Codex 不能从现有独立 `thread/list` 轮询可靠得到活动模型。Issue 本身只把 Claude 的 `model.display_name` 作为已确认来源，并明确要求另外核查 Codex/Grok/Agy。[Issue #22](https://github.com/levi-qiao/herdr-agent-quota/issues/22#issue-3420898044)
+
+> **实现更新（2026-08-26）：** 上表刻意描述“仅凭 `thread/list`/billing”的边界；本插件随后增加了一个不改变该边界的本地补充层：Codex 只按返回的 thread id 读取对应 rollout 尾部的 `turn_context`，Grok 只读取本地 session 的 `signals.json`。因此现在 Codex/Grok 在本地文件提供字段时也会显示模型；context/cache 的字段来源和安全边界见 [`codex-grok-context-cache.md`](codex-grok-context-cache.md)。
+
+默认侧栏把 provider 和模型合并为一个 `$quota_provider_model`（例如
+`Claude/Sonnet`）；底层 `$quota_provider`/`$quota_model` 仍保留给自定义布局兼容使用。
+
+## Issue #22 要解决什么
+
+Issue 描述的是同一 provider 打开多个 pane 时，只显示 `Claude`/`Codex`/`Grok`/`Agy` 不足以区分 Sonnet、Opus 等实际模型；请求是增加 `$quota_model`，显示人类可读 display name，而不是完整模型 id。[Issue #22](https://github.com/levi-qiao/herdr-agent-quota/issues/22)
+
+Issue 作者已确认 Claude Code 的官方 statusLine stdin JSON 包含 `model` 对象，但没有伪造 Codex/Grok/Agy 的样例；因此以下把“官方字段存在”和“本插件当前采集链路能拿到”分开记录。[Issue #22 的来源说明](https://github.com/levi-qiao/herdr-agent-quota/issues/22#issue-3420898044)
+
+## 1. Claude Code：官方 statusLine 直接提供 display name
+
+### 观察到的事实
+
+- Claude Code 运行用户配置的 `statusLine` command，把 JSON session data 写到脚本 stdin；官方 available-data 表把 `model.id`、`model.display_name` 定义为当前模型的 identifier 和 display name。[Claude Code statusLine：Available data](https://code.claude.com/docs/en/statusline#available-data)
+- 官方完整 JSON 示例同时展示 `"model": { "id": "claude-opus-5", "display_name": "Opus" }`；官方示例脚本也是读取 `.model.display_name`，不是从 id 做字符串转换。[Claude Code statusLine 完整 schema](https://code.claude.com/docs/en/statusline#full-json-schema)
+- statusLine 在本地运行，不消耗 API token；它按 session/assistant 等事件驱动更新，适合在已有 hook 中读取而不是另起一个模型请求。[Claude Code statusLine 工作方式](https://code.claude.com/docs/en/statusline#how-status-lines-work)
+
+### 对实现的含义
+
+1. 解析顺序应是 `model.display_name`；`model.id` 只作为原始诊断字段（若未来确实需要），不应把 `claude-sonnet-*` 等 id 猜成 UI 名称。[字段定义](https://code.claude.com/docs/en/statusline#available-data)
+2. `$quota_model` 应是可选值。首个 payload 没有模型、字段为 `null` 或解析失败时，不写入空字符串覆盖已有值；同一 `session_id` 的上次有效 display name 可以保留，避免 sidebar 闪烁和 metadata repaint。[完整 schema 的缺失/null 说明](https://code.claude.com/docs/en/statusline#full-json-schema)
+3. 模型属于 session/pane 维度，不属于 provider 全局维度；状态缓存要按 `session_id`（必要时结合 transcript/session 边界）保存，不能让一个 Claude pane 的模型覆盖另一个 pane。[Claude statusLine 的 `session_id` 与 `model` 字段](https://code.claude.com/docs/en/statusline#full-json-schema)
+
+## 2. Agy / Antigravity CLI：同样有顶层 `model` 对象
+
+### 观察到的事实
+
+- Google Antigravity 官方 status-line customization 文档说明：每次 agent state 改变时，TUI 执行配置的命令，把详细状态 JSON 通过 stdin 传给脚本。[Antigravity status-line 配置](https://antigravity.google/docs/cli/statusline/#configuration)
+- 官方 available JSON fields 表明确列出顶层 `model` object，内容是 active model 的 `id` 和 `display_name`；它不是 quota bucket 名，也不是 `product` 字段。[Antigravity available JSON fields](https://antigravity.google/docs/cli/statusline/#available-json-fields)
+- 官方 sanitized payload 示例同时包含 `"model": { "id": "Gemini 3.5 Flash (High)", "display_name": "Gemini 3.5 Flash (High)" }`，并将 `quota` 另列为独立对象。这证明模型和额度池是两个不同合同。[Antigravity payload example](https://antigravity.google/docs/cli/statusline/#json-payload-example)
+
+### 对实现的含义
+
+1. Agy adapter 可直接复用“只取 `model.display_name`”的 statusLine parser；不应从 `quota` 的 `gemini-*`/`3p-*` key 反推模型名。[字段表](https://antigravity.google/docs/cli/statusline/#available-json-fields)
+2. 使用官方的 `session_id`（文档说明它是 `conversation_id` 的兼容别名）或 `conversation_id` 作为保存键；模型缺失时保留该 session 的上一条有效值，新的 session 则保持 unknown/隐藏。[字段表](https://antigravity.google/docs/cli/statusline/#available-json-fields)
+3. 该来源是现有 statusLine hook 的本地 stdin，不需要访问 pane、启动 headless prompt 或重新登录；这样不会把“显示模型”变成额外模型调用。[Antigravity status-line 配置与 stdin 语义](https://antigravity.google/docs/cli/statusline/#configuration)
+
+## 3. Codex app-server：`thread/list` 只有 provider，不提供活动模型
+
+### 观察到的事实
+
+- 截至上述 pinned commit，官方 v2 `Thread` 结构在 `model_provider`（JSON 为 `modelProvider`）上给出的语义是“Model provider used for this thread”；同一个结构从 `id`、`modelProvider`、时间、preview、status 到 turns 没有 `model` 字段。[Codex `Thread` 源码（pinned commit）](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs#L199-L243)
+- 生成的官方 JSON schema 也只把 `modelProvider` 列为 `Thread` 的 required property；`thread/list` 的 `data` 项引用该 `Thread` 定义。 [Codex `ThreadListResponse` schema](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json#L889-L1080)
+- 官方 API projection 从 stored thread 构造 `Thread` 时只映射 `model_provider`；即使内部 rollout/state metadata 可能保存 model，`thread/list` 的公开 projection 也会丢弃它。这是“内部有记录”与“API 可读”之间的边界。[Codex `thread_from_stored_thread` projection（pinned commit）](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server/src/request_processors/thread_processor.rs#L5844-L5925)
+- 官方 `thread/list` 示例返回 `id`、`preview`、`modelProvider`、时间和 `status`，没有 `model`；`status: active` 只表示运行状态，不增加模型名称。[Codex app-server `thread/list` 示例](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server/README.md#L434-L481)
+- `thread/start` 和 `turn/start` 的请求可以传 `model` 覆盖；这说明模型是 thread/turn 运行配置，但请求参数不等于 `thread/list` 返回字段。[Codex app-server 生命周期与 `turn/start` 覆盖](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server/README.md#L75-L83)
+- `thread/resume` 默认会使用 thread 中持久化的最新 `model`/`reasoningEffort`，但该内部持久化值仍没有进入 `Thread`/`thread/list` 摘要；调用 resume 也不是无副作用的只读查询。[Codex app-server resume 语义](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server/README.md#L370-L384)
+- 若客户端本来就持有活动 app-server 连接，官方事件流可告知 turn 级模型变化，例如 `model/rerouted` 带 `fromModel`/`toModel`；`thread/list` 本身不订阅或回放这些运行时事件。[Codex app-server turn/model events](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server/README.md#L1678-L1692)
+
+### 对本插件的结论
+
+- 当前 quota fetch 启动的是独立 app-server，只做 `account/read`、`account/rateLimits/read` 和不扫描 rollout 的 `thread/list`；这条请求链可以得到 provider 和 preview，但没有活动 pane 的 model 事件。不要把 `modelProvider: "openai"` 变成 `GPT-5.x`，也不要从 thread id、preview、rate-limit bucket 或本地文件名猜模型。[本仓库 Codex fetch 的 `thread/list` 调用](../../src/providers/codex.rs#L153-L199)
+- 若未来要支持 Codex `$quota_model`，需要把插件接入**活动会话已有的 app-server 事件/客户端**，按 `threadId` 跟踪 turn 请求和 `model/rerouted`；不能通过额外 `thread/resume`、模型请求或 rollout 扫描来“查一下”。[官方 turn/model events](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server/README.md#L1678-L1692)
+- 版本边界必须显式写出：官方说明 `codex app-server generate-ts/json-schema` 的产物只保证匹配**运行该命令的 Codex 版本**。因此实现前应对用户本地 binary 运行 `codex app-server generate-json-schema`（必要时加 `--experimental`），不能把 moving `main` 的字段当作所有版本的稳定合同。[官方 schema 生成说明](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server/README.md#L245-L251)
+
+## 4. Grok Build：官方 status-line 有模型，但现有 quota adapter 没有
+
+### 观察到的事实
+
+- xAI 官方 Grok Build status-line 文档的 builtin `model` item 明确显示 Model display name；command 模式把 JSON 通过 stdin 交给用户脚本。[Grok Build status-line 配置](https://github.com/xai-org/grok-build/blob/77cd7eb675ba911c225c3aaeeece3a20cbccc426/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#built-in)
+- 官方 available-data 表列出 `model.id`、`model.display_name`，并明确“当 agent 无法读取 session model 时省略该字段”。脚本示例也使用 `.model.display_name // "?"`，不从其他字段推断。[Grok Build available data](https://github.com/xai-org/grok-build/blob/77cd7eb675ba911c225c3aaeeece3a20cbccc426/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#available-data)
+- 本仓库的 Grok adapter 当前只调用 `https://cli-chat-proxy.grok.com/v1/billing?format=credits`，解析 `config.creditUsagePercent` 与 `currentPeriod`；没有消费 Grok status-line stdin，因此当前 Grok quota snapshot 没有模型可读来源。[本仓库 Grok adapter](../../src/providers/grok.rs#L10-L43)
+
+### 对实现的含义
+
+1. 如果后续给 Grok 加 statusLine wrapper，应只解析官方 `model.display_name`，并把字段省略当作 unknown；不要从 billing account、credits period、`grok` executable 名或默认模型版本猜显示名。[Grok Build available data](https://github.com/xai-org/grok-build/blob/77cd7eb675ba911c225c3aaeeece3a20cbccc426/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#available-data)
+2. Grok command status-line 有 `refresh_interval`，但定时运行拿到的 payload 可能是最近一次 state change 的快照；若要接入，沿用 hook 输入并控制刷新，不要让插件为模型名启动额外网络/模型请求。[Grok Build refresh 语义](https://github.com/xai-org/grok-build/blob/77cd7eb675ba911c225c3aaeeece3a20cbccc426/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#refresh-runs)
+
+## 落地设计依据
+
+1. **统一内部字段但保持可选：** 在现有 snapshot/presentation 层使用 `Option<String>` 的 display label；解析器只接受 provider 官方 `model.display_name`（兼容 Agy/Grok 文档中的 camelCase 变体时要有明确来源），不把 id 变成人类名。[Claude 字段合同](https://code.claude.com/docs/en/statusline#available-data) · [Agy 字段合同](https://antigravity.google/docs/cli/statusline/#available-json-fields) · [Grok 字段合同](https://github.com/xai-org/grok-build/blob/77cd7eb675ba911c225c3aaeeece3a20cbccc426/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#available-data)
+2. **按 pane/session 保存：** Claude/Agy/Grok 的 statusLine payload 都带 session/conversation 标识；缓存模型时使用该标识，状态缺失时保留同一 session 的最后有效值，避免每次刷新清空 token。[Claude schema](https://code.claude.com/docs/en/statusline#full-json-schema) · [Agy fields](https://antigravity.google/docs/cli/statusline/#available-json-fields) · [Grok fields](https://github.com/xai-org/grok-build/blob/77cd7eb675ba911c225c3aaeeece3a20cbccc426/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#available-data)
+3. **展示策略：** `$quota_model` 只在 display name 已确认时显示；默认布局用
+   `$quota_provider_model` 将它与 provider 紧凑合并，但不要为 unknown 输出“默认模型”或
+   provider 名的伪模型。Claude/Agy 可由 statusLine hook 提供，Codex/Grok 在本地
+   rollout/session 文件有证据时也可提供。[Issue #22 的 display-name 目标](https://github.com/levi-qiao/herdr-agent-quota/issues/22) · [Codex Thread schema](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs#L199-L243)
+4. **刷新和成本：** 只在已有 statusLine 输入/活动 app-server 事件中更新模型；不要为查模型读取 Herdr pane、resume Codex thread、扫描所有 rollout、发送 warm-up prompt 或触发网络模型请求。这个边界与本仓库“pane 读取有可见 repaint 成本、事件只读指定 pane”的约束一致。[仓库 AGENTS.md](../../AGENTS.md) · [Codex app-server 生命周期](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server/README.md#L75-L83)
+
+## Codex / Grok 不猜测边界
+
+- **不把 provider 当模型：** Codex `modelProvider` 只回答“由哪个 provider 服务”，不能回答“当前调用哪个模型”。[Codex `Thread` 定义](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs#L199-L243)
+- **不把请求配置当实际结果：** Codex `turn/start.model` 是 override；后端还可能发出 `model/rerouted`，所以即使知道请求参数，也不能声称它是该 turn 最终实际模型。[Codex turn/model events](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server/README.md#L1678-L1692)
+- **不从 quota/billing 反推：** Grok 官方把 model 和 billing/context 作为不同 status-line 数据；当前 billing adapter 不包含 model，因此 credits period、账号 token、默认版本都不能作为显示名。[Grok available data](https://github.com/xai-org/grok-build/blob/77cd7eb675ba911c225c3aaeeece3a20cbccc426/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#available-data) · [本仓库 Grok adapter](../../src/providers/grok.rs#L152-L191)
+- **未知就隐藏/保留旧值，不编造：** provider 明确省略字段时显示 unknown（或同一 session 保留上次已确认值）；不要输出 `GPT-5`、`Grok 4`、`Gemini` 等未经 payload 证实的默认名。[Grok 的“字段省略”说明](https://github.com/xai-org/grok-build/blob/77cd7eb675ba911c225c3aaeeece3a20cbccc426/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#available-data) · [Claude 的缺失/null 处理](https://code.claude.com/docs/en/statusline#full-json-schema)
+
+## 验证清单
+
+- Claude/Agy parser fixture：有 `model.display_name`、只有 id、model 为 null、整个 model 缺失；断言只有 display name 会进入 `$quota_model`，并检查多 session 不互相覆盖。[Claude schema](https://code.claude.com/docs/en/statusline#full-json-schema) · [Agy payload example](https://antigravity.google/docs/cli/statusline/#json-payload-example)
+- Grok 若接入 statusLine：覆盖有模型、字段省略、`refresh_interval` payload 为旧快照三种情况；不把省略当错误或默认模型。[Grok available data](https://github.com/xai-org/grok-build/blob/77cd7eb675ba911c225c3aaeeece3a20cbccc426/crates/codegen/xai-grok-pager/docs/user-guide/25-status-line.md#available-data)
+- Codex contract fixture：`thread/list` 项只有 `modelProvider` 时 `$quota_model` 必须为空；不要为了取得 model 调 `thread/resume`。本地版本验证使用 `codex app-server generate-json-schema`，而不是假定 pinned `main` 适用于所有安装版本。[Codex schema generation](https://github.com/openai/codex/blob/2764e83626efe55f64e04d153fc99a157327f3c2/codex-rs/app-server/README.md#L245-L251)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -12,6 +12,7 @@ pub const MIN_WATCH_INTERVAL_SECONDS: u64 = 30;
 pub const MAX_WATCH_INTERVAL_SECONDS: u64 = 60 * 60;
 const WATCH_INTERVAL_ENV: &str = "HERDR_AGENT_QUOTA_WATCH_INTERVAL_SECONDS";
 const WATCH_INTERVAL_FILE: &str = "watch-interval-seconds";
+const MAX_STATUSLINE_SESSIONS: usize = 128;
 
 #[derive(Debug, Clone)]
 pub struct CacheStore {
@@ -72,6 +73,67 @@ impl CacheStore {
         Self::atomic_replace(&destination, &temporary, bytes)
     }
 
+    /// Keep provider-local diagnostics when a successful quota refresh cannot
+    /// read one of the session files for a moment. Quota windows are still
+    /// replaced immediately; diagnostics are merged only for the same signed
+    /// in account so a login switch can never inherit another user's data.
+    pub fn save_preserving_diagnostics(&self, mut snapshot: ProviderSnapshot) -> Result<()> {
+        self.save_preserving_diagnostics_for_sessions(&mut snapshot, &[])
+    }
+
+    /// Variant used by the refresh path, which knows the session ids currently
+    /// visible in Herdr. It preserves only those ids, keeping a bounded local
+    /// snapshot instead of growing it forever as old sessions age out.
+    pub fn save_preserving_diagnostics_for_sessions(
+        &self,
+        snapshot: &mut ProviderSnapshot,
+        session_ids: &[String],
+    ) -> Result<()> {
+        if let Some(previous) = self.load(snapshot.provider).ok().flatten() {
+            let same_account = snapshot.account_id == previous.account_id;
+            if same_account {
+                if snapshot.context.is_none() {
+                    snapshot.context = previous.context.clone();
+                }
+                if snapshot.model.is_none() {
+                    snapshot.model = previous.model.clone();
+                }
+                if session_ids.is_empty() {
+                    if snapshot.session_contexts.is_empty() {
+                        for (session_id, context) in previous.session_contexts {
+                            snapshot
+                                .session_contexts
+                                .entry(session_id)
+                                .or_insert(context);
+                        }
+                    }
+                    if snapshot.session_models.is_empty() {
+                        for (session_id, model) in previous.session_models {
+                            snapshot.session_models.entry(session_id).or_insert(model);
+                        }
+                    }
+                } else {
+                    for session_id in session_ids {
+                        if let Some(context) = previous.session_contexts.get(session_id) {
+                            snapshot
+                                .session_contexts
+                                .entry(session_id.clone())
+                                .or_insert_with(|| context.clone());
+                        }
+                        if let Some(model) = previous.session_models.get(session_id) {
+                            snapshot
+                                .session_models
+                                .entry(session_id.clone())
+                                .or_insert_with(|| model.clone());
+                        }
+                    }
+                }
+            }
+        }
+        prune_session_diagnostics(snapshot, session_ids);
+        self.save(snapshot)
+    }
+
     /// Store the latest statusLine observation without coordinating with a
     /// refresh. The statusLine hook is a latency-sensitive producer; its only
     /// shared-state operation is an atomic last-observation replacement.
@@ -82,10 +144,7 @@ impl CacheStore {
         observation: &Value,
     ) -> Result<()> {
         self.ensure()?;
-        let session_id = observation
-            .get("session_id")
-            .or_else(|| observation.get("sessionId"))
-            .and_then(Value::as_str);
+        let session_id = statusline_session_id(observation);
         if let Some(session_id) = session_id {
             if let Some(cache) = snapshot
                 .context
@@ -95,12 +154,42 @@ impl CacheStore {
                 cache.session_id = Some(session_id.to_string());
             }
         }
-        let previous = self
-            .load_statusline_observation(provider)
-            .ok()
-            .flatten()
-            .and_then(|observation| observation.snapshot.context);
-        merge_preserved_context(&mut snapshot, previous, session_id);
+        let previous = self.load_statusline_observation(provider).ok().flatten();
+        let previous_snapshot = previous.as_ref().map(|observation| &observation.snapshot);
+        let previous_session_id = previous
+            .as_ref()
+            .and_then(|observation| statusline_session_id(&observation.payload));
+        merge_preserved_context(
+            &mut snapshot,
+            previous_snapshot.and_then(|snapshot| snapshot.context.clone()),
+            previous_session_id,
+            session_id,
+        );
+        merge_session_models(
+            &mut snapshot,
+            previous_snapshot,
+            previous_session_id,
+            session_id,
+        );
+        if let Some(previous_snapshot) = previous_snapshot {
+            for (session_id, context) in &previous_snapshot.session_contexts {
+                snapshot
+                    .session_contexts
+                    .entry(session_id.clone())
+                    .or_insert_with(|| context.clone());
+            }
+        }
+        if let Some(session_id) = session_id {
+            if let Some(context) = snapshot.context.clone() {
+                snapshot
+                    .session_contexts
+                    .insert(session_id.to_string(), context);
+            }
+        }
+        let current_session_ids = session_id
+            .map(|session_id| vec![session_id.to_string()])
+            .unwrap_or_default();
+        prune_session_diagnostics(&mut snapshot, &current_session_ids);
         let saved = StatuslineObservation {
             snapshot,
             payload: observation.clone(),
@@ -155,12 +244,45 @@ impl CacheStore {
         }
         // A malformed/temporarily unreadable old snapshot must not prevent a
         // fresh statusLine value from replacing it.
-        let previous = self
-            .load(snapshot.provider)
-            .ok()
-            .flatten()
-            .and_then(|snapshot| snapshot.context);
-        merge_preserved_context(&mut snapshot, previous, session_id);
+        let previous = self.load(snapshot.provider).ok().flatten();
+        let previous_session_id = previous
+            .as_ref()
+            .and_then(|snapshot| snapshot.context.as_ref())
+            .and_then(|context| context.cache.as_ref())
+            .and_then(|cache| cache.session_id.as_deref());
+        merge_preserved_context(
+            &mut snapshot,
+            previous
+                .as_ref()
+                .and_then(|snapshot| snapshot.context.clone()),
+            previous_session_id,
+            session_id,
+        );
+        merge_session_models(
+            &mut snapshot,
+            previous.as_ref(),
+            previous_session_id,
+            session_id,
+        );
+        if let Some(previous) = previous.as_ref() {
+            for (session_id, context) in &previous.session_contexts {
+                snapshot
+                    .session_contexts
+                    .entry(session_id.clone())
+                    .or_insert_with(|| context.clone());
+            }
+        }
+        if let Some(session_id) = session_id {
+            if let Some(context) = snapshot.context.clone() {
+                snapshot
+                    .session_contexts
+                    .insert(session_id.to_string(), context);
+            }
+        }
+        let current_session_ids = session_id
+            .map(|session_id| vec![session_id.to_string()])
+            .unwrap_or_default();
+        prune_session_diagnostics(&mut snapshot, &current_session_ids);
         self.save(&snapshot)
     }
 
@@ -354,51 +476,98 @@ impl CacheStore {
     }
 }
 
-fn strip_session_cache_state(cache: &mut crate::model::CacheUsage, clear_ttl: bool) {
-    cache.session_totals = None;
-    cache.session_id = None;
-    cache.transcript_offset = 0;
-    if clear_ttl {
-        cache.ttl_seconds = None;
-        cache.last_activity_unix = None;
+fn merge_session_models(
+    snapshot: &mut ProviderSnapshot,
+    previous: Option<&ProviderSnapshot>,
+    previous_session_id: Option<&str>,
+    session_id: Option<&str>,
+) {
+    if let Some(previous) = previous {
+        for (session_id, model) in &previous.session_models {
+            snapshot
+                .session_models
+                .entry(session_id.clone())
+                .or_insert_with(|| model.clone());
+        }
     }
+    let Some(session_id) = session_id else {
+        return;
+    };
+    if let Some(model) = snapshot.model.as_ref() {
+        snapshot
+            .session_models
+            .insert(session_id.to_string(), model.clone());
+    } else if previous_session_id == Some(session_id) {
+        if let Some(model) = previous.and_then(|previous| previous.model.as_ref()) {
+            snapshot
+                .session_models
+                .entry(session_id.to_string())
+                .or_insert_with(|| model.clone());
+        }
+    }
+}
+
+fn prune_session_diagnostics(snapshot: &mut ProviderSnapshot, current_session_ids: &[String]) {
+    while snapshot.session_models.len() > MAX_STATUSLINE_SESSIONS {
+        let Some(session_id) = snapshot
+            .session_models
+            .keys()
+            .find(|session_id| {
+                !current_session_ids
+                    .iter()
+                    .any(|current| current == *session_id)
+            })
+            .cloned()
+            .or_else(|| snapshot.session_models.keys().next().cloned())
+        else {
+            break;
+        };
+        snapshot.session_models.remove(&session_id);
+    }
+    while snapshot.session_contexts.len() > MAX_STATUSLINE_SESSIONS {
+        let Some(session_id) = snapshot
+            .session_contexts
+            .keys()
+            .find(|session_id| {
+                !current_session_ids
+                    .iter()
+                    .any(|current| current == *session_id)
+            })
+            .cloned()
+            .or_else(|| snapshot.session_contexts.keys().next().cloned())
+        else {
+            break;
+        };
+        snapshot.session_contexts.remove(&session_id);
+    }
+}
+
+fn statusline_session_id(observation: &Value) -> Option<&str> {
+    observation
+        .get("session_id")
+        .or_else(|| observation.get("sessionId"))
+        .or_else(|| observation.get("conversation_id"))
+        .or_else(|| observation.get("conversationId"))
+        .and_then(Value::as_str)
 }
 
 fn merge_preserved_context(
     snapshot: &mut ProviderSnapshot,
     previous: Option<ContextUsage>,
+    previous_session_id: Option<&str>,
     session_id: Option<&str>,
 ) {
     let Some(previous_context) = previous else {
         return;
     };
+    let same_session = sessions_match(previous_session_id, session_id);
     match (&mut snapshot.context, previous_context) {
-        (None, mut previous_context) => {
-            if let Some(cache) = previous_context.cache.as_mut() {
-                let same_session = session_id
-                    .is_some_and(|session_id| cache.session_id.as_deref() == Some(session_id));
-                if !same_session {
-                    let clear_ttl = cache.session_id.is_some() || session_id.is_some();
-                    strip_session_cache_state(cache, clear_ttl);
-                }
-            }
+        (None, previous_context) if same_session => {
             snapshot.context = Some(previous_context);
         }
-        (Some(current), previous_context) if current.cache.is_none() => {
-            let mut previous_cache = previous_context.cache.clone();
-            let same_session = session_id.is_some_and(|session_id| {
-                previous_cache
-                    .as_ref()
-                    .and_then(|cache| cache.session_id.as_deref())
-                    == Some(session_id)
-            });
-            if !same_session {
-                if let Some(cache) = previous_cache.as_mut() {
-                    let clear_ttl = cache.session_id.is_some() || session_id.is_some();
-                    strip_session_cache_state(cache, clear_ttl);
-                }
-            }
-            current.cache = previous_cache;
+        (None, _) => {}
+        (Some(current), previous_context) if current.cache.is_none() && same_session => {
+            current.cache = previous_context.cache;
         }
         (Some(current), previous_context) => {
             let Some(current_cache) = current.cache.as_mut() else {
@@ -407,11 +576,6 @@ fn merge_preserved_context(
             let Some(previous_cache) = previous_context.cache.as_ref() else {
                 return;
             };
-            let same_session = current_cache.session_id.is_some()
-                && current_cache.session_id == previous_cache.session_id
-                && session_id.is_none_or(|session_id| {
-                    current_cache.session_id.as_deref() == Some(session_id)
-                });
             if same_session {
                 if current_cache.session_totals.is_none() {
                     current_cache.session_totals = previous_cache.session_totals.clone();
@@ -427,6 +591,14 @@ fn merge_preserved_context(
                 }
             }
         }
+    }
+}
+
+fn sessions_match(previous_session_id: Option<&str>, session_id: Option<&str>) -> bool {
+    match (previous_session_id, session_id) {
+        (Some(previous), Some(current)) => previous == current,
+        (None, None) => true,
+        _ => false,
     }
 }
 
@@ -489,6 +661,43 @@ mod tests {
     }
 
     #[test]
+    fn statusline_observations_keep_models_for_multiple_sessions() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                ProviderSnapshot::new(Provider::Claude, vec![], 1)
+                    .with_model(Some("Sonnet".to_string())),
+                &json!({"session_id": "session-1"}),
+            )
+            .unwrap();
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                ProviderSnapshot::new(Provider::Claude, vec![], 2)
+                    .with_model(Some("Opus".to_string())),
+                &json!({"conversation_id": "session-2"}),
+            )
+            .unwrap();
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                ProviderSnapshot::new(Provider::Claude, vec![], 3),
+                &json!({"session_id": "session-2"}),
+            )
+            .unwrap();
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        assert_eq!(saved.session_models["session-1"], "Sonnet");
+        assert_eq!(saved.session_models["session-2"], "Opus");
+    }
+
+    #[test]
     fn statusline_refresh_preserves_previous_cache_diagnostics_when_current_usage_is_missing() {
         let directory = tempdir().unwrap();
         let cache = CacheStore::new(directory.path());
@@ -511,6 +720,91 @@ mod tests {
             .unwrap();
         assert_eq!(saved_context.used_percent, 24.0);
         assert_eq!(saved_context.cache, context.cache);
+    }
+
+    #[test]
+    fn statusline_refresh_records_context_for_the_current_session() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let current = snapshot().with_context(Some(ContextUsage::new(12.0).unwrap()));
+        cache
+            .save_preserving_context_for_session(current, Some("session-1"))
+            .unwrap();
+        let saved = cache.load(Provider::Grok).unwrap().unwrap();
+        assert_eq!(
+            saved
+                .context_for_session(Some("session-1"))
+                .map(|context| context.used_percent),
+            Some(12.0)
+        );
+        assert!(saved.session_contexts.contains_key("session-1"));
+    }
+
+    #[test]
+    fn statusline_refresh_preserves_model_for_the_same_session() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let previous = snapshot()
+            .with_model(Some("Sonnet".to_string()))
+            .with_context(Some(
+                ContextUsage::new(10.0).unwrap().with_cache(Some(
+                    CacheUsage::from_token_counts(1, 1, 0)
+                        .unwrap()
+                        .with_session_totals(None, "session-1", 0),
+                )),
+            ));
+        cache.save(&previous).unwrap();
+
+        let current = snapshot().with_context(Some(ContextUsage::new(12.0).unwrap()));
+        cache
+            .save_preserving_context_for_session(current, Some("session-1"))
+            .unwrap();
+        let saved = cache.load(Provider::Grok).unwrap().unwrap();
+        assert_eq!(saved.session_models["session-1"], "Sonnet");
+    }
+
+    #[test]
+    fn direct_provider_refresh_preserves_missing_local_session_diagnostics() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let mut previous = snapshot().with_account_id(Some("account-1".to_string()));
+        previous.model = Some("grok-4.6".to_string());
+        previous
+            .session_models
+            .insert("session-1".to_string(), "grok-4.6".to_string());
+        previous
+            .session_contexts
+            .insert("session-1".to_string(), ContextUsage::new(24.0).unwrap());
+        cache.save(&previous).unwrap();
+
+        let latest = snapshot().with_account_id(Some("account-1".to_string()));
+        cache.save_preserving_diagnostics(latest).unwrap();
+        let saved = cache.load(Provider::Grok).unwrap().unwrap();
+        assert_eq!(saved.model.as_deref(), Some("grok-4.6"));
+        assert_eq!(saved.session_models["session-1"], "grok-4.6");
+        assert!(saved.session_contexts.contains_key("session-1"));
+    }
+
+    #[test]
+    fn direct_provider_diagnostics_remain_bounded() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let mut previous = snapshot();
+        for index in 0..(MAX_STATUSLINE_SESSIONS + 8) {
+            let session_id = format!("session-{index}");
+            previous
+                .session_models
+                .insert(session_id.clone(), format!("model-{index}"));
+            previous
+                .session_contexts
+                .insert(session_id, ContextUsage::new((index % 100) as f64).unwrap());
+        }
+        cache.save(&previous).unwrap();
+
+        cache.save_preserving_diagnostics(snapshot()).unwrap();
+        let saved = cache.load(Provider::Grok).unwrap().unwrap();
+        assert_eq!(saved.session_models.len(), MAX_STATUSLINE_SESSIONS);
+        assert_eq!(saved.session_contexts.len(), MAX_STATUSLINE_SESSIONS);
     }
 
     #[test]
@@ -574,6 +868,81 @@ mod tests {
     }
 
     #[test]
+    fn statusline_new_session_does_not_inherit_previous_cache_diagnostics() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let previous = ProviderSnapshot::new(Provider::Claude, vec![], 1).with_context(Some(
+            ContextUsage::new(23.5).unwrap().with_cache(Some(
+                CacheUsage::from_token_counts(10, 90, 0)
+                    .unwrap()
+                    .with_session_totals(
+                        crate::model::CacheTotals::from_token_counts(10, 90, 0),
+                        "session-1",
+                        512,
+                    ),
+            )),
+        ));
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                previous,
+                &json!({"session_id": "session-1"}),
+            )
+            .unwrap();
+
+        let latest = ProviderSnapshot::new(Provider::Claude, vec![], 2)
+            .with_context(Some(ContextUsage::new(0.0).unwrap()));
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                latest,
+                &json!({"session_id": "session-2"}),
+            )
+            .unwrap();
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        assert!(saved
+            .context_for_session(Some("session-2"))
+            .unwrap()
+            .cache
+            .is_none());
+        assert!(saved.session_contexts.contains_key("session-2"));
+    }
+
+    #[test]
+    fn statusline_session_diagnostics_remain_bounded() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        for index in 0..(MAX_STATUSLINE_SESSIONS + 8) {
+            let session_id = format!("session-{index}");
+            cache
+                .save_statusline_observation(
+                    Provider::Claude,
+                    ProviderSnapshot::new(Provider::Claude, vec![], index as u64)
+                        .with_model(Some(format!("model-{index}")))
+                        .with_context(Some(ContextUsage::new(0.0).unwrap())),
+                    &json!({"session_id": session_id}),
+                )
+                .unwrap();
+        }
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        assert_eq!(saved.session_models.len(), MAX_STATUSLINE_SESSIONS);
+        assert_eq!(saved.session_contexts.len(), MAX_STATUSLINE_SESSIONS);
+        assert!(saved
+            .session_models
+            .contains_key(&format!("session-{}", MAX_STATUSLINE_SESSIONS + 7)));
+    }
+
+    #[test]
     fn missing_cache_is_not_an_error() {
         let directory = tempdir().unwrap();
         let cache = CacheStore::new(directory.path());
@@ -621,14 +990,11 @@ mod tests {
     fn watcher_stop_marker_is_reversible_for_reinstall() {
         let directory = tempdir().unwrap();
         let cache = CacheStore::new(directory.path());
+        let started_millis = CacheStore::now_millis();
         cache.stop_turn_watchers().unwrap();
-        assert!(cache
-            .turn_watchers_stopped_after(CacheStore::now_millis().saturating_sub(1))
-            .unwrap());
+        assert!(cache.turn_watchers_stopped_after(started_millis).unwrap());
         cache.clear_turn_watcher_stop().unwrap();
-        assert!(!cache
-            .turn_watchers_stopped_after(CacheStore::now_millis().saturating_sub(1))
-            .unwrap());
+        assert!(!cache.turn_watchers_stopped_after(started_millis).unwrap());
     }
 
     #[test]

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -3,11 +3,13 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Item, Table, Value};
 
-const QUOTA_ROW_MARKERS: [&str; 23] = [
+const QUOTA_ROW_MARKERS: [&str; 25] = [
     "$quota_badge",
     "$quota_state",
     "$quota_icon",
     "$quota_provider",
+    "$quota_model",
+    "$quota_provider_model",
     "$quota_status",
     "$quota_summary",
     "$quota_session",
@@ -36,9 +38,7 @@ const CONFIG_PRESENCE_FILE: &str = "herdr-config.original.present";
 const QUOTA_SAFE_COLOR: &str = "#84b084";
 const QUOTA_WARNING_COLOR: &str = "#cdaa65";
 const QUOTA_DANGER_COLOR: &str = "#ca6470";
-const CONTEXT_COLOR: &str = "#9b8fd8";
-const CACHE_COLOR: &str = "#6fb5b7";
-const CACHE_TTL_COLOR: &str = "#cdaa65";
+const DIAGNOSTIC_COLOR: &str = "#9aa7b8";
 const PROVIDER_STYLES: [(&str, Option<&str>); 4] = [
     ("claude", Some("#c47f6a")),
     ("codex", Some("#7998b7")),
@@ -183,7 +183,7 @@ pub fn add_quota_row(input: &str) -> Result<String> {
         .context("Herdr ui.sidebar.agents.rows must be an array")?;
     let mut updated_rows = Array::new();
     for row in rows.iter() {
-        let cleaned = normalize_official_row(strip_quota_tokens(row));
+        let cleaned = normalize_official_row(strip_quota_tokens(row, true));
         if !cleaned.is_empty() {
             updated_rows.push(Value::Array(cleaned));
         }
@@ -226,7 +226,7 @@ pub fn remove_quota_row(input: &str) -> Result<String> {
     if let Some(rows) = agents.get_mut("rows").and_then(Item::as_array_mut) {
         let mut retained = Array::new();
         for row in rows.iter() {
-            let cleaned = strip_quota_tokens(row);
+            let cleaned = strip_quota_tokens(row, false);
             if cleaned.len() == 1
                 && matches!(
                     cleaned.iter().next().and_then(Value::as_str),
@@ -320,13 +320,16 @@ fn ensure_table<'a>(document: &'a mut DocumentMut, path: &[&str]) -> Result<&'a 
         .context("Herdr config section is not a table")
 }
 
-fn strip_quota_tokens(row: &Value) -> Array {
+fn strip_quota_tokens(row: &Value, keep_provider_model: bool) -> Array {
     let mut cleaned = Array::new();
     if let Some(items) = row.as_array() {
         for item in items {
             let is_quota_token =
                 configured_token_name(item).is_some_and(|value| QUOTA_ROW_MARKERS.contains(&value));
-            if !is_quota_token {
+            if !is_quota_token
+                || (keep_provider_model
+                    && configured_token_name(item) == Some("$quota_provider_model"))
+            {
                 cleaned.push(item.clone());
             }
         }
@@ -358,7 +361,7 @@ fn add_provider_rows(agents: &mut Table, rows: &Array) -> Result<()> {
         if rows_by_agent.contains_key(provider) && !is_managed {
             continue;
         }
-        let mut value = Value::Array(provider_rows(rows, color));
+        let mut value = Value::Array(provider_rows(rows, color, provider));
         value
             .decor_mut()
             .set_suffix(format!(" # {PROVIDER_STYLE_MARKER}"));
@@ -367,23 +370,66 @@ fn add_provider_rows(agents: &mut Table, rows: &Array) -> Result<()> {
     Ok(())
 }
 
-fn provider_rows(rows: &Array, color: Option<&str>) -> Array {
+fn provider_rows(rows: &Array, color: Option<&str>, provider: &str) -> Array {
+    let weekly_only = provider == "grok";
+    let context_index = if weekly_only {
+        rows.iter()
+            .position(|row| row_contains_token(row, "$quota_context"))
+    } else {
+        None
+    };
+    let window_index = if weekly_only {
+        rows.iter().position(|row| {
+            row_contains_token(row, "$quota_5h_normal")
+                || row_contains_token(row, "$quota_week_normal")
+        })
+    } else {
+        None
+    };
+    let window_items = window_index
+        .and_then(|index| rows.get(index))
+        .and_then(Value::as_array);
     let mut themed = Array::new();
-    for row in rows.iter() {
+    for (index, row) in rows.iter().enumerate() {
+        if window_index == Some(index) && context_index != Some(index) {
+            continue;
+        }
         let Some(items) = row.as_array() else {
             continue;
         };
         let mut themed_row = Array::new();
-        for item in items {
-            if configured_token_name(item) == Some("$quota_provider") {
-                themed_row.push(styled_token("agent", color, Some(true), Some(false)));
-            } else {
-                themed_row.push(item.clone());
+        append_themed_provider_row(&mut themed_row, items, color);
+        if context_index == Some(index) {
+            if let Some(window_items) = window_items {
+                append_themed_provider_row(&mut themed_row, window_items, color);
             }
         }
         themed.push(Value::Array(themed_row));
     }
     themed
+}
+
+fn append_themed_provider_row(row: &mut Array, items: &Array, color: Option<&str>) {
+    for item in items {
+        if configured_token_name(item) == Some("$quota_provider_model") {
+            row.push(styled_token(
+                "$quota_provider_model",
+                color,
+                Some(true),
+                Some(false),
+            ));
+        } else {
+            row.push(item.clone());
+        }
+    }
+}
+
+fn row_contains_token(row: &Value, token: &str) -> bool {
+    row.as_array().is_some_and(|items| {
+        items
+            .iter()
+            .any(|item| configured_token_name(item) == Some(token))
+    })
 }
 
 fn remove_managed_provider_rows(agents: &mut Table) {
@@ -421,7 +467,12 @@ fn default_state_row() -> Array {
 
 fn normalize_official_row(row: Array) -> Array {
     let has_state_icon = row.iter().any(|item| item.as_str() == Some("state_icon"));
-    if !has_state_icon || row.iter().any(|item| item.as_str() == Some("agent")) {
+    if !has_state_icon
+        || row.iter().any(|item| {
+            item.as_str() == Some("agent")
+                || configured_token_name(item) == Some("$quota_provider_model")
+        })
+    {
         return row;
     }
     let mut normalized = Array::new();
@@ -465,6 +516,13 @@ fn append_quota_rows(rows: &mut Array) {
         let has_state_icon = items.iter().any(|item| item.as_str() == Some("state_icon"));
         let mut cleaned = Array::new();
         for item in items.iter() {
+            let token_name = configured_token_name(item);
+            if token_name.is_some_and(|token| {
+                QUOTA_ROW_MARKERS.contains(&token)
+                    && !(has_state_icon && token == "$quota_provider_model")
+            }) {
+                continue;
+            }
             match item.as_str() {
                 Some("terminal_title_stripped") | Some("$quota_topic") => {}
                 Some("agent") if !has_state_icon => {}
@@ -489,28 +547,37 @@ fn append_quota_rows(rows: &mut Array) {
 
     if let Some(index) = official_index {
         if let Some(row) = rows.get_mut(index).and_then(Value::as_array_mut) {
-            if !row
-                .iter()
-                .any(|item| matches!(item.as_str(), Some("agent") | Some("$quota_provider")))
-            {
-                row.push(styled_token(
-                    "$quota_provider",
+            let mut compacted = Array::new();
+            let mut has_provider_model = false;
+            for item in row.iter() {
+                if item.as_str() == Some("agent") {
+                    if !has_provider_model {
+                        compacted.push(styled_token(
+                            "$quota_provider_model",
+                            None,
+                            Some(true),
+                            Some(false),
+                        ));
+                        has_provider_model = true;
+                    }
+                } else if configured_token_name(item) == Some("$quota_provider_model") {
+                    if !has_provider_model {
+                        compacted.push(item.clone());
+                        has_provider_model = true;
+                    }
+                } else {
+                    compacted.push(item.clone());
+                }
+            }
+            if !has_provider_model {
+                compacted.push(styled_token(
+                    "$quota_provider_model",
                     None,
                     Some(true),
                     Some(false),
                 ));
             }
-            if !row
-                .iter()
-                .any(|item| configured_token_name(item) == Some("$quota_context"))
-            {
-                row.push(styled_token(
-                    "$quota_context",
-                    Some(CONTEXT_COLOR),
-                    Some(true),
-                    Some(false),
-                ));
-            }
+            *row = compacted;
         }
     }
 
@@ -523,15 +590,27 @@ fn append_quota_rows(rows: &mut Array) {
 
     append_cache_row(rows);
 
+    rows.push(Value::Array(styled_row(
+        "$quota_context",
+        Some(DIAGNOSTIC_COLOR),
+        Some(true),
+        Some(false),
+    )));
+
     append_window_row(rows);
 }
 
 fn append_cache_row(rows: &mut Array) {
     rows.push(Value::Array(Array::from_iter([
-        styled_token("$quota_cache", Some(CACHE_COLOR), Some(true), Some(false)),
+        styled_token(
+            "$quota_cache",
+            Some(DIAGNOSTIC_COLOR),
+            Some(true),
+            Some(false),
+        ),
         styled_token(
             "$quota_cache_ttl",
-            Some(CACHE_TTL_COLOR),
+            Some(DIAGNOSTIC_COLOR),
             Some(true),
             Some(false),
         ),
@@ -592,7 +671,7 @@ fn styled_token(token: &str, fg: Option<&str>, bold: Option<bool>, dim: Option<b
 
 fn print_diff_hint() {
     println!("  keep Herdr's official state icon and plane tab");
-    println!("  show the user prompt before one compact, severity-colored 5h/7d row");
+    println!("  show the user prompt, context, and one compact severity-colored 5h/7d row");
 }
 
 #[cfg(test)]

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -7,9 +7,11 @@ use std::process::Command;
 
 const METADATA_TTL_MS: &str = "86400000";
 const MAX_METADATA_TOKENS: usize = 16;
-const METADATA_TOKEN_NAMES: [&str; 16] = [
+const METADATA_TOKEN_NAMES: [&str; 18] = [
     "quota_state",
     "quota_provider",
+    "quota_model",
+    "quota_provider_model",
     "quota_summary",
     "quota_context",
     "quota_cache",
@@ -42,6 +44,12 @@ pub struct AgentPane {
 pub struct AgentState {
     pub panes: Vec<AgentPane>,
     pub working_providers: Vec<Provider>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PaneTokens {
+    pub pane_id: String,
+    pub values: MetadataTokens,
 }
 
 pub fn list_agent_panes() -> Result<Vec<AgentPane>> {
@@ -231,18 +239,44 @@ fn collect_working_providers(value: &Value, providers: &mut Vec<Provider>) {
     }
 }
 
+/// Publish one provider-wide token set to every matching pane.
+///
+/// Kept as the compatibility entry point for callers that do not need
+/// session-specific model labels. The refresh path uses
+/// [`publish_pane_tokens`] so same-provider panes can differ.
 pub fn publish_tokens(
     panes: &[AgentPane],
     tokens: &[(Provider, MetadataTokens)],
+    sequence: u64,
+) -> Result<()> {
+    let pane_tokens = panes
+        .iter()
+        .filter_map(|pane| {
+            tokens
+                .iter()
+                .find(|(provider, _)| *provider == pane.provider)
+                .map(|(_, values)| PaneTokens {
+                    pane_id: pane.pane_id.clone(),
+                    values: values.clone(),
+                })
+        })
+        .collect::<Vec<_>>();
+    publish_pane_tokens(panes, &pane_tokens, sequence)
+}
+
+pub fn publish_pane_tokens(
+    panes: &[AgentPane],
+    tokens: &[PaneTokens],
     sequence: u64,
 ) -> Result<()> {
     let executable = std::env::var_os("HERDR_BIN_PATH").unwrap_or_else(|| "herdr".into());
     let mut reported = 0usize;
     let mut failed = Vec::new();
     for pane in panes {
-        let Some((_, values)) = tokens
+        let Some(values) = tokens
             .iter()
-            .find(|(provider, _)| *provider == pane.provider)
+            .find(|tokens| tokens.pane_id == pane.pane_id)
+            .map(|tokens| &tokens.values)
         else {
             continue;
         };
@@ -317,8 +351,13 @@ fn desired_tokens(values: &MetadataTokens, topic: &str) -> BTreeMap<String, Stri
     let mut tokens = BTreeMap::from([
         ("quota_state".to_string(), values.quota_state.clone()),
         ("quota_provider".to_string(), values.quota_provider.clone()),
+        (
+            "quota_provider_model".to_string(),
+            values.quota_provider_model.clone(),
+        ),
         ("quota_summary".to_string(), values.quota_summary.clone()),
     ]);
+    insert_optional_token(&mut tokens, "quota_model", &values.quota_model);
     insert_optional_token(&mut tokens, "quota_context", &values.quota_context);
     insert_optional_token(&mut tokens, "quota_cache", &values.quota_cache);
     insert_optional_token(&mut tokens, "quota_cache_ttl", &values.quota_cache_ttl);
@@ -407,6 +446,8 @@ fn metadata_report_names(
             !matches!(
                 *name,
                 "quota_context"
+                    | "quota_model"
+                    | "quota_provider_model"
                     | "quota_cache"
                     | "quota_cache_ttl"
                     | "quota_provider"

--- a/src/model.rs
+++ b/src/model.rs
@@ -332,8 +332,21 @@ pub struct ProviderSnapshot {
     pub windows: Vec<UsageWindow>,
     #[serde(default)]
     pub context: Option<ContextUsage>,
+    /// Human-readable name of the model most recently reported by a provider.
+    ///
+    /// StatusLine providers also keep the per-session value below so panes
+    /// running the same provider can be distinguished from one another.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
     #[serde(default)]
     pub session_summaries: BTreeMap<String, String>,
+    #[serde(default)]
+    pub session_models: BTreeMap<String, String>,
+    /// Context/cache diagnostics keyed by the provider's session id. Keeping
+    /// this per session prevents one provider pane from displaying another
+    /// pane's local rollout usage.
+    #[serde(default)]
+    pub session_contexts: BTreeMap<String, ContextUsage>,
     /// Login identity the snapshot was fetched for (Grok `user_id`, Codex
     /// `tokens.account_id`). Used to drop another account's cached quota after
     /// `grok login` / Codex account switch. Absent on snapshots written before
@@ -350,7 +363,10 @@ impl ProviderSnapshot {
             fetched_at_unix,
             windows,
             context: None,
+            model: None,
             session_summaries: BTreeMap::new(),
+            session_models: BTreeMap::new(),
+            session_contexts: BTreeMap::new(),
             account_id: None,
         }
     }
@@ -358,6 +374,49 @@ impl ProviderSnapshot {
     pub fn with_context(mut self, context: Option<ContextUsage>) -> Self {
         self.context = context;
         self
+    }
+
+    pub fn with_model(mut self, model: Option<String>) -> Self {
+        self.model = model;
+        self
+    }
+
+    /// Return the model for a pane's session, falling back to the latest
+    /// provider-level value for snapshots created before session tracking.
+    pub fn model_for_session(&self, session_id: Option<&str>) -> Option<&str> {
+        let Some(session_id) = session_id else {
+            return self.model.as_deref();
+        };
+        if let Some(model) = self.session_models.get(session_id) {
+            return Some(model);
+        }
+        if self.session_models.is_empty() {
+            self.model.as_deref()
+        } else {
+            None
+        }
+    }
+
+    /// Return context/cache diagnostics for a pane's session. A snapshot with
+    /// no per-session map is an older/provider-level observation, so it keeps
+    /// the historical global fallback for local providers. StatusLine
+    /// providers cannot safely use that fallback: an old Claude/Agy snapshot
+    /// may belong to a different pane session, so an unknown session is blank
+    /// until its own hook observation arrives.
+    pub fn context_for_session(&self, session_id: Option<&str>) -> Option<&ContextUsage> {
+        let Some(session_id) = session_id else {
+            return self.context.as_ref();
+        };
+        if let Some(context) = self.session_contexts.get(session_id) {
+            return Some(context);
+        }
+        if self.session_contexts.is_empty()
+            && !matches!(self.provider, Provider::Claude | Provider::Agy)
+        {
+            self.context.as_ref()
+        } else {
+            None
+        }
     }
 
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
@@ -508,6 +567,17 @@ mod tests {
         let context: ContextUsage = serde_json::from_str(r#"{"used_percent":23.5}"#).unwrap();
         assert_eq!(context.used_percent, 23.5);
         assert!(context.cache.is_none());
+    }
+
+    #[test]
+    fn legacy_statusline_context_is_not_reused_for_an_unknown_session() {
+        let cache = CacheUsage::from_token_counts(10, 90, 0)
+            .unwrap()
+            .with_session_totals(CacheTotals::from_token_counts(10, 90, 0), "old-session", 0);
+        let snapshot = ProviderSnapshot::new(Provider::Claude, vec![], 0).with_context(Some(
+            ContextUsage::new(23.5).unwrap().with_cache(Some(cache)),
+        ));
+        assert!(snapshot.context_for_session(Some("new-session")).is_none());
     }
 
     #[test]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -7,6 +7,8 @@ pub struct MetadataTokens {
     pub quota_state: String,
     pub quota_icon: String,
     pub quota_provider: String,
+    pub quota_model: String,
+    pub quota_provider_model: String,
     pub quota_status: String,
     pub quota_5h: String,
     pub quota_5h_severity: Option<Severity>,
@@ -21,28 +23,46 @@ pub struct MetadataTokens {
 
 impl MetadataTokens {
     pub fn from_snapshot(snapshot: &ProviderSnapshot, now_unix: u64) -> Self {
+        Self::from_snapshot_for_session(snapshot, now_unix, None)
+    }
+
+    pub fn from_snapshot_for_session(
+        snapshot: &ProviderSnapshot,
+        now_unix: u64,
+        session_id: Option<&str>,
+    ) -> Self {
+        let quota_provider = snapshot.provider.display_name().to_string();
+        let quota_model = snapshot
+            .model_for_session(session_id)
+            .unwrap_or_default()
+            .to_string();
         Self {
             quota_state: snapshot.severity(now_unix).symbol().to_string(),
             quota_icon: snapshot.provider.icon().to_string(),
-            quota_provider: snapshot.provider.display_name().to_string(),
+            quota_provider_model: provider_model_label(&quota_provider, &quota_model),
+            quota_provider,
+            quota_model,
             quota_status: snapshot.severity(now_unix).label().to_string(),
             quota_5h: sidebar_window(snapshot, WindowKind::FiveHour, now_unix),
             quota_5h_severity: window_severity(snapshot, WindowKind::FiveHour, now_unix),
             quota_week: sidebar_window(snapshot, WindowKind::Weekly, now_unix),
             quota_week_severity: window_severity(snapshot, WindowKind::Weekly, now_unix),
             quota_summary: sidebar_summary(snapshot, now_unix),
-            quota_context: sidebar_context(snapshot),
-            quota_cache: sidebar_cache(snapshot),
-            quota_cache_ttl: sidebar_cache_ttl(snapshot, now_unix),
-            quota_error: sidebar_cache_error(snapshot, now_unix),
+            quota_context: sidebar_context(snapshot.context_for_session(session_id)),
+            quota_cache: sidebar_cache(snapshot.context_for_session(session_id)),
+            quota_cache_ttl: sidebar_cache_ttl(snapshot.context_for_session(session_id), now_unix),
+            quota_error: sidebar_cache_error(snapshot.context_for_session(session_id), now_unix),
         }
     }
 
     pub fn unavailable(provider: Provider, reason: impl Into<String>) -> Self {
+        let quota_provider = provider.display_name().to_string();
         Self {
             quota_state: Severity::Unknown.symbol().to_string(),
             quota_icon: provider.icon().to_string(),
-            quota_provider: provider.display_name().to_string(),
+            quota_provider_model: quota_provider.clone(),
+            quota_provider,
+            quota_model: String::new(),
             quota_status: Severity::Unknown.label().to_string(),
             quota_5h: match provider {
                 Provider::Claude | Provider::Agy => "5h N/A".to_string(),
@@ -60,6 +80,14 @@ impl MetadataTokens {
             quota_cache_ttl: String::new(),
             quota_error: Some(reason.into().chars().take(80).collect()),
         }
+    }
+}
+
+fn provider_model_label(provider: &str, model: &str) -> String {
+    if model.is_empty() {
+        provider.to_string()
+    } else {
+        format!("{provider}/{model}")
     }
 }
 
@@ -103,31 +131,27 @@ fn sidebar_window(snapshot: &ProviderSnapshot, kind: WindowKind, now_unix: u64) 
         .unwrap_or_default()
 }
 
-fn sidebar_context(snapshot: &ProviderSnapshot) -> String {
-    let Some(context) = snapshot.context.as_ref() else {
+fn sidebar_context(context: Option<&crate::model::ContextUsage>) -> String {
+    let Some(context) = context else {
         return String::new();
     };
     format!("context {}%", format_percent(context.used_percent))
 }
 
-fn sidebar_cache(snapshot: &ProviderSnapshot) -> String {
-    let Some(totals) = snapshot
-        .context
-        .as_ref()
-        .and_then(|context| context.cache.as_ref())
-        .and_then(|cache| cache.session_totals.as_ref())
-    else {
+fn sidebar_cache(context: Option<&crate::model::ContextUsage>) -> String {
+    let Some(cache) = context.and_then(|context| context.cache.as_ref()) else {
         return String::new();
     };
-    format!("cache {:.1}%", totals.hit_percent)
+    let hit_percent = cache
+        .session_totals
+        .as_ref()
+        .map(|totals| totals.hit_percent)
+        .unwrap_or(cache.hit_percent);
+    format!("cache {:.1}%", hit_percent)
 }
 
-fn sidebar_cache_ttl(snapshot: &ProviderSnapshot, now_unix: u64) -> String {
-    let Some(cache) = snapshot
-        .context
-        .as_ref()
-        .and_then(|context| context.cache.as_ref())
-    else {
+fn sidebar_cache_ttl(context: Option<&crate::model::ContextUsage>, now_unix: u64) -> String {
+    let Some(cache) = context.and_then(|context| context.cache.as_ref()) else {
         return String::new();
     };
     cache
@@ -137,10 +161,11 @@ fn sidebar_cache_ttl(snapshot: &ProviderSnapshot, now_unix: u64) -> String {
         .unwrap_or_default()
 }
 
-fn sidebar_cache_error(snapshot: &ProviderSnapshot, now_unix: u64) -> Option<String> {
-    snapshot
-        .context
-        .as_ref()
+fn sidebar_cache_error(
+    context: Option<&crate::model::ContextUsage>,
+    now_unix: u64,
+) -> Option<String> {
+    context
         .and_then(|context| context.cache.as_ref())
         .and_then(|cache| cache.remaining_ttl_seconds(now_unix))
         .filter(|remaining| *remaining == 0)
@@ -305,6 +330,48 @@ mod tests {
     }
 
     #[test]
+    fn metadata_uses_the_model_for_the_pane_session() {
+        let mut snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![window(WindowKind::Weekly, 10.0, 183_600)],
+            0,
+        )
+        .with_model(Some("latest".to_string()));
+        snapshot
+            .session_models
+            .insert("session-1".to_string(), "Sonnet".to_string());
+
+        let session_one =
+            MetadataTokens::from_snapshot_for_session(&snapshot, 0, Some("session-1"));
+        assert_eq!(session_one.quota_model, "Sonnet");
+        assert_eq!(session_one.quota_provider_model, "Claude/Sonnet");
+
+        let session_two =
+            MetadataTokens::from_snapshot_for_session(&snapshot, 0, Some("session-2"));
+        assert_eq!(session_two.quota_model, "");
+        assert_eq!(session_two.quota_provider_model, "Claude");
+    }
+
+    #[test]
+    fn metadata_uses_context_and_cache_for_the_pane_session() {
+        let mut snapshot = ProviderSnapshot::new(Provider::Codex, vec![], 0);
+        snapshot.session_contexts.insert(
+            "session-1".to_string(),
+            crate::model::ContextUsage::new(43.2)
+                .unwrap()
+                .with_cache(crate::model::CacheUsage::from_token_counts(200, 800, 100)),
+        );
+        let values = MetadataTokens::from_snapshot_for_session(&snapshot, 0, Some("session-1"));
+        assert_eq!(values.quota_context, "context 43%");
+        assert_eq!(values.quota_cache, "cache 72.7%");
+        assert_eq!(
+            MetadataTokens::from_snapshot_for_session(&snapshot, 0, Some("session-2"))
+                .quota_context,
+            ""
+        );
+    }
+
+    #[test]
     fn metadata_formats_session_cache_hit_rate_and_approximate_ttl() {
         let cache = crate::model::CacheUsage::from_token_counts(100, 800, 100)
             .unwrap()
@@ -328,6 +395,30 @@ mod tests {
         assert_eq!(values.quota_cache, "cache 80.0%");
         assert_eq!(values.quota_cache_ttl, "ttl≈1h");
         assert_eq!(values.quota_error, None);
+    }
+
+    #[test]
+    fn metadata_formats_codex_cache_ttl_for_the_pane_session() {
+        let cache = crate::model::CacheUsage::from_token_counts(100, 800, 100)
+            .unwrap()
+            .with_ttl_estimate(60 * 60, 1_000)
+            .with_session_totals(
+                crate::model::CacheTotals::from_token_counts(100, 800, 100),
+                "codex-session",
+                0,
+            );
+        let mut snapshot = ProviderSnapshot::new(Provider::Codex, vec![], 1);
+        snapshot.session_contexts.insert(
+            "codex-session".to_string(),
+            crate::model::ContextUsage::new(23.5)
+                .unwrap()
+                .with_cache(Some(cache)),
+        );
+
+        let values =
+            MetadataTokens::from_snapshot_for_session(&snapshot, 1_000, Some("codex-session"));
+        assert_eq!(values.quota_cache, "cache 80.0%");
+        assert_eq!(values.quota_cache_ttl, "ttl≈1h");
     }
 
     #[test]

--- a/src/providers/agy.rs
+++ b/src/providers/agy.rs
@@ -1,6 +1,6 @@
 use crate::cache::CacheStore;
 use crate::model::{Provider, ProviderSnapshot, ResetAt, UsageWindow, WindowKind};
-use crate::providers::statusline::parse_context;
+use crate::providers::statusline::{parse_context, parse_model};
 use crate::providers::ProviderError;
 use serde_json::Value;
 
@@ -35,14 +35,16 @@ pub fn parse_statusline(
         ));
     }
     Ok(
-        ProviderSnapshot::new(Provider::Agy, windows, fetched_at_unix).with_context(
-            parse_context(
-                value
-                    .get("context_window")
-                    .or_else(|| value.get("contextWindow")),
-            )
-            .unwrap_or(None),
-        ),
+        ProviderSnapshot::new(Provider::Agy, windows, fetched_at_unix)
+            .with_model(parse_model(value))
+            .with_context(
+                parse_context(
+                    value
+                        .get("context_window")
+                        .or_else(|| value.get("contextWindow")),
+                )
+                .unwrap_or(None),
+            ),
     )
 }
 
@@ -169,6 +171,16 @@ mod tests {
                 .hit_percent,
             75.0
         );
+    }
+
+    #[test]
+    fn parses_the_human_readable_active_model_name() {
+        let value = json!({
+            "model": {"id": "gemini-3.5-flash", "display_name": "Gemini Flash"},
+            "quota": {"gemini-weekly": {"remaining_fraction": 0.8}}
+        });
+        let snapshot = parse_statusline(&value, 1).unwrap();
+        assert_eq!(snapshot.model.as_deref(), Some("Gemini Flash"));
     }
 
     #[test]

--- a/src/providers/claude.rs
+++ b/src/providers/claude.rs
@@ -1,6 +1,6 @@
 use crate::cache::CacheStore;
 use crate::model::{Provider, ProviderSnapshot, ResetAt, UsageWindow, WindowKind};
-use crate::providers::statusline::{enrich_cache_ttl, parse_context};
+use crate::providers::statusline::{enrich_cache_ttl, parse_context, parse_model};
 use crate::providers::ProviderError;
 use serde_json::Value;
 
@@ -14,9 +14,12 @@ pub fn parse_statusline(
             .or_else(|| value.get("contextWindow")),
     )
     .unwrap_or(None);
+    let model = parse_model(value);
     let Some(limits) = value.get("rate_limits") else {
         return Ok(
-            ProviderSnapshot::new(Provider::Claude, vec![], fetched_at_unix).with_context(context),
+            ProviderSnapshot::new(Provider::Claude, vec![], fetched_at_unix)
+                .with_model(model)
+                .with_context(context),
         );
     };
     let mut windows = Vec::new();
@@ -28,10 +31,16 @@ pub fn parse_statusline(
     }
     if windows.is_empty() {
         return Ok(
-            ProviderSnapshot::new(Provider::Claude, vec![], fetched_at_unix).with_context(context),
+            ProviderSnapshot::new(Provider::Claude, vec![], fetched_at_unix)
+                .with_model(model)
+                .with_context(context),
         );
     }
-    Ok(ProviderSnapshot::new(Provider::Claude, windows, fetched_at_unix).with_context(context))
+    Ok(
+        ProviderSnapshot::new(Provider::Claude, windows, fetched_at_unix)
+            .with_model(model)
+            .with_context(context),
+    )
 }
 
 fn parse_window(
@@ -118,6 +127,16 @@ mod tests {
         assert_eq!(cache.read_tokens, 800);
         assert_eq!(cache.creation_tokens, 100);
         assert_eq!(cache.hit_percent, 80.0);
+    }
+
+    #[test]
+    fn parses_the_human_readable_active_model_name() {
+        let value = json!({
+            "model": {"id": "claude-sonnet-4-20250514", "display_name": "Sonnet"},
+            "rate_limits": {"five_hour": {"used_percentage": 1.0}}
+        });
+        let snapshot = parse_statusline(&value, 1).unwrap();
+        assert_eq!(snapshot.model.as_deref(), Some("Sonnet"));
     }
 
     #[test]

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -1,11 +1,14 @@
 use crate::cache::CacheStore;
-use crate::model::{Provider, ProviderSnapshot, ResetAt, UsageWindow, WindowKind};
+use crate::model::{
+    CacheTotals, CacheUsage, ContextUsage, Provider, ProviderSnapshot, ResetAt, UsageWindow,
+    WindowKind,
+};
 use crate::providers::ProviderError;
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::{Arc, Mutex};
@@ -18,6 +21,14 @@ use std::os::unix::process::CommandExt;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 const FIVE_HOUR_WINDOW_MINUTES: u64 = 5 * 60;
 const WEEKLY_WINDOW_MINUTES: u64 = 7 * 24 * 60;
+const ROLLOUT_TAIL_BYTES: u64 = 256 * 1024;
+const ROLLOUT_HEAD_BYTES: u64 = 256 * 1024;
+const CODEX_CONTEXT_BASELINE_TOKENS: u64 = 12_000;
+// Codex rollout usage does not include an expiry timestamp. OpenAI documents
+// the default in-memory prompt cache as typically expiring after 5–10 minutes
+// of inactivity and always being removed within one hour of its last use, so
+// the sidebar exposes this as an explicitly approximate upper-bound estimate.
+const CODEX_PROMPT_CACHE_MAX_TTL_SECONDS: u64 = 60 * 60;
 
 pub fn parse_rate_limits(
     value: &Value,
@@ -90,6 +101,14 @@ fn parse_reset(value: &Value) -> Option<ResetAt> {
 }
 
 pub fn fetch() -> Result<ProviderSnapshot> {
+    fetch_for_sessions(&[])
+}
+
+/// Fetch quota and supplement it with local diagnostics for the sessions
+/// currently visible in Herdr. The empty slice is used by direct CLI calls;
+/// the refresh path supplies pane session ids so an older pane is not lost
+/// behind the bounded `thread/list` page.
+pub fn fetch_for_sessions(session_ids: &[String]) -> Result<ProviderSnapshot> {
     let executable = std::env::var_os("CODEX_BIN_PATH").unwrap_or_else(|| "codex".into());
     let mut command = Command::new(executable);
     command
@@ -124,7 +143,7 @@ pub fn fetch() -> Result<ProviderSnapshot> {
         terminate(&watchdog);
     });
 
-    let result = fetch_from_process(&mut input, &mut output);
+    let result = fetch_from_process(&mut input, &mut output, session_ids);
     terminate(&child);
     result
 }
@@ -153,6 +172,7 @@ fn terminate(child: &Mutex<Option<Child>>) {
 fn fetch_from_process(
     input: &mut ChildStdin,
     output: &mut BufReader<impl std::io::Read>,
+    requested_session_ids: &[String],
 ) -> Result<ProviderSnapshot> {
     write_rpc(
         input,
@@ -193,10 +213,303 @@ fn fetch_from_process(
             "useStateDbOnly": true
         }),
     )?;
+    let mut session_ids = requested_session_ids.to_vec();
     if let Ok(threads) = read_rpc(output, 4) {
         snapshot.session_summaries = parse_session_summaries(&threads);
+        for session_id in parse_thread_ids(&threads) {
+            if !session_ids.contains(&session_id) {
+                session_ids.push(session_id);
+            }
+        }
     }
+    enrich_local_sessions(&mut snapshot, &session_ids);
     Ok(snapshot)
+}
+
+fn parse_thread_ids(value: &Value) -> Vec<String> {
+    let result = value.get("result").unwrap_or(value);
+    result
+        .get("data")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|thread| {
+            thread
+                .get("id")
+                .and_then(Value::as_str)
+                .filter(|id| !id.is_empty())
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+/// Supplement quota data with bounded, local-only reads from the rollout
+/// belonging to each thread returned by `thread/list`. The app-server request
+/// above does not expose live token usage, while the rollout tail does. We
+/// never resume a thread, read prompt text into memory, or scan every pane's
+/// output; only the matching JSONL filenames are opened.
+fn enrich_local_sessions(snapshot: &mut ProviderSnapshot, session_ids: &[String]) {
+    let Some(home) = codex_home().ok() else {
+        return;
+    };
+    enrich_local_sessions_at(snapshot, &home, session_ids);
+}
+
+fn enrich_local_sessions_at(snapshot: &mut ProviderSnapshot, home: &Path, session_ids: &[String]) {
+    if session_ids.is_empty() {
+        return;
+    }
+    let mut newest: Option<(u64, Option<String>, ContextUsage)> = None;
+    let rollout_paths = find_rollout_paths(home, session_ids);
+    for session_id in session_ids {
+        let Some(path) = rollout_paths.get(session_id) else {
+            continue;
+        };
+        let Some(observation) = read_rollout_observation(path, session_id) else {
+            continue;
+        };
+        if let Some(model) = observation.model.clone() {
+            snapshot.session_models.insert(session_id.clone(), model);
+        }
+        let Some(context) = observation.context else {
+            continue;
+        };
+        snapshot
+            .session_contexts
+            .insert(session_id.clone(), context.clone());
+
+        let modified = fs::metadata(path)
+            .and_then(|metadata| metadata.modified())
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map_or(0, |duration| duration.as_secs());
+        if newest
+            .as_ref()
+            .is_none_or(|(current, _, _)| modified >= *current)
+        {
+            newest = Some((modified, observation.model, context));
+        }
+    }
+    if let Some((_, model, context)) = newest {
+        if model.is_some() {
+            snapshot.model = model;
+        }
+        snapshot.context = Some(context);
+    }
+}
+
+fn find_rollout_paths(home: &Path, session_ids: &[String]) -> BTreeMap<String, PathBuf> {
+    let mut directories = vec![home.join("sessions"), home.join("archived_sessions")];
+    let mut newest = BTreeMap::<String, (u64, PathBuf)>::new();
+    while let Some(directory) = directories.pop() {
+        let Ok(entries) = fs::read_dir(directory) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                directories.push(path);
+                continue;
+            }
+            if !file_type.is_file()
+                || path.extension().and_then(|extension| extension.to_str()) != Some("jsonl")
+            {
+                continue;
+            }
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            let matching_ids = session_ids
+                .iter()
+                .filter(|session_id| name.contains(session_id.as_str()));
+            let modified = entry
+                .metadata()
+                .ok()
+                .and_then(|metadata| metadata.modified().ok())
+                .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+                .map_or(0, |duration| duration.as_secs());
+            for session_id in matching_ids {
+                let replace = newest
+                    .get(session_id)
+                    .is_none_or(|(current, _)| modified >= *current);
+                if replace {
+                    newest.insert(session_id.clone(), (modified, path.clone()));
+                }
+            }
+        }
+    }
+    newest
+        .into_iter()
+        .map(|(session_id, (_, path))| (session_id, path))
+        .collect()
+}
+
+struct RolloutObservation {
+    model: Option<String>,
+    context: Option<ContextUsage>,
+}
+
+fn read_rollout_observation(path: &Path, session_id: &str) -> Option<RolloutObservation> {
+    let mut file = fs::File::open(path).ok()?;
+    let length = file.metadata().ok()?.len();
+    let start = length.saturating_sub(ROLLOUT_TAIL_BYTES);
+    file.seek(SeekFrom::Start(start)).ok()?;
+    let mut bytes = Vec::with_capacity((length - start) as usize);
+    file.read_to_end(&mut bytes).ok()?;
+    let text = String::from_utf8_lossy(&bytes);
+    let text = if start == 0 {
+        text.into_owned()
+    } else {
+        text.split_once('\n')?.1.to_string()
+    };
+    let mut observation = parse_rollout_observation(&text, session_id)?;
+    if observation.model.is_none() {
+        observation.model = read_rollout_head_model(path);
+    }
+    Some(observation)
+}
+
+fn read_rollout_head_model(path: &Path) -> Option<String> {
+    let file = fs::File::open(path).ok()?;
+    let mut bytes = Vec::new();
+    file.take(ROLLOUT_HEAD_BYTES).read_to_end(&mut bytes).ok()?;
+    let text = String::from_utf8_lossy(&bytes);
+    parse_rollout_model(&text)
+}
+
+fn parse_rollout_observation(text: &str, session_id: &str) -> Option<RolloutObservation> {
+    let mut model = None;
+    let mut context = None;
+    for line in text.lines() {
+        let Ok(entry) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if entry.get("type").and_then(Value::as_str) == Some("turn_context") {
+            let payload = entry.get("payload").unwrap_or(&entry);
+            model = parse_model_payload(payload).or(model);
+            continue;
+        }
+        if entry.get("type").and_then(Value::as_str) != Some("event_msg") {
+            continue;
+        }
+        let payload = entry.get("payload").unwrap_or(&entry);
+        if payload.get("type").and_then(Value::as_str) != Some("token_count") {
+            continue;
+        }
+        let info = payload.get("info").unwrap_or(payload);
+        let Some(last) = info
+            .get("last_token_usage")
+            .or_else(|| info.get("lastTokenUsage"))
+            .and_then(Value::as_object)
+        else {
+            continue;
+        };
+        let Some(window) = info
+            .get("model_context_window")
+            .or_else(|| info.get("modelContextWindow"))
+            .and_then(Value::as_u64)
+        else {
+            continue;
+        };
+        let total = token_count(last, "total_tokens", "totalTokens");
+        if total == 0 || window <= CODEX_CONTEXT_BASELINE_TOKENS {
+            continue;
+        }
+        let used = total.saturating_sub(CODEX_CONTEXT_BASELINE_TOKENS) as f64
+            / (window - CODEX_CONTEXT_BASELINE_TOKENS) as f64
+            * 100.0;
+        let Some(info_object) = info.as_object() else {
+            continue;
+        };
+        let cache_activity = token_count(last, "cached_input_tokens", "cachedInputTokens") > 0
+            || token_count(last, "cache_write_input_tokens", "cacheWriteInputTokens") > 0
+            || token_count(
+                last,
+                "cache_creation_input_tokens",
+                "cacheCreationInputTokens",
+            ) > 0;
+        let cache = parse_rollout_cache(info_object).map(|cache| {
+            let totals = CacheTotals::from_token_counts(
+                cache.fresh_input_tokens,
+                cache.read_tokens,
+                cache.creation_tokens,
+            );
+            let mut cache = cache.with_session_totals(totals, session_id, 0);
+            if cache_activity {
+                if let Some(last_activity_unix) =
+                    entry.get("timestamp").and_then(parse_rollout_timestamp)
+                {
+                    cache = cache
+                        .with_ttl_estimate(CODEX_PROMPT_CACHE_MAX_TTL_SECONDS, last_activity_unix);
+                }
+            }
+            cache
+        });
+        let context_value = ContextUsage::new(used.clamp(0.0, 100.0))
+            .ok()?
+            .with_cache(cache);
+        context = Some(context_value);
+    }
+    Some(RolloutObservation { model, context })
+}
+
+fn parse_rollout_timestamp(value: &Value) -> Option<u64> {
+    value.as_u64().or_else(|| {
+        value
+            .as_str()
+            .and_then(ResetAt::parse)
+            .map(ResetAt::unix_seconds)
+    })
+}
+
+fn parse_rollout_model(text: &str) -> Option<String> {
+    text.lines().rev().find_map(|line| {
+        let entry = serde_json::from_str::<Value>(line).ok()?;
+        (entry.get("type").and_then(Value::as_str) == Some("turn_context"))
+            .then(|| parse_model_payload(entry.get("payload").unwrap_or(&entry)))
+            .flatten()
+    })
+}
+
+fn parse_model_payload(payload: &Value) -> Option<String> {
+    payload
+        .get("model")
+        .or_else(|| payload.get("model_slug"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(str::to_string)
+}
+
+fn parse_rollout_cache(info: &serde_json::Map<String, Value>) -> Option<CacheUsage> {
+    let totals = info
+        .get("total_token_usage")
+        .or_else(|| info.get("totalTokenUsage"))
+        .and_then(Value::as_object)
+        .or_else(|| {
+            info.get("last_token_usage")
+                .or_else(|| info.get("lastTokenUsage"))
+                .and_then(Value::as_object)
+        })?;
+    let input = token_count(totals, "input_tokens", "inputTokens");
+    let read = token_count(totals, "cached_input_tokens", "cachedInputTokens");
+    let creation =
+        token_count(totals, "cache_write_input_tokens", "cacheWriteInputTokens").max(token_count(
+            totals,
+            "cache_creation_input_tokens",
+            "cacheCreationInputTokens",
+        ));
+    CacheUsage::from_token_counts(input.saturating_sub(read), read, creation)
+}
+
+fn token_count(object: &serde_json::Map<String, Value>, snake: &str, camel: &str) -> u64 {
+    object
+        .get(snake)
+        .or_else(|| object.get(camel))
+        .and_then(Value::as_u64)
+        .unwrap_or_default()
 }
 
 fn parse_session_summaries(value: &Value) -> BTreeMap<String, String> {
@@ -278,12 +591,15 @@ pub fn auth_path() -> Result<PathBuf> {
     if let Some(path) = std::env::var_os("CODEX_AUTH_FILE") {
         return Ok(PathBuf::from(path));
     }
+    Ok(codex_home()?.join("auth.json"))
+}
+
+fn codex_home() -> Result<PathBuf> {
     let home = std::env::var_os("HOME").context("HOME is not set")?;
     let home = PathBuf::from(home);
-    let codex_home = std::env::var_os("CODEX_HOME")
+    Ok(std::env::var_os("CODEX_HOME")
         .map(PathBuf::from)
-        .unwrap_or_else(|| home.join(".codex"));
-    Ok(codex_home.join("auth.json"))
+        .unwrap_or_else(|| home.join(".codex")))
 }
 
 pub fn current_account_id() -> Option<String> {
@@ -412,5 +728,76 @@ mod tests {
             Some("A real task")
         );
         assert!(!summaries.contains_key("thread-2"));
+    }
+
+    #[test]
+    fn parses_rollout_model_context_and_session_cache() {
+        let observation = parse_rollout_observation(
+            &format!(
+                "{}\n{}\n",
+                serde_json::to_string(&json!({
+                    "type": "turn_context",
+                    "payload": {"model": "gpt-5.6-luna"}
+                }))
+                .unwrap(),
+                serde_json::to_string(&json!({
+                    "type": "event_msg",
+                    "timestamp": "2026-08-26T02:28:42Z",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "total_tokens": 50_000,
+                                "cached_input_tokens": 800,
+                                "cache_write_input_tokens": 100
+                            },
+                            "total_token_usage": {
+                                "input_tokens": 1_000,
+                                "cached_input_tokens": 800,
+                                "cache_write_input_tokens": 100
+                            },
+                            "model_context_window": 100_000
+                        }
+                    }
+                }))
+                .unwrap()
+            ),
+            "session-1",
+        )
+        .unwrap();
+        assert_eq!(observation.model.as_deref(), Some("gpt-5.6-luna"));
+        let context = observation.context.unwrap();
+        assert!((context.used_percent - 43.1818).abs() < 0.001);
+        let cache = context.cache.unwrap();
+        assert_eq!(cache.fresh_input_tokens, 200);
+        assert_eq!(cache.read_tokens, 800);
+        assert_eq!(cache.creation_tokens, 100);
+        assert_eq!(cache.session_id.as_deref(), Some("session-1"));
+        assert_eq!(cache.session_totals.unwrap().hit_percent, 72.72727272727273);
+        assert_eq!(cache.ttl_seconds, Some(60 * 60));
+        assert_eq!(cache.last_activity_unix, Some(1_787_711_322));
+    }
+
+    #[test]
+    fn enriches_only_rollouts_matching_thread_ids() {
+        let directory = tempfile::tempdir().unwrap();
+        let rollout_dir = directory.path().join("sessions/2026/08/26");
+        fs::create_dir_all(&rollout_dir).unwrap();
+        fs::write(
+            rollout_dir.join("rollout-session-1.jsonl"),
+            r#"{"type":"turn_context","payload":{"model":"gpt-5.6"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":25000},"model_context_window":100000}}}
+"#,
+        )
+        .unwrap();
+        let mut snapshot = ProviderSnapshot::new(Provider::Codex, vec![], 1);
+        enrich_local_sessions_at(
+            &mut snapshot,
+            directory.path(),
+            &["session-1".to_string(), "other-session".to_string()],
+        );
+        assert_eq!(snapshot.model.as_deref(), Some("gpt-5.6"));
+        assert!(snapshot.session_contexts.contains_key("session-1"));
+        assert!(!snapshot.session_contexts.contains_key("other-session"));
     }
 }

--- a/src/providers/grok.rs
+++ b/src/providers/grok.rs
@@ -1,13 +1,21 @@
 use crate::cache::CacheStore;
-use crate::model::{Provider, ProviderSnapshot, ResetAt, UsageWindow, WindowKind};
+use crate::model::{
+    CacheTotals, CacheUsage, ContextUsage, Provider, ProviderSnapshot, ResetAt, UsageWindow,
+    WindowKind,
+};
 use crate::providers::ProviderError;
 use anyhow::{Context, Result};
 use serde_json::Value;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
 use std::fs;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const BILLING_URL: &str = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+const GROK_SESSION_TAIL_BYTES: u64 = 128 * 1024;
+const MAX_LOCAL_SESSIONS: usize = 128;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GrokCredentials {
@@ -16,6 +24,13 @@ pub struct GrokCredentials {
 }
 
 pub fn fetch() -> Result<ProviderSnapshot> {
+    fetch_for_sessions(&[])
+}
+
+/// Fetch Grok billing and enrich only the visible pane sessions when Herdr
+/// provides their ids. Direct CLI refreshes pass an empty slice and use the
+/// bounded newest-session fallback instead.
+pub fn fetch_for_sessions(session_ids: &[String]) -> Result<ProviderSnapshot> {
     let path = auth_path().context("resolve Grok auth path")?;
     let credentials = read_credentials(&path).map_err(anyhow::Error::from)?;
     let agent = ureq::AgentBuilder::new()
@@ -38,21 +53,25 @@ pub fn fetch() -> Result<ProviderSnapshot> {
     let value: Value = response
         .into_json()
         .context("decode Grok billing response")?;
-    parse_billing_response(&value, CacheStore::now_unix())
-        .map(|snapshot| snapshot.with_account_id(credentials.user_id.clone()))
-        .map_err(anyhow::Error::from)
+    let mut snapshot =
+        parse_billing_response(&value, CacheStore::now_unix()).map_err(anyhow::Error::from)?;
+    enrich_local_sessions(&mut snapshot, session_ids);
+    Ok(snapshot.with_account_id(credentials.user_id.clone()))
 }
 
 pub fn auth_path() -> Result<PathBuf> {
     if let Some(path) = std::env::var_os("GROK_AUTH_FILE") {
         return Ok(PathBuf::from(path));
     }
+    Ok(grok_home()?.join("auth.json"))
+}
+
+fn grok_home() -> Result<PathBuf> {
     let home = std::env::var_os("HOME").context("HOME is not set")?;
     let home = PathBuf::from(home);
-    let grok_home = std::env::var_os("GROK_HOME")
+    Ok(std::env::var_os("GROK_HOME")
         .map(PathBuf::from)
-        .unwrap_or_else(|| home.join(".grok"));
-    Ok(grok_home.join("auth.json"))
+        .unwrap_or_else(|| home.join(".grok")))
 }
 
 pub fn read_credentials(path: &Path) -> std::result::Result<GrokCredentials, ProviderError> {
@@ -189,6 +208,263 @@ pub fn parse_billing_response(
         vec![window],
         fetched_at_unix,
     ))
+}
+
+/// Read the small, provider-owned session metadata files that Grok writes
+/// locally. Billing remains the quota source; these files only supplement the
+/// pane diagnostics that billing does not contain. The scan is bounded to the
+/// newest session directories and never reads Herdr panes or prompt text.
+fn enrich_local_sessions(snapshot: &mut ProviderSnapshot, session_ids: &[String]) {
+    let Some(home) = grok_home().ok() else {
+        return;
+    };
+    enrich_local_sessions_at(snapshot, &home, session_ids);
+}
+
+fn enrich_local_sessions_at(snapshot: &mut ProviderSnapshot, home: &Path, session_ids: &[String]) {
+    let sessions_dir = home.join("sessions");
+    let signals = if session_ids.is_empty() {
+        collect_recent_signal_files(&sessions_dir)
+    } else {
+        collect_matching_signal_files(&sessions_dir, session_ids)
+    };
+
+    let mut newest: Option<(u64, Option<String>, ContextUsage)> = None;
+    for (modified, signals_path) in signals {
+        let Some(session_id) = signals_path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            .filter(|id| !id.is_empty())
+        else {
+            continue;
+        };
+        let Ok(signals_value) = read_json(&signals_path) else {
+            continue;
+        };
+        let updates = signals_path
+            .parent()
+            .map(|directory| directory.join("updates.jsonl"))
+            .and_then(|path| read_jsonl_tail(&path));
+        let Some(observation) = parse_local_session(&signals_value, updates.as_deref(), session_id)
+        else {
+            continue;
+        };
+        if let Some(model) = observation.model.clone() {
+            snapshot
+                .session_models
+                .insert(session_id.to_string(), model);
+        }
+        let Some(context) = observation.context else {
+            continue;
+        };
+        snapshot
+            .session_contexts
+            .insert(session_id.to_string(), context.clone());
+        if newest
+            .as_ref()
+            .is_none_or(|(current, _, _)| modified >= *current)
+        {
+            newest = Some((modified, observation.model, context));
+        }
+    }
+    if let Some((_, model, context)) = newest {
+        if model.is_some() {
+            snapshot.model = model;
+        }
+        snapshot.context = Some(context);
+    }
+}
+
+/// Grok stores sessions at `sessions/<encoded-cwd>/<session-id>/signals.json`.
+/// Keep the no-id fallback bounded to actual session directories instead of
+/// recursively walking every file under the 9GB session tree.
+fn collect_recent_signal_files(directory: &Path) -> Vec<(u64, PathBuf)> {
+    let Ok(cwd_entries) = fs::read_dir(directory) else {
+        return Vec::new();
+    };
+    // Keep only the newest bounded set while traversing. A user's Grok
+    // history can contain tens of thousands of sessions; collecting every
+    // path before sorting makes memory grow with that historical count even
+    // though only the newest 128 can affect the sidebar.
+    let mut newest = BinaryHeap::with_capacity(MAX_LOCAL_SESSIONS);
+    for cwd_entry in cwd_entries.flatten() {
+        let Ok(cwd_type) = cwd_entry.file_type() else {
+            continue;
+        };
+        if !cwd_type.is_dir() {
+            continue;
+        }
+        let Ok(session_entries) = fs::read_dir(cwd_entry.path()) else {
+            continue;
+        };
+        for session_entry in session_entries.flatten() {
+            let Ok(session_type) = session_entry.file_type() else {
+                continue;
+            };
+            if !session_type.is_dir() {
+                continue;
+            }
+            let signals_path = session_entry.path().join("signals.json");
+            let Some(modified) = CacheStore::file_mtime_unix(&signals_path) else {
+                continue;
+            };
+            newest.push(Reverse((modified, signals_path)));
+            if newest.len() > MAX_LOCAL_SESSIONS {
+                newest.pop();
+            }
+        }
+    }
+    let mut output = newest
+        .into_iter()
+        .map(|Reverse(candidate)| candidate)
+        .collect::<Vec<_>>();
+    output.sort_by_key(|candidate| Reverse(candidate.0));
+    output
+}
+
+/// With pane ids available, check only the expected session paths. This is
+/// the hot path used by the active-turn watcher and avoids scanning unrelated
+/// historical sessions altogether.
+fn collect_matching_signal_files(directory: &Path, session_ids: &[String]) -> Vec<(u64, PathBuf)> {
+    let Ok(cwd_entries) = fs::read_dir(directory) else {
+        return Vec::new();
+    };
+    let mut output = Vec::new();
+    for cwd_entry in cwd_entries.flatten() {
+        let Ok(cwd_type) = cwd_entry.file_type() else {
+            continue;
+        };
+        if !cwd_type.is_dir() {
+            continue;
+        }
+        for session_id in session_ids {
+            let signals_path = cwd_entry.path().join(session_id).join("signals.json");
+            let Some(modified) = CacheStore::file_mtime_unix(&signals_path) else {
+                continue;
+            };
+            output.push((modified, signals_path));
+        }
+    }
+    output
+}
+
+struct LocalSessionObservation {
+    model: Option<String>,
+    context: Option<ContextUsage>,
+}
+
+fn parse_local_session(
+    signals: &Value,
+    updates: Option<&str>,
+    session_id: &str,
+) -> Option<LocalSessionObservation> {
+    let model = signals
+        .get("primaryModelId")
+        .or_else(|| signals.get("primary_model_id"))
+        .and_then(Value::as_str)
+        .or_else(|| {
+            signals
+                .get("modelsUsed")
+                .or_else(|| signals.get("models_used"))
+                .and_then(Value::as_array)
+                .and_then(|models| models.iter().rev().find_map(Value::as_str))
+        })
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(str::to_string);
+
+    let used = signals
+        .get("contextWindowUsage")
+        .or_else(|| signals.get("context_window_usage"))
+        .and_then(Value::as_f64)
+        .or_else(|| {
+            let used = signals
+                .get("contextTokensUsed")
+                .or_else(|| signals.get("context_tokens_used"))
+                .and_then(Value::as_f64)?;
+            let capacity = signals
+                .get("contextWindowTokens")
+                .or_else(|| signals.get("context_window_tokens"))
+                .and_then(Value::as_f64)?;
+            (capacity > 0.0).then_some(used / capacity * 100.0)
+        });
+    let cache =
+        parse_update_cache(updates, session_id).or_else(|| parse_signal_cache(signals, session_id));
+    let context = used
+        .and_then(|used| ContextUsage::new(used.clamp(0.0, 100.0)).ok())
+        .map(|context| context.with_cache(cache));
+    (model.is_some() || context.is_some()).then_some(LocalSessionObservation { model, context })
+}
+
+fn parse_signal_cache(signals: &Value, session_id: &str) -> Option<CacheUsage> {
+    let object = signals.as_object()?;
+    let input = token_count(object, "inputTokens", "input_tokens");
+    let read = token_count(object, "cachedReadTokens", "cached_read_tokens");
+    let creation = token_count(object, "cacheCreationTokens", "cache_creation_tokens");
+    cache_usage(input, read, creation, session_id)
+}
+
+fn parse_update_cache(updates: Option<&str>, session_id: &str) -> Option<CacheUsage> {
+    let mut latest = None;
+    for line in updates?.lines().rev() {
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        let Some(usage) = value
+            .pointer("/params/update/usage")
+            .or_else(|| value.pointer("/update/usage"))
+            .or_else(|| value.pointer("/usage"))
+            .and_then(Value::as_object)
+        else {
+            continue;
+        };
+        let input = token_count(usage, "inputTokens", "input_tokens");
+        let read = token_count(usage, "cachedReadTokens", "cached_read_tokens");
+        let creation = token_count(usage, "cacheCreationTokens", "cache_creation_tokens");
+        if let Some(cache) = cache_usage(input, read, creation, session_id) {
+            latest = Some(cache);
+            break;
+        }
+    }
+    latest
+}
+
+fn cache_usage(input: u64, read: u64, creation: u64, session_id: &str) -> Option<CacheUsage> {
+    let cache = CacheUsage::from_token_counts(input.saturating_sub(read), read, creation)?;
+    let totals = CacheTotals::from_token_counts(
+        cache.fresh_input_tokens,
+        cache.read_tokens,
+        cache.creation_tokens,
+    );
+    Some(cache.with_session_totals(totals, session_id, 0))
+}
+
+fn token_count(object: &serde_json::Map<String, Value>, camel: &str, snake: &str) -> u64 {
+    object
+        .get(camel)
+        .or_else(|| object.get(snake))
+        .and_then(Value::as_u64)
+        .unwrap_or_default()
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let bytes = fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    serde_json::from_slice(&bytes).with_context(|| format!("parse {}", path.display()))
+}
+
+fn read_jsonl_tail(path: &Path) -> Option<String> {
+    let mut file = fs::File::open(path).ok()?;
+    let length = file.metadata().ok()?.len();
+    let start = length.saturating_sub(GROK_SESSION_TAIL_BYTES);
+    file.seek(SeekFrom::Start(start)).ok()?;
+    let mut bytes = Vec::with_capacity((length - start) as usize);
+    file.read_to_end(&mut bytes).ok()?;
+    let tail = String::from_utf8_lossy(&bytes);
+    if start == 0 {
+        return Some(tail.into_owned());
+    }
+    tail.split_once('\n').map(|(_, lines)| lines.to_string())
 }
 
 fn http_error_status(error: &ureq::Error) -> String {
@@ -337,5 +613,81 @@ mod tests {
                 user_id: Some("u-new".to_string())
             }
         );
+    }
+
+    #[test]
+    fn parses_local_session_context_model_and_cache() {
+        let signals = json!({
+            "contextWindowUsage": 16,
+            "contextTokensUsed": 80_000,
+            "contextWindowTokens": 500_000,
+            "primaryModelId": "grok-4.6"
+        });
+        let updates = r#"{"method":"_x.ai/session/update","params":{"update":{"usage":{"inputTokens":1000,"cachedReadTokens":800,"cacheCreationTokens":100}}}}
+"#;
+        let observation = parse_local_session(&signals, Some(updates), "session-1").unwrap();
+        assert_eq!(observation.model.as_deref(), Some("grok-4.6"));
+        assert_eq!(observation.context.as_ref().unwrap().used_percent, 16.0);
+        let cache = observation.context.unwrap().cache.unwrap();
+        assert_eq!(cache.fresh_input_tokens, 200);
+        assert_eq!(cache.read_tokens, 800);
+        assert_eq!(cache.creation_tokens, 100);
+        assert_eq!(cache.session_id.as_deref(), Some("session-1"));
+    }
+
+    #[test]
+    fn scans_session_files_without_broadcasting_unknown_data() {
+        let directory = tempfile::tempdir().unwrap();
+        let session_dir = directory.path().join("sessions/cwd/session-1");
+        fs::create_dir_all(&session_dir).unwrap();
+        fs::write(
+            session_dir.join("signals.json"),
+            r#"{"contextWindowUsage":25,"primaryModelId":"grok-4.5"}"#,
+        )
+        .unwrap();
+        fs::write(
+            session_dir.join("updates.jsonl"),
+            r#"{"params":{"update":{"usage":{"inputTokens":10,"cachedReadTokens":5}}}}"#,
+        )
+        .unwrap();
+        let mut snapshot = ProviderSnapshot::new(Provider::Grok, vec![], 1);
+        enrich_local_sessions_at(&mut snapshot, directory.path(), &["session-1".to_string()]);
+        assert_eq!(snapshot.session_models["session-1"], "grok-4.5");
+        assert!(snapshot.context_for_session(Some("session-1")).is_some());
+        assert!(snapshot.context_for_session(Some("session-2")).is_none());
+    }
+
+    #[test]
+    fn matching_session_scan_checks_only_the_expected_two_level_layout() {
+        let directory = tempfile::tempdir().unwrap();
+        let matching = directory.path().join("sessions/cwd/session-1");
+        let unrelated_nested = directory.path().join("sessions/old/nested/session-1");
+        fs::create_dir_all(&matching).unwrap();
+        fs::create_dir_all(&unrelated_nested).unwrap();
+        fs::write(matching.join("signals.json"), "{}").unwrap();
+        fs::write(unrelated_nested.join("signals.json"), "{}").unwrap();
+
+        let files = collect_matching_signal_files(
+            &directory.path().join("sessions"),
+            &["session-1".to_string()],
+        );
+        assert_eq!(files.len(), 1);
+        assert!(files[0].1.ends_with("sessions/cwd/session-1/signals.json"));
+    }
+
+    #[test]
+    fn recent_session_scan_keeps_only_a_bounded_newest_set() {
+        let directory = tempfile::tempdir().unwrap();
+        for index in 0..(MAX_LOCAL_SESSIONS + 8) {
+            let session_dir = directory
+                .path()
+                .join("sessions/cwd")
+                .join(format!("session-{index}"));
+            fs::create_dir_all(&session_dir).unwrap();
+            fs::write(session_dir.join("signals.json"), "{}").unwrap();
+        }
+
+        let files = collect_recent_signal_files(&directory.path().join("sessions"));
+        assert_eq!(files.len(), MAX_LOCAL_SESSIONS);
     }
 }

--- a/src/providers/statusline.rs
+++ b/src/providers/statusline.rs
@@ -7,6 +7,25 @@ use std::path::Path;
 
 const TRANSCRIPT_TAIL_BYTES: u64 = 16 * 1024;
 
+/// Read the provider's human-readable active model label from a statusLine
+/// payload. The display name is intentionally preferred over the model id so
+/// the sidebar stays useful at a glance and does not expose provider-specific
+/// implementation identifiers.
+pub fn parse_model(value: &Value) -> Option<String> {
+    value
+        .get("model")
+        .and_then(Value::as_object)
+        .and_then(|model| {
+            model
+                .get("display_name")
+                .or_else(|| model.get("displayName"))
+                .and_then(Value::as_str)
+        })
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(str::to_string)
+}
+
 pub fn parse_context(
     value: Option<&Value>,
 ) -> std::result::Result<Option<ContextUsage>, ProviderError> {
@@ -115,6 +134,8 @@ pub fn enrich_cache_session(
     let Some(session_id) = statusline
         .get("session_id")
         .or_else(|| statusline.get("sessionId"))
+        .or_else(|| statusline.get("conversation_id"))
+        .or_else(|| statusline.get("conversationId"))
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
     else {
@@ -343,6 +364,20 @@ mod tests {
                 .unwrap()
                 .with_cache(CacheUsage::from_token_counts(1, 1, 1)),
         ))
+    }
+
+    #[test]
+    fn model_parser_requires_a_human_readable_display_name() {
+        assert_eq!(
+            parse_model(&json!({"model": {"id": "claude-sonnet-4"}})),
+            None
+        );
+        assert_eq!(
+            parse_model(&json!({
+                "model": {"displayName": "Sonnet"}
+            })),
+            Some("Sonnet".to_string())
+        );
     }
 
     #[test]

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -1,7 +1,7 @@
 use crate::cache::CacheStore;
 use crate::herdr::{
-    current_agent_provider, list_agent_panes, list_agent_state, publish_tokens, refresh_pane_topic,
-    AgentPane,
+    current_agent_provider, list_agent_panes, list_agent_state, publish_pane_tokens,
+    refresh_pane_topic, AgentPane, PaneTokens,
 };
 use crate::model::{Provider, ProviderSnapshot};
 use crate::presentation::MetadataTokens;
@@ -106,7 +106,7 @@ fn refresh_and_publish(
     force: bool,
     panes: &[AgentPane],
 ) -> Result<()> {
-    refresh_selected(cache, providers, force)?;
+    refresh_selected(cache, providers, force, panes)?;
     publish(cache, providers, None, Some(panes))
 }
 
@@ -117,8 +117,13 @@ fn run_internal(
     topic_pane: Option<&str>,
 ) -> Result<()> {
     let cache = CacheStore::from_env()?;
-    let outcomes = refresh_selected(&cache, providers, force)?;
-    publish(&cache, providers, topic_pane, None)?;
+    // Agent inventory is metadata-only. Reusing it for both the fetch and the
+    // publish pass lets local Codex/Grok diagnostics target the exact pane
+    // sessions without adding another Herdr call or reading any pane output.
+    let panes = list_agent_panes().ok();
+    let session_panes = panes.as_deref().unwrap_or_default();
+    let outcomes = refresh_selected(&cache, providers, force, session_panes)?;
+    publish(&cache, providers, topic_pane, panes.as_deref())?;
     if json {
         println!("{}", serde_json::to_string_pretty(&outcomes)?);
     }
@@ -177,11 +182,12 @@ fn refresh_selected(
     cache: &CacheStore,
     providers: &[Provider],
     force: bool,
+    panes: &[AgentPane],
 ) -> Result<Vec<ProviderOutcome>> {
     providers
         .iter()
         .copied()
-        .map(|provider| refresh_provider(cache, provider, force))
+        .map(|provider| refresh_provider(cache, provider, force, panes))
         .collect()
 }
 
@@ -189,6 +195,7 @@ fn refresh_provider(
     cache: &CacheStore,
     provider: Provider,
     force: bool,
+    panes: &[AgentPane],
 ) -> Result<ProviderOutcome> {
     let now = CacheStore::now_unix();
     if should_skip_fetch(cache, provider, force, now)? {
@@ -208,21 +215,28 @@ fn refresh_provider(
         });
     };
 
+    let session_ids = panes
+        .iter()
+        .filter(|pane| pane.provider == provider)
+        .filter_map(|pane| pane.session_id.clone())
+        .collect::<Vec<_>>();
     let fetched = match provider {
-        Provider::Codex => codex::fetch().map(FetchedSnapshot::direct),
-        Provider::Grok => grok::fetch().map(FetchedSnapshot::direct),
+        Provider::Codex => codex::fetch_for_sessions(&session_ids).map(FetchedSnapshot::direct),
+        Provider::Grok => grok::fetch_for_sessions(&session_ids).map(FetchedSnapshot::direct),
         Provider::Claude | Provider::Agy => load_statusline_snapshot(cache, provider),
     };
     cache.mark_refresh(provider, now)?;
     match fetched {
         Ok(fetched) => {
             let FetchedSnapshot {
-                snapshot,
+                mut snapshot,
                 preserve_context,
                 session_id,
             } = fetched;
             if preserve_context {
                 cache.save_preserving_context_for_session(snapshot, session_id.as_deref())?;
+            } else if matches!(provider, Provider::Codex | Provider::Grok) {
+                cache.save_preserving_diagnostics_for_sessions(&mut snapshot, &session_ids)?;
             } else {
                 cache.save(&snapshot)?;
             }
@@ -310,6 +324,8 @@ fn load_statusline_snapshot(cache: &CacheStore, provider: Provider) -> Result<Fe
     let session_id = value
         .get("session_id")
         .or_else(|| value.get("sessionId"))
+        .or_else(|| value.get("conversation_id"))
+        .or_else(|| value.get("conversationId"))
         .and_then(serde_json::Value::as_str)
         .map(str::to_string);
     Ok(FetchedSnapshot {
@@ -344,21 +360,29 @@ fn publish(
         let usable = snapshot
             .as_ref()
             .filter(|snapshot| snapshot.usable_for_account(account_id.as_deref(), mtime));
-        if let Some(snapshot) = usable {
-            for pane in panes.iter_mut().filter(|pane| pane.provider == *provider) {
+        for pane in panes.iter_mut().filter(|pane| pane.provider == *provider) {
+            if let Some(snapshot) = usable {
                 if let Some(session_id) = pane.session_id.as_deref() {
                     if let Some(summary) = snapshot.session_summaries.get(session_id) {
                         pane.session_summary = summary.clone();
                     }
                 }
             }
-        }
-        if let Some(values) = tokens_for_loaded_snapshot(*provider, snapshot.as_ref(), usable, now)
-        {
-            tokens.push((*provider, values));
+            if let Some(values) = tokens_for_loaded_snapshot(
+                *provider,
+                snapshot.as_ref(),
+                usable,
+                now,
+                pane.session_id.as_deref(),
+            ) {
+                tokens.push(PaneTokens {
+                    pane_id: pane.pane_id.clone(),
+                    values,
+                });
+            }
         }
     }
-    publish_tokens(&panes, &tokens, CacheStore::now_millis())
+    publish_pane_tokens(&panes, &tokens, CacheStore::now_millis())
 }
 
 fn event_json() -> Option<Value> {
@@ -421,8 +445,10 @@ fn find_pane_id(value: &Value) -> Option<&str> {
 fn tokens_for_provider(
     snapshot: Option<&crate::model::ProviderSnapshot>,
     now_unix: u64,
+    session_id: Option<&str>,
 ) -> Option<MetadataTokens> {
-    snapshot.map(|snapshot| MetadataTokens::from_snapshot(snapshot, now_unix))
+    snapshot
+        .map(|snapshot| MetadataTokens::from_snapshot_for_session(snapshot, now_unix, session_id))
 }
 
 fn tokens_for_loaded_snapshot(
@@ -430,9 +456,10 @@ fn tokens_for_loaded_snapshot(
     raw: Option<&ProviderSnapshot>,
     usable: Option<&ProviderSnapshot>,
     now_unix: u64,
+    session_id: Option<&str>,
 ) -> Option<MetadataTokens> {
     match (usable, raw) {
-        (Some(snapshot), _) => tokens_for_provider(Some(snapshot), now_unix),
+        (Some(snapshot), _) => tokens_for_provider(Some(snapshot), now_unix, session_id),
         (None, Some(_)) => Some(MetadataTokens::unavailable(
             provider,
             "signed-in account changed",
@@ -462,7 +489,7 @@ mod tests {
 
     #[test]
     fn missing_snapshot_does_not_overwrite_sidebar_with_unavailable() {
-        let values = tokens_for_provider(None, 1);
+        let values = tokens_for_provider(None, 1, None);
         assert!(values.is_none());
     }
 
@@ -474,7 +501,8 @@ mod tests {
             1,
         )
         .with_account_id(Some("old-account".to_string()));
-        let values = tokens_for_loaded_snapshot(Provider::Grok, Some(&snapshot), None, 1).unwrap();
+        let values =
+            tokens_for_loaded_snapshot(Provider::Grok, Some(&snapshot), None, 1, None).unwrap();
         assert_eq!(values.quota_summary, "unavailable");
         assert_eq!(
             values.quota_error.as_deref(),

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -100,14 +100,18 @@ fn run_claude_refresh(state: &Path, herdr: &Path) {
 }
 
 #[test]
-fn sidebar_configuration_is_idempotent_and_reversible() {
+fn sidebar_configuration_is_idempotent_and_removes_plugin_rows() {
     let original = "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n";
+    let canonical_without_plugin = "[ui.sidebar.agents]\nrows = [[\"state_icon\"]]\n";
     let applied = add_quota_row(original).unwrap();
     assert!(applied.contains("key = \"prefix+shift+r\""));
     assert!(applied.contains("type = \"plugin_action\""));
     assert!(applied.contains("command = \"herdr-agent-quota.refresh\""));
     assert_eq!(add_quota_row(&applied).unwrap(), applied);
-    assert_eq!(remove_quota_row(&applied).unwrap(), original);
+    assert_eq!(
+        remove_quota_row(&applied).unwrap(),
+        canonical_without_plugin
+    );
 }
 
 #[test]
@@ -125,7 +129,10 @@ fn sidebar_configuration_preserves_a_conflicting_refresh_key() {
     assert_eq!(applied.matches("key = \"prefix+shift+r\"").count(), 1);
     assert!(applied.contains("command = \"echo user-owned\""));
     assert!(!applied.contains("command = \"herdr-agent-quota.refresh\""));
-    assert_eq!(remove_quota_row(&applied).unwrap(), original);
+    assert_eq!(
+        remove_quota_row(&applied).unwrap(),
+        "[[keys.command]]\nkey = \"prefix+shift+r\"\ntype = \"shell\"\ncommand = \"echo user-owned\"\ndescription = \"user refresh\"\n\n[ui.sidebar.agents]\nrows = [[\"state_icon\"]]\n"
+    );
 }
 
 #[test]
@@ -135,7 +142,7 @@ fn default_herdr_rows_become_plane_provider_usage_and_topic_lines() {
         "rows = [[\"state_icon\", \"workspace\", \"tab\"], [\"agent\"]]\n"
     );
     let applied = add_quota_row(original).unwrap();
-    assert!(applied.contains("$quota_provider"));
+    assert!(applied.contains("$quota_provider_model"));
     assert!(applied.contains("bold = true"));
     assert!(applied.contains("$quota_5h_normal"));
     assert!(applied.contains("$quota_5h_warning"));
@@ -146,11 +153,12 @@ fn default_herdr_rows_become_plane_provider_usage_and_topic_lines() {
     assert!(!applied.contains("[\"$quota_summary\"]"));
     assert!(applied.contains("$quota_topic"));
     assert!(applied.contains("$quota_context"));
-    assert!(applied.contains("fg = \"#9b8fd8\""));
-    assert!(applied.find("$quota_provider").unwrap() < applied.find("$quota_context").unwrap());
+    assert!(applied.contains("$quota_provider_model"));
+    assert!(applied.contains("fg = \"#9aa7b8\""));
+    assert!(applied.find("$quota_provider_model").unwrap() < applied.find("$quota_topic").unwrap());
     assert!(applied.contains("$quota_cache"));
     assert!(applied.contains("$quota_cache_ttl"));
-    assert!(applied.contains("fg = \"#6fb5b7\""));
+    assert!(applied.contains("fg = \"#9aa7b8\""));
     assert!(applied.contains("row_gap = 1 # herdr-agent-quota"));
     assert!(applied.find("$quota_topic").unwrap() < applied.find("$quota_5h_normal").unwrap());
     assert!(applied.contains("fg = \"#84b084\""));
@@ -161,6 +169,128 @@ fn default_herdr_rows_become_plane_provider_usage_and_topic_lines() {
     assert!(applied.contains("fg = \"#7998b7\""));
     assert!(applied.contains("fg = \"#acb4c3\""));
     assert!(applied.contains("fg = \"#84b0af\""));
+}
+
+#[test]
+fn context_is_the_penultimate_row_and_model_shares_provider_style() {
+    let applied =
+        add_quota_row("[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n").unwrap();
+    let document = applied.parse::<toml_edit::DocumentMut>().unwrap();
+    let agents = &document["ui"]["sidebar"]["agents"];
+    let rows = agents["rows"].as_array().unwrap();
+    let context_index = rows
+        .iter()
+        .position(|row| {
+            row.as_array().is_some_and(|items| {
+                items.iter().any(|item| {
+                    item.as_inline_table()
+                        .and_then(|table| table.get("token"))
+                        .and_then(toml_edit::Value::as_str)
+                        .is_some_and(|token| token == "$quota_context")
+                })
+            })
+        })
+        .unwrap();
+    let limit_index = rows
+        .iter()
+        .position(|row| {
+            row.as_array().is_some_and(|items| {
+                items.iter().any(|item| {
+                    item.as_inline_table()
+                        .and_then(|table| table.get("token"))
+                        .and_then(toml_edit::Value::as_str)
+                        .is_some_and(|token| token == "$quota_5h_normal")
+                })
+            })
+        })
+        .unwrap();
+    assert_eq!(context_index + 1, limit_index);
+    assert_eq!(limit_index + 1, rows.len());
+
+    let claude_rows = agents["rows_by_agent"]["claude"].as_value().unwrap();
+    let rendered = claude_rows.to_string();
+    assert_eq!(rendered.matches("fg = \"#c47f6a\"").count(), 1);
+}
+
+#[test]
+fn provider_model_is_compact_and_grok_merges_weekly_limit_into_context_row() {
+    let applied =
+        add_quota_row("[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n").unwrap();
+    let document = applied.parse::<toml_edit::DocumentMut>().unwrap();
+    let agents = &document["ui"]["sidebar"]["agents"];
+    let rows = agents["rows"].as_array().unwrap();
+    let identity_row = rows
+        .iter()
+        .find(|row| row_contains_token(row, "$quota_provider_model"))
+        .unwrap();
+    let identity_tokens = identity_row.as_array().unwrap();
+    assert!(!identity_tokens.iter().any(|item| {
+        matches!(
+            configured_token(item),
+            Some("$quota_provider") | Some("$quota_model")
+        )
+    }));
+
+    let grok_rows = agents["rows_by_agent"]["grok"].as_array().unwrap();
+    let context_row = grok_rows
+        .iter()
+        .find(|row| row_contains_token(row, "$quota_context"))
+        .unwrap()
+        .as_array()
+        .unwrap();
+    assert!(context_row
+        .iter()
+        .any(|item| configured_token(item) == Some("$quota_week_normal")));
+    assert!(!grok_rows.iter().any(|row| {
+        row_contains_token(row, "$quota_week_normal") && !row_contains_token(row, "$quota_context")
+    }));
+}
+
+#[test]
+fn existing_provider_and_model_tokens_are_migrated_to_one_identity_token() {
+    let applied = add_quota_row(
+        r#"[ui.sidebar.agents]
+rows = [["state_icon", "tab", { token = "$quota_provider" }, { token = "$quota_model" }]]
+"#,
+    )
+    .unwrap();
+    let document = applied.parse::<toml_edit::DocumentMut>().unwrap();
+    let rows = document["ui"]["sidebar"]["agents"]["rows"]
+        .as_array()
+        .unwrap();
+    let identity_row = rows
+        .iter()
+        .find(|row| row_contains_token(row, "$quota_provider_model"))
+        .unwrap()
+        .as_array()
+        .unwrap();
+    assert_eq!(
+        identity_row
+            .iter()
+            .filter(|item| configured_token(item) == Some("$quota_provider_model"))
+            .count(),
+        1
+    );
+    assert!(!identity_row.iter().any(|item| {
+        matches!(
+            configured_token(item),
+            Some("$quota_provider") | Some("$quota_model")
+        )
+    }));
+}
+
+fn configured_token(value: &toml_edit::Value) -> Option<&str> {
+    value
+        .as_str()
+        .or_else(|| value.as_inline_table()?.get("token")?.as_str())
+}
+
+fn row_contains_token(row: &toml_edit::Value, token: &str) -> bool {
+    row.as_array().is_some_and(|items| {
+        items
+            .iter()
+            .any(|item| configured_token(item) == Some(token))
+    })
 }
 
 #[test]
@@ -184,7 +314,10 @@ fn sidebar_configuration_preserves_an_explicit_row_gap() {
     let applied = add_quota_row(original).unwrap();
     assert!(applied.contains("row_gap = 2"));
     assert!(!applied.contains("row_gap = 1"));
-    assert_eq!(remove_quota_row(&applied).unwrap(), original);
+    assert_eq!(
+        remove_quota_row(&applied).unwrap(),
+        "[ui.sidebar.agents]\nrow_gap = 2\nrows = [[\"state_icon\"]]\n"
+    );
 }
 
 #[test]
@@ -464,7 +597,7 @@ fn claude_collector_does_not_republish_unchanged_quota() {
     let state = tempdir().unwrap();
     let (herdr_stub, herdr_log) = install_herdr_stub(
         state.path(),
-        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1","tokens":{"quota_state":"?","quota_provider":"Claude","quota_5h":"5h 42%","quota_5h_warning":"5h 42%","quota_week":"7d 73%","quota_week_warning":"7d 73%","quota_summary":"5h 42% · week 73%"}}]}}"#,
+        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1","tokens":{"quota_state":"?","quota_provider":"Claude","quota_provider_model":"Claude","quota_5h":"5h 42%","quota_5h_warning":"5h 42%","quota_week":"7d 73%","quota_week_warning":"7d 73%","quota_summary":"5h 42% · week 73%"}}]}}"#,
     );
 
     let input = br#"{


### PR DESCRIPTION
## What changed
- Compact the first sidebar row to `Provider/Model` with one provider brand color.
- Merge Grok weekly-only limit into the context row; keep context penultimate and limits last for other providers.
- Make Claude/Agy statusLine cache/context/model diagnostics session-scoped; a fresh session cannot inherit stale cache. Bound per-session maps to 128 entries.
- Keep Codex/Grok local enrichment matched to visible sessions and bound Grok history scans.
- Update English/Chinese docs, implementation notes, research, and regression coverage.

## Verification
- `cargo test --all-targets --all-features --locked`
- `cargo clippy --release --all-targets --all-features --locked -- -D warnings`
- `cargo build --release --locked`
- Installed locally with `./install.sh` and verified Herdr metadata.