### PR TITLE
fix: keep five-hour quota off the context row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Sidebar cards now decide from the 5h token, not the provider name, whether
+  weekly quota sits beside context. A present 5h window keeps `5h` and `7d`
+  on the limits row so they never share a line with context; an empty 5h
+  publishes week on the context row instead, so weekly-only cards still read
+  `context · 7d`. Codex can therefore split when OpenAI returns 5h and fold
+  after a reset; Grok, Claude, and Agy keep their previous visual shape.
 - Agy/Antigravity quota now shows the pool that the active model actually
   draws from instead of the conservative minimum across both pools. Gemini-family
   model names (`gemini`, `flash`, `learnlm`) select the `gemini-*` pool;

--- a/README.md
+++ b/README.md
@@ -236,7 +236,12 @@ rows = [
     { token = "$quota_cache_ttl", fg = "#9aa7b8", bold = true, dim = false },
     { token = "$quota_error", fg = "#ca6470", bold = true, dim = false },
   ],
-  [{ token = "$quota_context", fg = "#9aa7b8", bold = true, dim = false }],
+  [
+    { token = "$quota_context", fg = "#9aa7b8", bold = true, dim = false },
+    { token = "$quota_week_inline_normal", fg = "#84b084", bold = true, dim = false },
+    { token = "$quota_week_inline_warning", fg = "#cdaa65", bold = true, dim = false },
+    { token = "$quota_week_inline_danger", fg = "#ca6470", bold = true, dim = false },
+  ],
   [
     { token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false },
     { token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false },
@@ -283,10 +288,13 @@ rows = [
   cards are easy to scan. Cache, TTL, and context share one muted diagnostic
   color (`#9aa7b8`); only quota runway health and explicit errors use green,
   amber, and red.
-- For Grok, and for Codex when OpenAI omits the five-hour window,
-  `rows_by_agent` puts the weekly limit on the context row. Empty `$quota_5h`
-  tokens are elided, so the card reads `context · 7d`. Claude and Agy keep
-  context as the penultimate row and limits as the final row.
+- If a five-hour window is present, 5h and 7d stay on the limits row, never
+  on the same line as context. If 5h is empty, the weekly token is published
+  on the context row instead (`$quota_week_inline_*`) and the empty limits
+  row disappears, so the card reads `context · 7d`. This is decided from the
+  tokens, not the provider name: Codex splits when OpenAI returns 5h and
+  folds when it does not; Grok stays compact; Claude and Agy keep a dedicated
+  limits row, including the `5h N/A` placeholder.
 - Claude and Agy statusLine diagnostics are keyed by session. A new session
   starts without the previous session's cache/context values; Codex and Grok
   read only visible session files. If Herdr exposes no session id for a pane,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -204,7 +204,12 @@ rows = [
     { token = "$quota_cache_ttl", fg = "#9aa7b8", bold = true, dim = false },
     { token = "$quota_error", fg = "#ca6470", bold = true, dim = false },
   ],
-  [{ token = "$quota_context", fg = "#9aa7b8", bold = true, dim = false }],
+  [
+    { token = "$quota_context", fg = "#9aa7b8", bold = true, dim = false },
+    { token = "$quota_week_inline_normal", fg = "#84b084", bold = true, dim = false },
+    { token = "$quota_week_inline_warning", fg = "#cdaa65", bold = true, dim = false },
+    { token = "$quota_week_inline_danger", fg = "#ca6470", bold = true, dim = false },
+  ],
   [
     { token = "$quota_5h_normal", fg = "#84b084", bold = true, dim = false },
     { token = "$quota_5h_warning", fg = "#cdaa65", bold = true, dim = false },
@@ -240,10 +245,11 @@ rows = [
   不做猜测。
 - provider 和 model 共用各自 provider 的品牌色，方便快速识别；cache、TTL 和 context
   共用一套低饱和诊断色（`#9aa7b8`），只有额度 limit 和明确错误使用绿/琥珀/红色。
-- Grok 只有周额度；Codex 在 OpenAI 不返回 5h 时也一样。两者的 `rows_by_agent`
-  都会把周 limit 拼到 context 同一行，空的 `$quota_5h` token 会被隐掉，
-  看起来就是 `context · 7d`。Claude 和 Agy 仍保持 context 倒数第二行、
-  limit 最后一行。
+- 只要 5h 有值，5h 和 7d 就留在 limit 行，不和 context 同一行。5h 为空时，
+  周额度改发到 context 行（`$quota_week_inline_*`），空的 limit 行会被隐掉，
+  看起来就是 `context · 7d`。这是按 token 有没有 5h 动态判断的，不按
+  provider 名称写死：Codex 在 OpenAI 返回 5h 时分行，没有 5h 时折叠；Grok
+  保持紧凑；Claude 和 Agy 继续用独立 limit 行（包括 `5h N/A` 占位）。
 - Claude/Agy 的 statusLine 诊断按 session 隔离，新 session 不会继承上一 session 的
   cache/context。Codex/Grok 只读取可匹配的本地会话文件；如果 pane 没有 session id，
   会先隐藏本地 context/cache，直到能匹配当前会话。每个 provider 的 session 诊断最多

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Item, Table, Value};
 
-const QUOTA_ROW_MARKERS: [&str; 25] = [
+const QUOTA_ROW_MARKERS: [&str; 29] = [
     "$quota_badge",
     "$quota_state",
     "$quota_icon",
@@ -29,6 +29,10 @@ const QUOTA_ROW_MARKERS: [&str; 25] = [
     "$quota_week_warning",
     "$quota_week_danger",
     "$quota_week_unknown",
+    "$quota_week_inline_normal",
+    "$quota_week_inline_warning",
+    "$quota_week_inline_danger",
+    "$quota_week_inline_unknown",
 ];
 const ROW_GAP_MARKER: &str = "herdr-agent-quota";
 const PROVIDER_STYLE_MARKER: &str = "herdr-agent-quota-provider";
@@ -361,7 +365,7 @@ fn add_provider_rows(agents: &mut Table, rows: &Array) -> Result<()> {
         if rows_by_agent.contains_key(provider) && !is_managed {
             continue;
         }
-        let mut value = Value::Array(provider_rows(rows, color, provider));
+        let mut value = Value::Array(provider_rows(rows, color));
         value
             .decor_mut()
             .set_suffix(format!(" # {PROVIDER_STYLE_MARKER}"));
@@ -370,43 +374,16 @@ fn add_provider_rows(agents: &mut Table, rows: &Array) -> Result<()> {
     Ok(())
 }
 
-fn provider_rows(rows: &Array, color: Option<&str>, provider: &str) -> Array {
-    // Grok never has a 5h window. Codex often doesn't either after a reset,
-    // so both fold the quota tokens onto the context row. Herdr then elides
-    // empty `$quota_5h_*` values and the card looks like Grok's weekly line.
-    let merge_windows_into_context = provider == "grok" || provider == "codex";
-    let context_index = if merge_windows_into_context {
-        rows.iter()
-            .position(|row| row_contains_token(row, "$quota_context"))
-    } else {
-        None
-    };
-    let window_index = if merge_windows_into_context {
-        rows.iter().position(|row| {
-            row_contains_token(row, "$quota_5h_normal")
-                || row_contains_token(row, "$quota_week_normal")
-        })
-    } else {
-        None
-    };
-    let window_items = window_index
-        .and_then(|index| rows.get(index))
-        .and_then(Value::as_array);
+fn provider_rows(rows: &Array, color: Option<&str>) -> Array {
+    // Brand color only. Whether 5h sits on its own row or 7d folds onto
+    // context is decided at publish time from the 5h token, not here.
     let mut themed = Array::new();
-    for (index, row) in rows.iter().enumerate() {
-        if window_index == Some(index) && context_index != Some(index) {
-            continue;
-        }
+    for row in rows.iter() {
         let Some(items) = row.as_array() else {
             continue;
         };
         let mut themed_row = Array::new();
         append_themed_provider_row(&mut themed_row, items, color);
-        if context_index == Some(index) {
-            if let Some(window_items) = window_items {
-                append_themed_provider_row(&mut themed_row, window_items, color);
-            }
-        }
         themed.push(Value::Array(themed_row));
     }
     themed
@@ -425,14 +402,6 @@ fn append_themed_provider_row(row: &mut Array, items: &Array, color: Option<&str
             row.push(item.clone());
         }
     }
-}
-
-fn row_contains_token(row: &Value, token: &str) -> bool {
-    row.as_array().is_some_and(|items| {
-        items
-            .iter()
-            .any(|item| configured_token_name(item) == Some(token))
-    })
 }
 
 fn remove_managed_provider_rows(agents: &mut Table) {
@@ -509,9 +478,9 @@ fn normalize_official_row(row: Array) -> Array {
 }
 
 fn append_quota_rows(rows: &mut Array) {
-    // Keep the official state row and put both quota windows on one compact
-    // row. Herdr elides missing tokens and their separators, so weekly-only
-    // providers do not gain a blank five-hour segment.
+    // Context can carry the weekly token when 5h is empty. Limits stay on the
+    // next row so a present 5h window never shares a line with context. Herdr
+    // drops empty tokens and empty rows.
     for row in rows.iter_mut() {
         let Some(items) = row.as_array_mut() else {
             continue;
@@ -593,12 +562,14 @@ fn append_quota_rows(rows: &mut Array) {
 
     append_cache_row(rows);
 
-    rows.push(Value::Array(styled_row(
+    let mut context_row = styled_row(
         "$quota_context",
         Some(DIAGNOSTIC_COLOR),
         Some(true),
         Some(false),
-    )));
+    );
+    append_window_style_tokens(&mut context_row, "quota_week_inline");
+    rows.push(Value::Array(context_row));
 
     append_window_row(rows);
 }
@@ -626,27 +597,25 @@ fn append_cache_row(rows: &mut Array) {
     ])));
 }
 
+fn append_window_style_tokens(row: &mut Array, base: &str) {
+    for (suffix, color) in [
+        ("normal", QUOTA_SAFE_COLOR),
+        ("warning", QUOTA_WARNING_COLOR),
+        ("danger", QUOTA_DANGER_COLOR),
+    ] {
+        row.push(styled_token(
+            &format!("${base}_{suffix}"),
+            Some(color),
+            Some(true),
+            Some(false),
+        ));
+    }
+}
+
 fn append_window_row(rows: &mut Array) {
     let mut row = Array::new();
     for base in ["quota_5h", "quota_week"] {
-        row.push(styled_token(
-            &format!("${base}_normal"),
-            Some(QUOTA_SAFE_COLOR),
-            Some(true),
-            Some(false),
-        ));
-        row.push(styled_token(
-            &format!("${base}_warning"),
-            Some(QUOTA_WARNING_COLOR),
-            Some(true),
-            Some(false),
-        ));
-        row.push(styled_token(
-            &format!("${base}_danger"),
-            Some(QUOTA_DANGER_COLOR),
-            Some(true),
-            Some(false),
-        ));
+        append_window_style_tokens(&mut row, base);
     }
     rows.push(Value::Array(row));
 }
@@ -695,6 +664,45 @@ rows = [["state_icon", "agent"]]
         assert!(updated.contains("$quota_5h_warning"));
         assert!(updated.contains("$quota_week_danger"));
         assert_eq!(add_quota_row(&updated).unwrap(), updated);
+    }
+
+    #[test]
+    fn context_row_can_fold_weekly_without_placing_five_hour_beside_it() {
+        let updated =
+            add_quota_row("[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n").unwrap();
+        let document = updated.parse::<DocumentMut>().unwrap();
+        let rows = document["ui"]["sidebar"]["agents"]["rows"]
+            .as_array()
+            .unwrap();
+        let context_row = rows
+            .iter()
+            .find(|row| {
+                row.as_array().is_some_and(|items| {
+                    items
+                        .iter()
+                        .any(|item| configured_token_name(item) == Some("$quota_context"))
+                })
+            })
+            .and_then(Value::as_array)
+            .unwrap();
+        assert!(context_row
+            .iter()
+            .any(|item| configured_token_name(item) == Some("$quota_week_inline_normal")));
+        assert!(context_row
+            .iter()
+            .all(|item| configured_token_name(item) != Some("$quota_5h_normal")));
+        assert!(rows.iter().any(|row| {
+            let items = row.as_array().unwrap();
+            items
+                .iter()
+                .any(|item| configured_token_name(item) == Some("$quota_5h_normal"))
+                && items
+                    .iter()
+                    .any(|item| configured_token_name(item) == Some("$quota_week_normal"))
+                && items
+                    .iter()
+                    .all(|item| configured_token_name(item) != Some("$quota_context"))
+        }));
     }
 
     #[test]

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 
 const METADATA_TTL_MS: &str = "86400000";
 const MAX_METADATA_TOKENS: usize = 16;
-const METADATA_TOKEN_NAMES: [&str; 18] = [
+const METADATA_TOKEN_NAMES: [&str; 21] = [
     "quota_state",
     "quota_provider",
     "quota_model",
@@ -24,6 +24,9 @@ const METADATA_TOKEN_NAMES: [&str; 18] = [
     "quota_week_normal",
     "quota_week_warning",
     "quota_week_danger",
+    "quota_week_inline_normal",
+    "quota_week_inline_warning",
+    "quota_week_inline_danger",
     "quota_topic",
     "quota_error",
 ];
@@ -371,7 +374,7 @@ fn desired_tokens(values: &MetadataTokens, topic: &str) -> BTreeMap<String, Stri
     insert_optional_token(&mut tokens, "quota_week", &values.quota_week);
     insert_severity_token(
         &mut tokens,
-        "quota_week",
+        week_style_base(&values.quota_5h),
         &values.quota_week,
         values.quota_week_severity,
     );
@@ -443,16 +446,21 @@ fn metadata_report_names(
     }
     while names.len() > active_capacity {
         let Some(index) = names.iter().position(|name| {
-            !matches!(
-                *name,
-                "quota_context"
-                    | "quota_model"
-                    | "quota_provider_model"
-                    | "quota_cache"
-                    | "quota_cache_ttl"
-                    | "quota_provider"
-                    | "quota_topic"
-            )
+            let must_clear = pane.tokens.contains_key(*name) && !desired.contains_key(*name);
+            !must_clear
+                && !matches!(
+                    *name,
+                    "quota_context"
+                        | "quota_model"
+                        | "quota_provider_model"
+                        | "quota_cache"
+                        | "quota_cache_ttl"
+                        | "quota_provider"
+                        | "quota_topic"
+                        | "quota_week_inline_normal"
+                        | "quota_week_inline_warning"
+                        | "quota_week_inline_danger"
+                )
         }) else {
             break;
         };
@@ -461,6 +469,16 @@ fn metadata_report_names(
     names.truncate(active_capacity);
     names.extend(cleanup_names);
     names
+}
+
+fn week_style_base(quota_5h: &str) -> &'static str {
+    // Empty 5h publishes week beside context (`context · 7d`). A present 5h
+    // keeps week on the limits row so 5h never shares a line with context.
+    if quota_5h.trim().is_empty() {
+        "quota_week_inline"
+    } else {
+        "quota_week"
+    }
 }
 
 fn insert_severity_token(
@@ -654,6 +672,48 @@ mod tests {
     }
 
     #[test]
+    fn weekly_only_inline_week_stays_inside_herdr_metadata_cap() {
+        let snapshot = crate::model::ProviderSnapshot::new(
+            Provider::Grok,
+            vec![crate::model::UsageWindow::new(
+                crate::model::WindowKind::Weekly,
+                30.0,
+                Some(crate::model::ResetAt::from_unix_seconds(183_600)),
+            )
+            .unwrap()],
+            0,
+        )
+        .with_context(Some(
+            crate::model::ContextUsage::new(42.0)
+                .unwrap()
+                .with_cache(Some(
+                    crate::model::CacheUsage::from_token_counts(100, 800, 100)
+                        .unwrap()
+                        .with_ttl_estimate(3_600, 0)
+                        .with_session_totals(
+                            crate::model::CacheTotals::from_token_counts(100, 800, 100),
+                            "session-1",
+                            1,
+                        ),
+                )),
+        ));
+        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        let pane = AgentPane {
+            pane_id: "w1:p1".to_string(),
+            provider: Provider::Grok,
+            session_id: None,
+            session_summary: String::new(),
+            topic: String::new(),
+            tokens: BTreeMap::new(),
+        };
+        let names = metadata_report_names(&pane, &desired);
+        assert!(names.len() <= MAX_METADATA_TOKENS);
+        assert!(names.contains(&"quota_week_inline_normal"));
+        assert!(!names.contains(&"quota_week_normal"));
+        assert!(!names.contains(&"quota_5h"));
+    }
+
+    #[test]
     fn cache_diagnostics_stay_inside_herdr_metadata_cap() {
         let snapshot = crate::model::ProviderSnapshot::new(
             Provider::Claude,
@@ -793,6 +853,143 @@ mod tests {
         let mut panes = Vec::new();
         collect_agent_panes(&value, &mut panes);
         assert_eq!(panes[0].topic, "");
+    }
+
+    #[test]
+    fn claude_placeholder_five_hour_does_not_fold_week_onto_context() {
+        let snapshot = crate::model::ProviderSnapshot::new(
+            Provider::Claude,
+            vec![crate::model::UsageWindow::new(
+                crate::model::WindowKind::Weekly,
+                31.0,
+                Some(crate::model::ResetAt::from_unix_seconds(183_600)),
+            )
+            .unwrap()],
+            0,
+        );
+        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        assert_eq!(desired.get("quota_5h").map(String::as_str), Some("5h N/A"));
+        assert!(desired.contains_key("quota_week_normal"));
+        assert!(!desired.contains_key("quota_week_inline_normal"));
+        assert!(!desired.contains_key("quota_week_inline_warning"));
+        assert!(!desired.contains_key("quota_week_inline_danger"));
+    }
+
+    #[test]
+    fn empty_five_hour_publishes_week_beside_context() {
+        let snapshot = crate::model::ProviderSnapshot::new(
+            Provider::Codex,
+            vec![crate::model::UsageWindow::new(
+                crate::model::WindowKind::Weekly,
+                31.0,
+                Some(crate::model::ResetAt::from_unix_seconds(183_600)),
+            )
+            .unwrap()],
+            0,
+        );
+        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        assert!(!desired.contains_key("quota_5h"));
+        assert!(desired.contains_key("quota_week"));
+        assert!(desired.contains_key("quota_week_inline_normal"));
+        assert!(!desired.contains_key("quota_week_normal"));
+    }
+
+    #[test]
+    fn present_five_hour_keeps_week_off_the_context_row() {
+        let snapshot = crate::model::ProviderSnapshot::new(
+            Provider::Codex,
+            vec![
+                crate::model::UsageWindow::new(
+                    crate::model::WindowKind::FiveHour,
+                    5.0,
+                    Some(crate::model::ResetAt::from_unix_seconds(14_820)),
+                )
+                .unwrap(),
+                crate::model::UsageWindow::new(
+                    crate::model::WindowKind::Weekly,
+                    1.0,
+                    Some(crate::model::ResetAt::from_unix_seconds(183_600)),
+                )
+                .unwrap(),
+            ],
+            0,
+        );
+        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        assert!(desired.contains_key("quota_5h"));
+        assert!(desired.contains_key("quota_week_normal"));
+        assert!(!desired.contains_key("quota_week_inline_normal"));
+        assert!(!desired.contains_key("quota_week_inline_warning"));
+        assert!(!desired.contains_key("quota_week_inline_danger"));
+    }
+
+    #[test]
+    fn folding_week_onto_context_clears_limits_week_styles() {
+        let snapshot = crate::model::ProviderSnapshot::new(
+            Provider::Grok,
+            vec![crate::model::UsageWindow::new(
+                crate::model::WindowKind::Weekly,
+                25.0,
+                Some(crate::model::ResetAt::from_unix_seconds(183_600)),
+            )
+            .unwrap()],
+            0,
+        );
+        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        let mut tokens = desired.clone();
+        tokens.remove("quota_week_inline_normal");
+        tokens.insert("quota_week_normal".to_string(), "7d 75% 5d0h".to_string());
+        let pane = AgentPane {
+            pane_id: "w1:p1".to_string(),
+            provider: Provider::Grok,
+            session_id: None,
+            session_summary: String::new(),
+            topic: String::new(),
+            tokens,
+        };
+        assert!(!metadata_matches(&pane.tokens, &desired));
+        let names = metadata_report_names(&pane, &desired);
+        assert!(names.contains(&"quota_week_normal"));
+        assert!(names.contains(&"quota_week_inline_normal"));
+        assert!(!desired.contains_key("quota_week_normal"));
+        assert!(names.len() <= MAX_METADATA_TOKENS);
+    }
+
+    #[test]
+    fn switching_into_a_five_hour_window_clears_inline_week() {
+        let snapshot = crate::model::ProviderSnapshot::new(
+            Provider::Codex,
+            vec![
+                crate::model::UsageWindow::new(
+                    crate::model::WindowKind::FiveHour,
+                    5.0,
+                    Some(crate::model::ResetAt::from_unix_seconds(14_820)),
+                )
+                .unwrap(),
+                crate::model::UsageWindow::new(
+                    crate::model::WindowKind::Weekly,
+                    1.0,
+                    Some(crate::model::ResetAt::from_unix_seconds(183_600)),
+                )
+                .unwrap(),
+            ],
+            0,
+        );
+        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        let mut tokens = desired.clone();
+        tokens.insert("quota_week_inline_normal".to_string(), "7d 99%".to_string());
+        let pane = AgentPane {
+            pane_id: "w1:p1".to_string(),
+            provider: Provider::Codex,
+            session_id: None,
+            session_summary: String::new(),
+            topic: String::new(),
+            tokens,
+        };
+        assert!(!metadata_matches(&pane.tokens, &desired));
+        let names = metadata_report_names(&pane, &desired);
+        assert!(names.contains(&"quota_week_inline_normal"));
+        assert!(names.contains(&"quota_week_normal"));
+        assert!(names.len() <= MAX_METADATA_TOKENS);
     }
 
     #[test]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -158,7 +158,7 @@ fn sidebar_window(snapshot: &ProviderSnapshot, kind: WindowKind, now_unix: u64) 
 }
 
 fn missing_five_hour_label(provider: Provider) -> Option<&'static str> {
-    // Codex matches Grok: omit the 5h token so Herdr splices 7d onto context.
+    // Codex matches Grok: omit the 5h token so week can fold onto context.
     // Claude/Agy keep a visible placeholder on their separate limits row.
     match provider {
         Provider::Claude | Provider::Agy => Some("5h N/A"),

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -150,6 +150,9 @@ fn default_herdr_rows_become_plane_provider_usage_and_topic_lines() {
     assert!(applied.contains("$quota_week_normal"));
     assert!(applied.contains("$quota_week_warning"));
     assert!(applied.contains("$quota_week_danger"));
+    assert!(applied.contains("$quota_week_inline_normal"));
+    assert!(applied.contains("$quota_week_inline_warning"));
+    assert!(applied.contains("$quota_week_inline_danger"));
     assert!(!applied.contains("[\"$quota_summary\"]"));
     assert!(applied.contains("$quota_topic"));
     assert!(applied.contains("$quota_context"));
@@ -213,7 +216,7 @@ fn context_is_the_penultimate_row_and_model_shares_provider_style() {
 }
 
 #[test]
-fn provider_model_is_compact_and_grok_merges_weekly_limit_into_context_row() {
+fn provider_model_is_compact_and_every_provider_can_fold_week_without_five_hour() {
     let applied =
         add_quota_row("[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n").unwrap();
     let document = applied.parse::<toml_edit::DocumentMut>().unwrap();
@@ -231,7 +234,7 @@ fn provider_model_is_compact_and_grok_merges_weekly_limit_into_context_row() {
         )
     }));
 
-    for provider in ["grok", "codex"] {
+    for provider in ["claude", "codex", "grok", "agy"] {
         let provider_rows = agents["rows_by_agent"][provider].as_array().unwrap();
         let context_row = provider_rows
             .iter()
@@ -242,22 +245,24 @@ fn provider_model_is_compact_and_grok_merges_weekly_limit_into_context_row() {
         assert!(
             context_row
                 .iter()
-                .any(|item| configured_token(item) == Some("$quota_week_normal")),
-            "{provider} should splice 7d onto the context row"
+                .any(|item| configured_token(item) == Some("$quota_week_inline_normal")),
+            "{provider} should be able to fold 7d onto context when 5h is empty"
         );
         assert!(
-            !provider_rows.iter().any(|row| {
+            context_row
+                .iter()
+                .all(|item| configured_token(item) != Some("$quota_5h_normal")),
+            "{provider} must not put 5h on the context row"
+        );
+        assert!(
+            provider_rows.iter().any(|row| {
                 row_contains_token(row, "$quota_week_normal")
+                    && row_contains_token(row, "$quota_5h_normal")
                     && !row_contains_token(row, "$quota_context")
             }),
-            "{provider} should not keep a separate weekly-only limits row"
+            "{provider} should keep 5h/7d on a dedicated limits row"
         );
     }
-
-    let claude_rows = agents["rows_by_agent"]["claude"].as_array().unwrap();
-    assert!(claude_rows.iter().any(|row| {
-        row_contains_token(row, "$quota_week_normal") && !row_contains_token(row, "$quota_context")
-    }));
 }
 
 #[test]


### PR DESCRIPTION
## What this changes

Sidebar cards now decide from the **5h token**, not the provider name, whether weekly quota sits beside context.

- When 5h is present: `context` stays on its own row, `5h · 7d` on the limits row.
- When 5h is empty: week is published as `$quota_week_inline_*` so the card still reads `context · 7d`.

Codex can split when OpenAI returns 5h and fold after a reset. Grok stays compact. Claude and Agy keep a dedicated limits row (including `5h N/A`).

Verified locally after `cargo build --release`, plugin disable/enable, and configure: Codex panes with `5h 95%` publish week on the limits tokens, Grok publishes `quota_week_inline_*` only.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features --locked`
- [x] A parser change comes with a fixture in `tests/fixtures/` and a test
- [x] No new network call, background process, or credential write

## Provider impact

All four (Claude Code, Codex, Grok, Agy). Layout is shared; token routing is based on whether `$quota_5h` is empty. Local check against a live Codex pane with a five-hour window and Grok weekly-only panes.