### PR TITLE
Fix Claude/Agy quota rows clobbering each other across accounts

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -181,6 +181,16 @@ impl CacheStore {
                     .entry(session_id.clone())
                     .or_insert_with(|| context.clone());
             }
+            // Preserve every other session's last known quota windows. Each
+            // statusLine tick only reports the account signed in to the pane
+            // that fired it, so a concurrent second account's windows would
+            // otherwise be dropped the moment any other pane reports in.
+            for (session_id, windows) in &previous_snapshot.session_windows {
+                snapshot
+                    .session_windows
+                    .entry(session_id.clone())
+                    .or_insert_with(|| windows.clone());
+            }
         }
         if let Some(session_id) = session_id {
             if let Some(context) = snapshot.context.clone() {
@@ -188,6 +198,9 @@ impl CacheStore {
                     .session_contexts
                     .insert(session_id.to_string(), context);
             }
+            snapshot
+                .session_windows
+                .insert(session_id.to_string(), snapshot.windows.clone());
         }
         let current_session_ids = session_id
             .map(|session_id| vec![session_id.to_string()])
@@ -546,6 +559,22 @@ fn prune_session_diagnostics(snapshot: &mut ProviderSnapshot, current_session_id
             break;
         };
         snapshot.session_contexts.remove(&session_id);
+    }
+    while snapshot.session_windows.len() > MAX_STATUSLINE_SESSIONS {
+        let Some(session_id) = snapshot
+            .session_windows
+            .keys()
+            .find(|session_id| {
+                !current_session_ids
+                    .iter()
+                    .any(|current| current == *session_id)
+            })
+            .cloned()
+            .or_else(|| snapshot.session_windows.keys().next().cloned())
+        else {
+            break;
+        };
+        snapshot.session_windows.remove(&session_id);
     }
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -355,6 +355,15 @@ pub struct ProviderSnapshot {
     /// pane's local rollout usage.
     #[serde(default)]
     pub session_contexts: BTreeMap<String, ContextUsage>,
+    /// Quota windows (5h/7d) keyed by the provider's session id. StatusLine
+    /// providers (Claude, Agy) can run more than one signed-in account
+    /// concurrently on the same machine (for example a work and a personal
+    /// login in separate config directories); the top-level `windows` field
+    /// only ever holds whichever account reported most recently, so a pane
+    /// with a known session id must read its own account's windows here
+    /// instead of falling back to that shared, potentially wrong value.
+    #[serde(default)]
+    pub session_windows: BTreeMap<String, Vec<UsageWindow>>,
     /// Login identity the snapshot was fetched for (Grok `user_id`, Codex
     /// `tokens.account_id`). Used to drop another account's cached quota after
     /// `grok login` / Codex account switch. Absent on snapshots written before
@@ -375,6 +384,7 @@ impl ProviderSnapshot {
             session_summaries: BTreeMap::new(),
             session_models: BTreeMap::new(),
             session_contexts: BTreeMap::new(),
+            session_windows: BTreeMap::new(),
             account_id: None,
         }
     }
@@ -413,6 +423,23 @@ impl ProviderSnapshot {
             return Some(context);
         }
         None
