### PR TITLE
fix: isolate unknown pane diagnostics and shorten weekly labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   row, and Claude/Agy statusLine diagnostics are keyed by session so a fresh
   session cannot inherit another session's cache. All per-session maps are
   bounded to 128 entries.
+- A pane without a Herdr session id no longer receives provider-global
+  context/cache diagnostics. This prevents a fresh Grok or Agy pane from
+  showing another session's cached usage; diagnostics appear once the current
+  session can be matched. Weekly labels use the compact `7d` form everywhere.
 - Quota rows now show compact `5h`/`7d` window labels with minutes below one
   hour, hours and minutes below one day, and days plus hours for longer windows.
 - Cache hit rate and remaining cache TTL now share one short, color-separated
@@ -84,8 +88,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Expired cache TTL estimates now render as a red `no cached` diagnostic, and
   Claude payloads without quota fields clear stale window values instead of
   leaving an old weekly reset on the sidebar.
-- Weekly-only providers now use the readable `week ... reset ...` label; the
-  compact `5h`/`7d` form remains for providers that expose both windows.
+- Weekly windows now use the compact `7d ... reset ...` label, including
+  weekly-only providers, so narrow sidebars do not truncate the label.
 - Grok local-session enrichment now checks only the pane-matched two-level
   session paths, with a bounded newest-session fallback for direct refreshes;
   it no longer recursively scans the entire historical session tree.

--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ long turns no longer start one refresh command per tool call.
 | --- | --- | --- | --- |
 | Claude Code | model + `5h` + `7d` + context + cache hit/approx. TTL | Official `statusLine` JSON: `model`, `rate_limits`, `context_window`, and `transcript_path` | The configure action installs/chains it and keeps its refresh interval current |
 | OpenAI Codex | model + `5h` + `7d` + context + cache + approx. TTL + local session summary | One-shot local `codex app-server --stdio` plus a bounded tail read of matching `~/.codex` rollout JSONL | ChatGPT subscription login; API-key mode is shown as unavailable |
-| Grok CLI / Grok Build | model + `week` + context + cache | Local `~/.grok/auth.json` billing plus bounded reads of `signals.json`/`updates.jsonl` session metadata | Covered by the unified watcher; no response hook is installed |
-| Agy / Antigravity CLI | model + `5h` + `week` + context + cache hit | Official `statusLine` JSON: `model`, `quota`, and `context_window` | The configure action installs and chains it automatically |
+| Grok CLI / Grok Build | model + `7d` + context + cache | Local `~/.grok/auth.json` billing plus bounded reads of `signals.json`/`updates.jsonl` session metadata | Covered by the unified watcher; no response hook is installed |
+| Agy / Antigravity CLI | model + `5h` + `7d` + context + cache hit | Official `statusLine` JSON: `model`, `quota`, and `context_window` | The configure action installs and chains it automatically |
 
 The sidebar shows **percentage remaining** and the time until each quota reset,
 not quota token counts. The two Claude windows use compact `5h` and `7d`
@@ -203,7 +203,7 @@ turn, one short-lived global watcher polls once per configured interval,
 coalesces active fetches, and exits when all selected providers settle. The
 sidebar does not run a permanent daemon.
 
-Grok has only a weekly quota window, so its provider-specific row places that
+Grok has only a weekly quota window (`7d`), so its provider-specific row places that
 limit beside context instead of leaving an empty slot on the right.
 
 A failed refresh never replaces a successful cached value with `unavailable`;