+    }
+
+    /// Return the quota windows for a pane's session. A known session never
+    /// falls back to provider-level data: the top-level `windows` field is
+    /// shared across every concurrently signed-in account for this provider,
+    /// so an unrecognized session must render as unavailable rather than
+    /// borrow another account's numbers. The global value is used only when
+    /// the caller has no session id at all (Herdr could not identify the
+    /// pane).
+    pub fn windows_for_session(&self, session_id: Option<&str>) -> &[UsageWindow] {
+        let Some(session_id) = session_id else {
+            return &self.windows;
+        };
+        match self.session_windows.get(session_id) {
+            Some(windows) => windows,
+            None => &[],
+        }
     }
 
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
@@ -482,11 +509,23 @@ impl ProviderSnapshot {
     }
 
     pub fn severity(&self, now_unix: u64) -> Severity {
-        let relevant = match self.provider {
-            Provider::Grok => self.window(WindowKind::Weekly),
-            Provider::Codex | Provider::Claude | Provider::Agy => self
-                .window(WindowKind::FiveHour)
-                .or_else(|| self.window(WindowKind::Weekly)),
+        Self::severity_for_windows(self.provider, &self.windows, now_unix)
+    }
+
+    /// Same runway-health calculation as [`Self::severity`], but over an
+    /// explicit window slice so a pane can be scored against its own
+    /// session/account windows instead of the provider-wide top-level ones.
+    pub fn severity_for_windows(
+        provider: Provider,
+        windows: &[UsageWindow],
+        now_unix: u64,
+    ) -> Severity {
+        let find = |kind: WindowKind| windows.iter().find(|window| window.kind == kind);
+        let relevant = match provider {
+            Provider::Grok => find(WindowKind::Weekly),
+            Provider::Codex | Provider::Claude | Provider::Agy => {
+                find(WindowKind::FiveHour).or_else(|| find(WindowKind::Weekly))
+            }
         };
         relevant
             .map(|window| Severity::for_window(window, now_unix))

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -36,6 +36,7 @@ impl MetadataTokens {
             now_unix,
             snapshot.model_for_session(session_id),
             snapshot.context_for_session(session_id),
+            snapshot.windows_for_session(session_id),
         )
     }
 
@@ -43,6 +44,11 @@ impl MetadataTokens {
     /// when Herdr cannot identify that pane's session. A provider-level model
     /// is still useful for the identity row, but context/cache values are
     /// session data and must stay blank until their session id is known.
+    ///
+    /// Quota windows are also resolved per session rather than from the
+    /// shared top-level snapshot: StatusLine providers (Claude, Agy) can have
+    /// more than one signed-in account reporting concurrently, and the
+    /// top-level windows only ever hold whichever account reported last.
     pub fn from_snapshot_for_pane(
         snapshot: &ProviderSnapshot,
         now_unix: u64,
@@ -54,7 +60,8 @@ impl MetadataTokens {
         };
         let context =
             session_id.and_then(|session_id| snapshot.context_for_session(Some(session_id)));
-        Self::from_snapshot_parts(snapshot, now_unix, quota_model, context)
+        let windows = snapshot.windows_for_session(session_id);
+        Self::from_snapshot_parts(snapshot, now_unix, quota_model, context, windows)
     }
 
     fn from_snapshot_parts(
@@ -62,23 +69,25 @@ impl MetadataTokens {
         now_unix: u64,
         model: Option<&str>,
         context: Option<&crate::model::ContextUsage>,
+        windows: &[UsageWindow],
     ) -> Self {
         let quota_provider = snapshot.provider.display_name().to_string();
         let quota_model = model.unwrap_or_default().to_string();
-        let quota_5h = sidebar_window(snapshot, WindowKind::FiveHour, now_unix);
+        let quota_5h = sidebar_window(windows, snapshot.provider, WindowKind::FiveHour, now_unix);
+        let severity = ProviderSnapshot::severity_for_windows(snapshot.provider, windows, now_unix);
         Self {
-            quota_state: snapshot.severity(now_unix).symbol().to_string(),
+            quota_state: severity.symbol().to_string(),
             quota_icon: snapshot.provider.icon().to_string(),
             quota_provider_model: provider_model_label(&quota_provider, &quota_model),
             quota_provider,
             quota_model,
-            quota_status: snapshot.severity(now_unix).label().to_string(),
-            quota_5h_severity: window_severity(snapshot, WindowKind::FiveHour, now_unix)
+            quota_status: severity.label().to_string(),
+            quota_5h_severity: window_severity(windows, WindowKind::FiveHour, now_unix)
                 .or_else(|| missing_five_hour_severity(snapshot.provider, &quota_5h)),
             quota_5h,
-            quota_week: sidebar_window(snapshot, WindowKind::Weekly, now_unix),
-            quota_week_severity: window_severity(snapshot, WindowKind::Weekly, now_unix),
-            quota_summary: sidebar_summary(snapshot, now_unix),
+            quota_week: sidebar_window(windows, snapshot.provider, WindowKind::Weekly, now_unix),
+            quota_week_severity: window_severity(windows, WindowKind::Weekly, now_unix),
+            quota_summary: summary_from_windows(windows, now_unix, false),
             quota_context: sidebar_context(context),
             quota_cache: sidebar_cache(context),
             quota_cache_ttl: sidebar_cache_ttl(context, now_unix),
@@ -118,39 +127,42 @@ fn provider_model_label(provider: &str, model: &str) -> String {
     }
 }
 
-fn window_severity(
-    snapshot: &ProviderSnapshot,
-    kind: WindowKind,
-    now_unix: u64,
-) -> Option<Severity> {
-    snapshot
-        .window(kind)
-        .map(|window| Severity::for_window(window, now_unix))
+fn window_severity(windows: &[UsageWindow], kind: WindowKind, now_unix: u64) -> Option<Severity> {
+    find_window(windows, kind).map(|window| Severity::for_window(window, now_unix))
+}
+
+fn find_window(windows: &[UsageWindow], kind: WindowKind) -> Option<&UsageWindow> {
+    windows.iter().find(|window| window.kind == kind)
 }
 
 pub fn sidebar_summary(snapshot: &ProviderSnapshot, now_unix: u64) -> String {
-    summary(snapshot, now_unix, false)
+    summary_from_windows(&snapshot.windows, now_unix, false)
 }
 
 pub fn dashboard_summary(snapshot: &ProviderSnapshot, now_unix: u64) -> String {
-    summary(snapshot, now_unix, true)
+    summary_from_windows(&snapshot.windows, now_unix, true)
 }
 
-fn summary(snapshot: &ProviderSnapshot, now_unix: u64, include_left: bool) -> String {
+fn summary_from_windows(windows: &[UsageWindow], now_unix: u64, include_left: bool) -> String {
     [WindowKind::FiveHour, WindowKind::Weekly]
         .into_iter()
-        .filter_map(|kind| snapshot.window(kind))
+        .filter_map(|kind| find_window(windows, kind))
         .map(|window| format_window(window, now_unix, include_left))
         .collect::<Vec<_>>()
         .join(" · ")
 }
 
-fn sidebar_window(snapshot: &ProviderSnapshot, kind: WindowKind, now_unix: u64) -> String {
-    if let Some(window) = snapshot.window(kind) {
+fn sidebar_window(
+    windows: &[UsageWindow],
+    provider: Provider,
+    kind: WindowKind,
+    now_unix: u64,
+) -> String {
+    if let Some(window) = find_window(windows, kind) {
         return format_compact_window(window, now_unix);
     }
     if kind == WindowKind::FiveHour {
-        return missing_five_hour_label(snapshot.provider)
+        return missing_five_hour_label(provider)
             .unwrap_or_default()
             .to_string();
     }

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -493,6 +493,60 @@ fn statusline_without_context_keeps_the_last_context_snapshot() {
 }
 
 #[test]
+fn concurrent_claude_accounts_keep_their_own_quota_windows() {
+    // Two Claude panes signed in to different accounts (for example a work
+    // and a personal login in separate CLAUDE_CONFIG_DIR checkouts) each send
+    // their own statusLine ticks. Before session-scoped windows, the second
+    // account's tick clobbered a single provider-wide snapshot, so both panes
+    // showed whichever account reported most recently.
+    let state = tempdir().unwrap();
+    let (herdr_stub, herdr_log) = install_herdr_stub(
+        state.path(),
+        r#"{"result":{"agents":[
+            {"agent":"claude","pane_id":"w1:p1","agent_session":{"value":"work-session"}},
+            {"agent":"claude","pane_id":"w2:p1","agent_session":{"value":"personal-session"}}
+        ]}}"#,
+    );
+    run_claude_collector(
+        state.path(),
+        &herdr_stub,
+        br#"{
+            "session_id": "work-session",
+            "rate_limits": {
+                "five_hour": {"used_percentage": 18.0},
+                "seven_day": {"used_percentage": 10.0}
+            }
+        }"#,
+    );
+    run_claude_collector(
+        state.path(),
+        &herdr_stub,
+        br#"{
+            "session_id": "personal-session",
+            "rate_limits": {
+                "five_hour": {"used_percentage": 82.0},
+                "seven_day": {"used_percentage": 90.0}
+            }
+        }"#,
+    );
+
+    run_claude_refresh(state.path(), &herdr_stub);
+    let report = fs::read_to_string(herdr_log).unwrap();
+    let work_report = report
+        .lines()
+        .find(|line| line.contains("w1:p1"))
+        .expect("work pane reported");
+    let personal_report = report
+        .lines()
+        .find(|line| line.contains("w2:p1"))
+        .expect("personal pane reported");
+    assert!(work_report.contains("quota_5h=5h 82%"));
+    assert!(work_report.contains("quota_week=7d 90%"));
+    assert!(personal_report.contains("quota_5h=5h 18%"));
+    assert!(personal_report.contains("quota_week=7d 10%"));
+}
+
+#[test]
 fn quota_refresh_does_not_report_metadata_to_a_scrolled_pane() {
     let state = tempdir().unwrap();
     let log = state.path().join("herdr.log");


### PR DESCRIPTION
I run a work and a personal Claude Code login side by side (separate CLAUDE_CONFIG_DIR checkouts on the same machine), and every pane in Herdr's sidebar showed the same 5h/7d numbers regardless of which account it actually belonged to.

The top-level `windows` field on a Claude/Agy `ProviderSnapshot` only ever holds whichever account's statusLine hook reported most recently. There's no per-session storage for the rate-limit windows themselves, even though context and model already get that treatment via `session_contexts` and `session_models`.

This adds a `session_windows` map alongside those two and reads from it the same way `context_for_session`/`model_for_session` already do: a pane with a known session id gets its own account's windows, or renders as unavailable if that session hasn't reported yet, instead of borrowing whatever the last tick happened to write.

Added a test with two concurrent panes on different sessions and different rate limits to pin the regression down. Full suite, clippy, and fmt all clean.