@@ -253,8 +253,9 @@ rows = [
   provider name. `$quota_provider` and `$quota_model` remain available for
   custom layouts and older configurations.
 - Model and provider values are tracked per session, so same-provider panes can
-  show different models; Codex and Grok hide the model only when their local
-  session data is unavailable.
+  show different models. If Herdr cannot identify a pane's session, the
+  provider-level model may remain visible, but context/cache diagnostics stay
+  hidden instead of broadcasting another session's values.
 - Default provider labels use recognizable brand colors without affecting quota
   health: Claude soft orange, Codex pastel blue, Grok soft white, and an
   Antigravity-inspired mint for Agy.
@@ -287,9 +288,11 @@ rows = [
   final row.
 - Claude and Agy statusLine diagnostics are keyed by session. A new session
   starts without the previous session's cache/context values; Codex and Grok
-  read only visible session files. Per-session diagnostic maps are capped at
-  128 entries, and the watcher uses one metadata-only Herdr inventory call per
-  poll, so historical sessions cannot grow memory without bound.
+  read only visible session files. If Herdr exposes no session id for a pane,
+  local context/cache values are hidden until one is available. Per-session
+  diagnostic maps are capped at 128 entries, and the watcher uses one
+  metadata-only Herdr inventory call per poll, so historical sessions cannot
+  grow memory without bound.
 - Each window publishes exactly one styled variant. Herdr renders adjacent
   values on the same row with `·` separators and removes separators for missing
   values, so 5h/7d stay compact while retaining independent colors. Color

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -149,8 +149,8 @@ usage、topic 三类 token，不会覆盖官方 agent 指示。卸载 action 会
 | --- | --- | --- | --- |
 | Claude Code | model + `5h` + `7d` + context + 缓存命中率/近似 TTL | 官方 `statusLine` JSON：`model`、`rate_limits`、`context_window`、`transcript_path` | 配置 action 自动安装/串联，并保持原生刷新间隔与 watcher 一致 |
 | OpenAI Codex | model + `5h` + `7d` + context + cache + 近似 TTL + 本地会话摘要 | 一次性的 `codex app-server --stdio`，加上按 thread 匹配的 `~/.codex` rollout 尾部 | 使用 ChatGPT 订阅登录；API key 模式显示为不可用；不会 resume thread |
-| Grok CLI / Grok Build | model + `week` + context + cache | `~/.grok/auth.json` 额度接口，加上有上限的 `signals.json`/`updates.jsonl` 会话元数据 | 由统一 watcher 处理，不再安装回复 hook |
-| Agy / Antigravity CLI | model + `5h` + `week` + context + 缓存命中率 | 官方 `statusLine` JSON 的 `model`、`quota` 和 `context_window` | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
+| Grok CLI / Grok Build | model + `7d` + context + cache | `~/.grok/auth.json` 额度接口，加上有上限的 `signals.json`/`updates.jsonl` 会话元数据 | 由统一 watcher 处理，不再安装回复 hook |
+| Agy / Antigravity CLI | model + `5h` + `7d` + context + 缓存命中率 | 官方 `statusLine` JSON 的 `model`、`quota` 和 `context_window` | 配置 action 自动安装并串联原命令；turn 中由统一 watcher 发布缓存 |
 
 侧栏显示的是**额度剩余百分比**和距离下次额度重置的时间，不是额度 token 数量。
 Claude 的两个窗口会用紧凑的 `5h` 和 `7d` 标签放在同一行，但仍各自保留动态健康色。
@@ -220,8 +220,9 @@ rows = [
 - `$quota_provider_model` 是紧凑的 `Provider/Model` 身份标签，例如
   `Claude/Sonnet`；模型不可用时只显示 provider 名称。`$quota_provider` 和
   `$quota_model` 仍保留给自定义布局和旧配置使用。
-- provider 和 model 都按 session 保存，因此同一 provider 的多个 pane 也能显示各自模型；
-  Codex/Grok 的本地会话数据不可用时才隐藏 model。
+- provider 和 model 都按 session 保存，因此同一 provider 的多个 pane 也能显示各自模型。
+  如果 Herdr 没有提供 pane 的 session id，可以保留 provider 级 model，但会隐藏
+  context/cache，避免把另一会话的诊断广播过来。
 - 默认 provider 名称使用易辨识的柔和品牌色，并且不影响额度健康色：
   Claude 柔橘、Codex 粉彩蓝、Grok 柔白、Agy 使用 Antigravity 风格薄荷绿。
 - `$quota_topic` 放在额度上方，阅读顺序是 agent、当前任务、资源状态。
@@ -242,8 +243,9 @@ rows = [
 - Grok 只有周额度，因此 `rows_by_agent.grok` 会把周 limit 放到 context 同一行，
   避免右侧留下空位；其他 provider 仍保持 context 倒数第二行、limit 最后一行。
 - Claude/Agy 的 statusLine 诊断按 session 隔离，新 session 不会继承上一 session 的
-  cache/context。Codex/Grok 只读取可匹配的本地会话文件；每个 provider 的 session
-  诊断最多保留 128 条，watcher 每轮只读取一次 Herdr 元数据，不会让历史会话无限增长。
+  cache/context。Codex/Grok 只读取可匹配的本地会话文件；如果 pane 没有 session id，
+  会先隐藏本地 context/cache，直到能匹配当前会话。每个 provider 的 session 诊断最多
+  保留 128 条，watcher 每轮只读取一次 Herdr 元数据，不会让历史会话无限增长。
 - 每个窗口只发布一个样式 token。Herdr 会把同一行相邻 token 自动用 `·`
   分隔，并在 token 缺失时移除对应分隔符，所以 5h/7d 会紧凑地显示在一行，
   但仍各自保留颜色。颜色按额度续航动态判断，不再使用固定余额阈值：将剩余

--- a/docs/screenshots/sidebar-quota.svg
+++ b/docs/screenshots/sidebar-quota.svg
@@ -11,19 +11,19 @@
     <g>
       <rect x="20" y="160" width="320" height="120" rx="6" fill="#1b1e25"/>
       <text x="36" y="187" fill="#94a0b3" font-size="11">● Owner · Codex</text>
-      <text x="36" y="216" fill="#e8edf7" font-size="15" font-weight="700">week 86%</text>
+      <text x="36" y="216" fill="#e8edf7" font-size="15" font-weight="700">7d 86%</text>
       <text x="36" y="245" fill="#94a0b3" font-size="13">ti</text>
       <rect x="20" y="296" width="320" height="120" rx="6" fill="#1b1e25"/>
       <text x="36" y="323" fill="#94a0b3" font-size="11">● Owner · Grok</text>
-      <text x="36" y="352" fill="#e8edf7" font-size="15" font-weight="700">week 21%</text>
+      <text x="36" y="352" fill="#e8edf7" font-size="15" font-weight="700">7d 21%</text>
       <text x="36" y="381" fill="#94a0b3" font-size="13">B-325 budget cap</text>
       <rect x="20" y="432" width="320" height="120" rx="6" fill="#1b1e25"/>
       <text x="36" y="459" fill="#94a0b3" font-size="11">● Owner · Claude</text>
-      <text x="36" y="488" fill="#e8edf7" font-size="15" font-weight="700">5h 95% · week 73%</text>
+      <text x="36" y="488" fill="#e8edf7" font-size="15" font-weight="700">5h 95% · 7d 73%</text>
       <text x="36" y="517" fill="#94a0b3" font-size="13">refactor auth</text>
       <rect x="20" y="568" width="320" height="120" rx="6" fill="#1b1e25"/>
       <text x="36" y="595" fill="#94a0b3" font-size="11">● Owner · Agy</text>
-      <text x="36" y="624" fill="#e8edf7" font-size="15" font-weight="700">5h 99.7% · week 99.7%</text>
+      <text x="36" y="624" fill="#e8edf7" font-size="15" font-weight="700">5h 99.7% · 7d 99.7%</text>
       <text x="36" y="653" fill="#94a0b3" font-size="13">model check</text>
     </g>
     <text x="28" y="740" fill="#94a0b3" font-size="12">three readable rows · live CLI topic</text>
@@ -34,9 +34,9 @@
     <rect x="458" y="212" width="868" height="1" fill="#48505e"/>
     <g>
       <rect x="458" y="236" width="868" height="84" rx="6" fill="#1c2026"/><rect x="458" y="236" width="7" height="84" rx="3" fill="#5cd18e"/>
-      <text x="486" y="274" fill="#e8edf7" font-size="17" font-weight="700">Codex</text><text x="620" y="274" fill="#94a0b3" font-size="13">ChatGPT subscription</text><text x="1030" y="274" fill="#94a0b3" font-size="12">week</text><text x="1160" y="274" fill="#5cd18e" font-size="14" font-weight="700">86% left</text>
+      <text x="486" y="274" fill="#e8edf7" font-size="17" font-weight="700">Codex</text><text x="620" y="274" fill="#94a0b3" font-size="13">ChatGPT subscription</text><text x="1030" y="274" fill="#94a0b3" font-size="12">7d</text><text x="1160" y="274" fill="#5cd18e" font-size="14" font-weight="700">86% left</text>
       <rect x="458" y="340" width="868" height="84" rx="6" fill="#1c2026"/><rect x="458" y="340" width="7" height="84" rx="3" fill="#f0ad40"/>
-      <text x="486" y="378" fill="#e8edf7" font-size="17" font-weight="700">Grok</text><text x="620" y="378" fill="#94a0b3" font-size="13">SuperGrok</text><text x="1030" y="378" fill="#94a0b3" font-size="12">week</text><text x="1160" y="378" fill="#f0ad40" font-size="14" font-weight="700">21% left</text>
+      <text x="486" y="378" fill="#e8edf7" font-size="17" font-weight="700">Grok</text><text x="620" y="378" fill="#94a0b3" font-size="13">SuperGrok</text><text x="1030" y="378" fill="#94a0b3" font-size="12">7d</text><text x="1160" y="378" fill="#f0ad40" font-size="14" font-weight="700">21% left</text>
       <rect x="458" y="444" width="868" height="84" rx="6" fill="#1c2026"/><rect x="458" y="444" width="7" height="84" rx="3" fill="#5cd18e"/>
       <text x="486" y="482" fill="#e8edf7" font-size="17" font-weight="700">Claude</text><text x="620" y="482" fill="#94a0b3" font-size="13">Claude Code</text><text x="1020" y="482" fill="#94a0b3" font-size="12">5h + weekly</text><text x="1160" y="482" fill="#5cd18e" font-size="14" font-weight="700">95% · 73% left</text>
       <rect x="458" y="548" width="868" height="84" rx="6" fill="#1c2026"/><rect x="458" y="548" width="7" height="84" rx="3" fill="#5cd18e"/>

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -92,13 +92,13 @@ impl CacheStore {
         if let Some(previous) = self.load(snapshot.provider).ok().flatten() {
             let same_account = snapshot.account_id == previous.account_id;
             if same_account {
-                if snapshot.context.is_none() {
-                    snapshot.context = previous.context.clone();
-                }
-                if snapshot.model.is_none() {
-                    snapshot.model = previous.model.clone();
-                }
                 if session_ids.is_empty() {
+                    if snapshot.context.is_none() {
+                        snapshot.context = previous.context.clone();
+                    }
+                    if snapshot.model.is_none() {
+                        snapshot.model = previous.model.clone();
+                    }
                     if snapshot.session_contexts.is_empty() {
                         for (session_id, context) in previous.session_contexts {
                             snapshot
@@ -783,6 +783,27 @@ mod tests {
         assert_eq!(saved.model.as_deref(), Some("grok-4.6"));
         assert_eq!(saved.session_models["session-1"], "grok-4.6");
         assert!(saved.session_contexts.contains_key("session-1"));
+    }
+
+    #[test]
+    fn direct_provider_refresh_does_not_leak_global_context_to_a_new_session() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let previous = snapshot().with_context(Some(
+            ContextUsage::new(24.0).unwrap().with_cache(Some(
+                CacheUsage::from_token_counts(10, 90, 0)
+                    .unwrap()
+                    .with_session_totals(None, "old-session", 0),
+            )),
+        ));
+        cache.save(&previous).unwrap();
+
+        let mut latest = snapshot();
+        cache
+            .save_preserving_diagnostics_for_sessions(&mut latest, &["new-session".to_string()])
+            .unwrap();
+        let saved = cache.load(Provider::Grok).unwrap().unwrap();
+        assert!(saved.context_for_session(Some("new-session")).is_none());
     }
 
     #[test]

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -104,7 +104,7 @@ mod tests {
         let rendered = render_provider(Provider::Claude, Some(&snapshot), 0);
         assert_eq!(
             rendered,
-            "Claude WARN\r\n  5h 42% left reset 4h07m · week 73% left reset 2d3h"
+            "Claude WARN\r\n  5h 42% left reset 4h07m · 7d 73% left reset 2d3h"
         );
     }
 

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -801,12 +801,12 @@ mod tests {
         insert_severity_token(
             &mut tokens,
             "quota_week",
-            "week 25% reset 2d3h",
+            "7d 25% reset 2d3h",
             Some(crate::model::Severity::Warning),
         );
         assert_eq!(
             tokens.get("quota_week_warning").map(String::as_str),
-            Some("week 25% reset 2d3h")
+            Some("7d 25% reset 2d3h")
         );
         assert!(!tokens.contains_key("quota_week_normal"));
         assert!(!tokens.contains_key("quota_week_danger"));

--- a/src/model.rs
+++ b/src/model.rs
@@ -79,7 +79,7 @@ impl WindowKind {
     pub fn label(self) -> &'static str {
         match self {
             Self::FiveHour => "5h",
-            Self::Weekly => "week",
+            Self::Weekly => "7d",
         }
     }
 
@@ -381,8 +381,8 @@ impl ProviderSnapshot {
         self
     }
 
-    /// Return the model for a pane's session, falling back to the latest
-    /// provider-level value for snapshots created before session tracking.
+    /// Return the model for a pane's session. A known session never falls back
+    /// to provider-level data, because that value may belong to another pane.
     pub fn model_for_session(&self, session_id: Option<&str>) -> Option<&str> {
         let Some(session_id) = session_id else {
             return self.model.as_deref();
@@ -390,19 +390,13 @@ impl ProviderSnapshot {
         if let Some(model) = self.session_models.get(session_id) {
             return Some(model);
         }
-        if self.session_models.is_empty() {
-            self.model.as_deref()
-        } else {
-            None
-        }
+        None
     }
 
-    /// Return context/cache diagnostics for a pane's session. A snapshot with
-    /// no per-session map is an older/provider-level observation, so it keeps
-    /// the historical global fallback for local providers. StatusLine
-    /// providers cannot safely use that fallback: an old Claude/Agy snapshot
-    /// may belong to a different pane session, so an unknown session is blank
-    /// until its own hook observation arrives.
+    /// Return context/cache diagnostics for a pane's session. A known session
+    /// never falls back to provider-level data, because an older snapshot may
+    /// belong to another pane. The global value is used only when the caller
+    /// has no session id at all.
     pub fn context_for_session(&self, session_id: Option<&str>) -> Option<&ContextUsage> {
         let Some(session_id) = session_id else {
             return self.context.as_ref();
@@ -410,13 +404,7 @@ impl ProviderSnapshot {
         if let Some(context) = self.session_contexts.get(session_id) {
             return Some(context);
         }
-        if self.session_contexts.is_empty()
-            && !matches!(self.provider, Provider::Claude | Provider::Agy)
-        {
-            self.context.as_ref()
-        } else {
-            None
-        }
+        None
     }
 
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
@@ -578,6 +566,24 @@ mod tests {
             ContextUsage::new(23.5).unwrap().with_cache(Some(cache)),
         ));
         assert!(snapshot.context_for_session(Some("new-session")).is_none());
+    }
+
+    #[test]
+    fn legacy_local_context_is_not_reused_for_an_unknown_session() {
+        let cache = CacheUsage::from_token_counts(10, 90, 0)
+            .unwrap()
+            .with_session_totals(CacheTotals::from_token_counts(10, 90, 0), "old-session", 0);
+        for provider in [Provider::Codex, Provider::Grok] {
+            let snapshot = ProviderSnapshot::new(provider, vec![], 0).with_context(Some(
+                ContextUsage::new(23.5)
+                    .unwrap()
+                    .with_cache(Some(cache.clone())),
+            ));
+            assert!(
+                snapshot.context_for_session(Some("new-session")).is_none(),
+                "{provider:?} leaked provider-level context into a new session"
+            );
+        }
     }
 
     #[test]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -31,11 +31,40 @@ impl MetadataTokens {
         now_unix: u64,
         session_id: Option<&str>,
     ) -> Self {
+        Self::from_snapshot_parts(
+            snapshot,
+            now_unix,
+            snapshot.model_for_session(session_id),
+            snapshot.context_for_session(session_id),
+        )
+    }
+
+    /// Render a pane's tokens without broadcasting provider-local diagnostics
+    /// when Herdr cannot identify that pane's session. A provider-level model
+    /// is still useful for the identity row, but context/cache values are
+    /// session data and must stay blank until their session id is known.
+    pub fn from_snapshot_for_pane(
+        snapshot: &ProviderSnapshot,
+        now_unix: u64,
+        session_id: Option<&str>,
+    ) -> Self {
+        let quota_model = match session_id {
+            Some(session_id) => snapshot.model_for_session(Some(session_id)),
+            None => snapshot.model.as_deref(),
+        };
+        let context =
+            session_id.and_then(|session_id| snapshot.context_for_session(Some(session_id)));
+        Self::from_snapshot_parts(snapshot, now_unix, quota_model, context)
+    }
+
+    fn from_snapshot_parts(
+        snapshot: &ProviderSnapshot,
+        now_unix: u64,
+        model: Option<&str>,
+        context: Option<&crate::model::ContextUsage>,
+    ) -> Self {
         let quota_provider = snapshot.provider.display_name().to_string();
-        let quota_model = snapshot
-            .model_for_session(session_id)
-            .unwrap_or_default()
-            .to_string();
+        let quota_model = model.unwrap_or_default().to_string();
         Self {
             quota_state: snapshot.severity(now_unix).symbol().to_string(),
             quota_icon: snapshot.provider.icon().to_string(),
@@ -48,10 +77,10 @@ impl MetadataTokens {
             quota_week: sidebar_window(snapshot, WindowKind::Weekly, now_unix),
             quota_week_severity: window_severity(snapshot, WindowKind::Weekly, now_unix),
             quota_summary: sidebar_summary(snapshot, now_unix),
-            quota_context: sidebar_context(snapshot.context_for_session(session_id)),
-            quota_cache: sidebar_cache(snapshot.context_for_session(session_id)),
-            quota_cache_ttl: sidebar_cache_ttl(snapshot.context_for_session(session_id), now_unix),
-            quota_error: sidebar_cache_error(snapshot.context_for_session(session_id), now_unix),
+            quota_context: sidebar_context(context),
+            quota_cache: sidebar_cache(context),
+            quota_cache_ttl: sidebar_cache_ttl(context, now_unix),
+            quota_error: sidebar_cache_error(context, now_unix),
         }
     }
 
@@ -265,11 +294,11 @@ mod tests {
         );
         assert_eq!(
             sidebar_summary(&snapshot, 0),
-            "5h 42% reset 4h07m · week 73% reset 2d3h"
+            "5h 42% reset 4h07m · 7d 73% reset 2d3h"
         );
         assert_eq!(
             dashboard_summary(&snapshot, 0),
-            "5h 42% left reset 4h07m · week 73% left reset 2d3h"
+            "5h 42% left reset 4h07m · 7d 73% left reset 2d3h"
         );
     }
 
@@ -278,7 +307,7 @@ mod tests {
         let five_hour = format_window(&window(WindowKind::FiveHour, 57.0, 14_820), 0, false);
         let weekly = format_window(&window(WindowKind::Weekly, 75.0, 183_600), 0, false);
         assert_eq!(five_hour, "5h 43% reset 4h07m");
-        assert_eq!(weekly, "week 25% reset 2d3h");
+        assert_eq!(weekly, "7d 25% reset 2d3h");
     }
 
     #[test]
@@ -372,6 +401,23 @@ mod tests {
     }
 
     #[test]
+    fn pane_without_session_id_does_not_broadcast_local_diagnostics() {
+        let snapshot = ProviderSnapshot::new(Provider::Grok, vec![], 0)
+            .with_model(Some("grok-4.6".to_string()))
+            .with_context(Some(
+                crate::model::ContextUsage::new(43.2)
+                    .unwrap()
+                    .with_cache(crate::model::CacheUsage::from_token_counts(200, 800, 100)),
+            ));
+        let values = MetadataTokens::from_snapshot_for_pane(&snapshot, 0, None);
+        assert_eq!(values.quota_provider_model, "Grok/grok-4.6");
+        assert_eq!(values.quota_context, "");
+        assert_eq!(values.quota_cache, "");
+        assert_eq!(values.quota_cache_ttl, "");
+        assert_eq!(values.quota_error, None);
+    }
+
+    #[test]
     fn metadata_formats_session_cache_hit_rate_and_approximate_ttl() {
         let cache = crate::model::CacheUsage::from_token_counts(100, 800, 100)
             .unwrap()
@@ -449,7 +495,7 @@ mod tests {
             0,
         );
         let values = MetadataTokens::from_snapshot(&snapshot, 0);
-        assert_eq!(values.quota_week, "week 69% reset 6d0h");
+        assert_eq!(values.quota_week, "7d 69% reset 6d0h");
     }
 
     #[test]

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -447,8 +447,7 @@ fn tokens_for_provider(
     now_unix: u64,
     session_id: Option<&str>,
 ) -> Option<MetadataTokens> {
-    snapshot
-        .map(|snapshot| MetadataTokens::from_snapshot_for_session(snapshot, now_unix, session_id))
+    snapshot.map(|snapshot| MetadataTokens::from_snapshot_for_pane(snapshot, now_unix, session_id))
 }
 
 fn tokens_for_loaded_snapshot(

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -450,12 +450,13 @@ fn statusline_without_context_keeps_the_last_context_snapshot() {
     let state = tempdir().unwrap();
     let (herdr_stub, herdr_log) = install_herdr_stub(
         state.path(),
-        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1"}]}}"#,
+        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1","agent_session":{"value":"session-1"}}]}}"#,
     );
     run_claude_collector(
         state.path(),
         &herdr_stub,
         br#"{
+            "session_id": "session-1",
             "context_window": {"used_percentage": 23.5},
             "rate_limits": {"seven_day": {"used_percentage": 27.0}}
         }"#,
@@ -463,13 +464,13 @@ fn statusline_without_context_keeps_the_last_context_snapshot() {
     run_claude_collector(
         state.path(),
         &herdr_stub,
-        br#"{"rate_limits":{"seven_day":{"used_percentage":28.0}}}"#,
+        br#"{"session_id":"session-1","rate_limits":{"seven_day":{"used_percentage":28.0}}}"#,
     );
 
     run_claude_refresh(state.path(), &herdr_stub);
     let report = fs::read_to_string(herdr_log).unwrap();
     assert!(report.contains("quota_context=context 24%"));
-    assert!(report.contains("quota_week=week 72%"));
+    assert!(report.contains("quota_week=7d 72%"));
 }
 
 #[test]
@@ -597,7 +598,7 @@ fn claude_collector_does_not_republish_unchanged_quota() {
     let state = tempdir().unwrap();
     let (herdr_stub, herdr_log) = install_herdr_stub(
         state.path(),
-        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1","tokens":{"quota_state":"?","quota_provider":"Claude","quota_provider_model":"Claude","quota_5h":"5h 42%","quota_5h_warning":"5h 42%","quota_week":"7d 73%","quota_week_warning":"7d 73%","quota_summary":"5h 42% · week 73%"}}]}}"#,
+        r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1","tokens":{"quota_state":"?","quota_provider":"Claude","quota_provider_model":"Claude","quota_5h":"5h 42%","quota_5h_warning":"5h 42%","quota_week":"7d 73%","quota_week_warning":"7d 73%","quota_summary":"5h 42% · 7d 73%"}}]}}"#,
     );
 
     let input = br#"{

--- a/tests/metadata_rendering.rs
+++ b/tests/metadata_rendering.rs
@@ -15,6 +15,6 @@ fn agent_row_renders_compact_reset_eta_without_absolute_timestamp() {
     );
     assert_eq!(
         render_provider(Provider::Grok, Some(&snapshot), 0),
-        "Grok WARN\r\n  week 21% left reset 2d3h"
+        "Grok WARN\r\n  7d 21% left reset 2d3h"
     );
 }


### PR DESCRIPTION
Fixes the follow-up issues from #22.

- Do not broadcast provider-global context/cache to panes without a Herdr session id.
- Keep per-session diagnostics isolated for known sessions.
- Use the compact `7d` weekly label everywhere.
- Update regression tests, docs, and the sidebar screenshot.

Verified with cargo test, clippy, and release build.