### PR TITLE
Fix Claude/Agy quota rows clobbering each other across accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Rebuilding the plugin no longer leaves a stale active-turn watcher that
   keeps publishing the old weekly token. That leftover `$quota_week_normal`
   stacked on `$quota_week_inline_*` and made Grok show `7d` twice.
+- Claude/Agy quota windows are remembered per statusLine session so a work
+  and a personal login no longer overwrite each other's 5h/7d rows. Grok and
+  Codex still publish the account-level windows to every pane of that login;
+  a Claude session that has not reported yet shows unavailable instead of
+  borrowing another account's numbers. Based on work by @joshfinnie in #30.
 
 ### Changed
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,8 +1,9 @@
-use crate::model::{ContextUsage, Provider, ProviderSnapshot};
+use crate::model::{merge_omitted_window_list, ContextUsage, Provider, ProviderSnapshot};
 use anyhow::{Context, Result};
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions, TryLockError};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -181,16 +182,6 @@ impl CacheStore {
                     .entry(session_id.clone())
                     .or_insert_with(|| context.clone());
             }
-            // Preserve every other session's last known quota windows. Each
-            // statusLine tick only reports the account signed in to the pane
-            // that fired it, so a concurrent second account's windows would
-            // otherwise be dropped the moment any other pane reports in.
-            for (session_id, windows) in &previous_snapshot.session_windows {
-                snapshot
-                    .session_windows
-                    .entry(session_id.clone())
-                    .or_insert_with(|| windows.clone());
-            }
         }
         if let Some(session_id) = session_id {
             if let Some(context) = snapshot.context.clone() {
@@ -198,10 +189,8 @@ impl CacheStore {
                     .session_contexts
                     .insert(session_id.to_string(), context);
             }
-            snapshot
-                .session_windows
-                .insert(session_id.to_string(), snapshot.windows.clone());
         }
+        merge_session_windows(&mut snapshot, previous_snapshot, session_id);
         let current_session_ids = session_id
             .map(|session_id| vec![session_id.to_string()])
             .unwrap_or_default();
@@ -262,9 +251,6 @@ impl CacheStore {
         // A malformed/temporarily unreadable old snapshot must not prevent a
         // fresh statusLine value from replacing it.
         let previous = self.load(snapshot.provider).ok().flatten();
-        if let Some(previous) = previous.as_ref() {
-            snapshot.merge_omitted_windows(previous);
-        }
         let previous_session_id = previous
             .as_ref()
             .and_then(|snapshot| snapshot.context.as_ref())
@@ -299,6 +285,7 @@ impl CacheStore {
                     .insert(session_id.to_string(), context);
             }
         }
+        merge_session_windows(&mut snapshot, previous.as_ref(), session_id);
         let current_session_ids = session_id
             .map(|session_id| vec![session_id.to_string()])
             .unwrap_or_default();
@@ -527,42 +514,57 @@ fn merge_session_models(
     }
 }
 
-fn prune_session_diagnostics(snapshot: &mut ProviderSnapshot, current_session_ids: &[String]) {
-    while snapshot.session_models.len() > MAX_STATUSLINE_SESSIONS {
-        let Some(session_id) = snapshot
-            .session_models
-            .keys()
-            .find(|session_id| {
-                !current_session_ids
-                    .iter()
-                    .any(|current| current == *session_id)
-            })
-            .cloned()
-            .or_else(|| snapshot.session_models.keys().next().cloned())
-        else {
-            break;
-        };
-        snapshot.session_models.remove(&session_id);
+fn merge_session_windows(
+    snapshot: &mut ProviderSnapshot,
+    previous: Option<&ProviderSnapshot>,
+    session_id: Option<&str>,
+) {
+    if let Some(previous) = previous {
+        for (session_id, windows) in &previous.session_windows {
+            snapshot
+                .session_windows
+                .entry(session_id.clone())
+                .or_insert_with(|| windows.clone());
+        }
+        match session_id {
+            Some(session_id) => {
+                let previous_windows = previous
+                    .session_windows
+                    .get(session_id)
+                    .map(Vec::as_slice)
+                    .or_else(|| {
+                        previous
+                            .session_windows
+                            .is_empty()
+                            .then_some(previous.windows.as_slice())
+                    });
+                if let Some(previous_windows) = previous_windows {
+                    merge_omitted_window_list(
+                        &mut snapshot.windows,
+                        previous_windows,
+                        snapshot.fetched_at_unix,
+                    );
+                }
+            }
+            None => snapshot.merge_omitted_windows(previous),
+        }
     }
-    while snapshot.session_contexts.len() > MAX_STATUSLINE_SESSIONS {
-        let Some(session_id) = snapshot
-            .session_contexts
-            .keys()
-            .find(|session_id| {
-                !current_session_ids
-                    .iter()
-                    .any(|current| current == *session_id)
-            })
-            .cloned()
-            .or_else(|| snapshot.session_contexts.keys().next().cloned())
-        else {
-            break;
-        };
-        snapshot.session_contexts.remove(&session_id);
-    }
-    while snapshot.session_windows.len() > MAX_STATUSLINE_SESSIONS {
-        let Some(session_id) = snapshot
+    if let Some(session_id) = session_id {
+        snapshot
             .session_windows
+            .insert(session_id.to_string(), snapshot.windows.clone());
+    }
+}
+
+fn prune_session_diagnostics(snapshot: &mut ProviderSnapshot, current_session_ids: &[String]) {
+    prune_session_map(&mut snapshot.session_models, current_session_ids);
+    prune_session_map(&mut snapshot.session_contexts, current_session_ids);
+    prune_session_map(&mut snapshot.session_windows, current_session_ids);
+}
+
+fn prune_session_map<T>(map: &mut BTreeMap<String, T>, current_session_ids: &[String]) {
+    while map.len() > MAX_STATUSLINE_SESSIONS {
+        let Some(session_id) = map
             .keys()
             .find(|session_id| {
                 !current_session_ids
@@ -570,11 +572,11 @@ fn prune_session_diagnostics(snapshot: &mut ProviderSnapshot, current_session_id
                     .any(|current| current == *session_id)
             })
             .cloned()
-            .or_else(|| snapshot.session_windows.keys().next().cloned())
+            .or_else(|| map.keys().next().cloned())
         else {
             break;
         };
-        snapshot.session_windows.remove(&session_id);
+        map.remove(&session_id);
     }
 }
 
@@ -731,6 +733,130 @@ mod tests {
             .snapshot;
         assert_eq!(saved.session_models["session-1"], "Sonnet");
         assert_eq!(saved.session_models["session-2"], "Opus");
+    }
+
+    #[test]
+    fn statusline_observations_keep_quota_windows_for_multiple_sessions() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![UsageWindow::new(WindowKind::Weekly, 10.0, None).unwrap()],
+                    1,
+                ),
+                &json!({"session_id": "work"}),
+            )
+            .unwrap();
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![UsageWindow::new(WindowKind::Weekly, 90.0, None).unwrap()],
+                    2,
+                ),
+                &json!({"session_id": "personal"}),
+            )
+            .unwrap();
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        assert_eq!(
+            saved.windows_for_session(Some("work"))[0].used_percent,
+            10.0
+        );
+        assert_eq!(
+            saved.windows_for_session(Some("personal"))[0].used_percent,
+            90.0
+        );
+        assert!(saved.windows_for_session(Some("unknown")).is_empty());
+    }
+
+    #[test]
+    fn statusline_omitted_five_hour_window_stays_on_the_same_session() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![
+                        UsageWindow::new(
+                            WindowKind::FiveHour,
+                            22.0,
+                            Some(ResetAt::from_unix_seconds(2_000)),
+                        )
+                        .unwrap(),
+                        UsageWindow::new(
+                            WindowKind::Weekly,
+                            65.0,
+                            Some(ResetAt::from_unix_seconds(10_000)),
+                        )
+                        .unwrap(),
+                    ],
+                    1_000,
+                ),
+                &json!({"session_id": "work"}),
+            )
+            .unwrap();
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![UsageWindow::new(
+                        WindowKind::Weekly,
+                        90.0,
+                        Some(ResetAt::from_unix_seconds(10_000)),
+                    )
+                    .unwrap()],
+                    1_100,
+                ),
+                &json!({"session_id": "personal"}),
+            )
+            .unwrap();
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![UsageWindow::new(
+                        WindowKind::Weekly,
+                        66.0,
+                        Some(ResetAt::from_unix_seconds(10_000)),
+                    )
+                    .unwrap()],
+                    1_200,
+                ),
+                &json!({"session_id": "work"}),
+            )
+            .unwrap();
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        assert_eq!(
+            saved
+                .windows_for_session(Some("work"))
+                .iter()
+                .find(|window| window.kind == WindowKind::FiveHour)
+                .unwrap()
+                .used_percent,
+            22.0
+        );
+        assert!(saved
+            .windows_for_session(Some("personal"))
+            .iter()
+            .all(|window| window.kind != WindowKind::FiveHour));
     }
 
     #[test]
@@ -994,6 +1120,7 @@ mod tests {
             .snapshot;
         assert_eq!(saved.session_models.len(), MAX_STATUSLINE_SESSIONS);
         assert_eq!(saved.session_contexts.len(), MAX_STATUSLINE_SESSIONS);
+        assert_eq!(saved.session_windows.len(), MAX_STATUSLINE_SESSIONS);
         assert!(saved
             .session_models
             .contains_key(&format!("session-{}", MAX_STATUSLINE_SESSIONS + 7)));
@@ -1049,6 +1176,15 @@ mod tests {
             22.0
         );
         assert_eq!(saved.window(WindowKind::Weekly).unwrap().used_percent, 66.0);
+        assert_eq!(
+            saved
+                .windows_for_session(Some("session-1"))
+                .iter()
+                .find(|window| window.kind == WindowKind::FiveHour)
+                .unwrap()
+                .used_percent,
+            22.0
+        );
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -181,6 +181,16 @@ impl CacheStore {
                     .entry(session_id.clone())
                     .or_insert_with(|| context.clone());
             }
+            // Preserve every other session's last known quota windows. Each
+            // statusLine tick only reports the account signed in to the pane
+            // that fired it, so a concurrent second account's windows would
+            // otherwise be dropped the moment any other pane reports in.
+            for (session_id, windows) in &previous_snapshot.session_windows {
+                snapshot
+                    .session_windows
+                    .entry(session_id.clone())
+                    .or_insert_with(|| windows.clone());
+            }
         }
         if let Some(session_id) = session_id {
             if let Some(context) = snapshot.context.clone() {
@@ -188,6 +198,9 @@ impl CacheStore {
                     .session_contexts
                     .insert(session_id.to_string(), context);
             }
+            snapshot
+                .session_windows
+                .insert(session_id.to_string(), snapshot.windows.clone());
         }
         let current_session_ids = session_id
             .map(|session_id| vec![session_id.to_string()])
@@ -546,6 +559,22 @@ fn prune_session_diagnostics(snapshot: &mut ProviderSnapshot, current_session_id
             break;
         };
         snapshot.session_contexts.remove(&session_id);
+    }
+    while snapshot.session_windows.len() > MAX_STATUSLINE_SESSIONS {
+        let Some(session_id) = snapshot
+            .session_windows
+            .keys()
+            .find(|session_id| {
+                !current_session_ids
+                    .iter()
+                    .any(|current| current == *session_id)
+            })
+            .cloned()
+            .or_else(|| snapshot.session_windows.keys().next().cloned())
+        else {
+            break;
+        };
+        snapshot.session_windows.remove(&session_id);
     }
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -355,13 +355,13 @@ pub struct ProviderSnapshot {
     /// pane's local rollout usage.
     #[serde(default)]
     pub session_contexts: BTreeMap<String, ContextUsage>,
-    /// Quota windows (5h/7d) keyed by the provider's session id. StatusLine
-    /// providers (Claude, Agy) can run more than one signed-in account
-    /// concurrently on the same machine (for example a work and a personal
-    /// login in separate config directories); the top-level `windows` field
-    /// only ever holds whichever account reported most recently, so a pane
-    /// with a known session id must read its own account's windows here
-    /// instead of falling back to that shared, potentially wrong value.
+    /// Account quota windows keyed by the provider's session id.
+    ///
+    /// Quota itself is account-level for every provider. Grok and Codex fetch
+    /// one login's windows and leave this map empty. StatusLine providers
+    /// (Claude, Agy) can run two signed-in accounts into one cache file, and
+    /// the top-level `windows` field only holds whichever account ticked last;
+    /// those ticks are stored here so a pane can read its own account.
     #[serde(default)]
     pub session_windows: BTreeMap<String, Vec<UsageWindow>>,
     /// Login identity the snapshot was fetched for (Grok `user_id`, Codex
@@ -425,21 +425,26 @@ impl ProviderSnapshot {
         None
     }
 
-    /// Return the quota windows for a pane's session. A known session never
-    /// falls back to provider-level data: the top-level `windows` field is
-    /// shared across every concurrently signed-in account for this provider,
-    /// so an unrecognized session must render as unavailable rather than
-    /// borrow another account's numbers. The global value is used only when
-    /// the caller has no session id at all (Herdr could not identify the
-    /// pane).
+    /// Return the quota windows for a pane's session.
+    ///
+    /// Context and model are session-local, so a known session never falls
+    /// back to the provider-level value. Quota is account-level: Grok and
+    /// Codex share one login's windows across every pane, and this map stays
+    /// empty for them. StatusLine providers fill the map; a known session
+    /// missing from a non-empty map must not borrow another account's
+    /// numbers. The top-level `windows` field is used when Herdr has no
+    /// session id, or when no session has reported windows yet (legacy cache).
     pub fn windows_for_session(&self, session_id: Option<&str>) -> &[UsageWindow] {
         let Some(session_id) = session_id else {
             return &self.windows;
         };
-        match self.session_windows.get(session_id) {
-            Some(windows) => windows,
-            None => &[],
+        if let Some(windows) = self.session_windows.get(session_id) {
+            return windows;
         }
+        if self.session_windows.is_empty() {
+            return &self.windows;
+        }
+        &[]
     }
 
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
@@ -470,7 +475,7 @@ impl ProviderSnapshot {
     }
 
     pub fn window(&self, kind: WindowKind) -> Option<&UsageWindow> {
-        self.windows.iter().find(|window| window.kind == kind)
+        window_in(&self.windows, kind)
     }
 
     /// Keep a previously observed quota window when the latest payload omits
@@ -482,30 +487,10 @@ impl ProviderSnapshot {
     /// snapshots has not itself reset. An empty `windows` list still means
     /// "rate limits were absent — clear stale quota".
     pub fn merge_omitted_windows(&mut self, previous: &Self) {
-        if self.windows.is_empty() {
-            return;
-        }
         if !same_quota_account(self, previous) {
             return;
         }
-        if sibling_quota_reset(self, previous) {
-            return;
-        }
-        for kind in [WindowKind::FiveHour, WindowKind::Weekly] {
-            if self.window(kind).is_some() {
-                continue;
-            }
-            let Some(previous_window) = previous.window(kind).cloned() else {
-                continue;
-            };
-            let Some(reset) = previous_window.resets_at else {
-                continue;
-            };
-            if reset.unix_seconds() <= self.fetched_at_unix {
-                continue;
-            }
-            self.windows.push(previous_window);
-        }
+        merge_omitted_window_list(&mut self.windows, &previous.windows, self.fetched_at_unix);
     }
 
     pub fn severity(&self, now_unix: u64) -> Severity {
@@ -520,16 +505,51 @@ impl ProviderSnapshot {
         windows: &[UsageWindow],
         now_unix: u64,
     ) -> Severity {
-        let find = |kind: WindowKind| windows.iter().find(|window| window.kind == kind);
         let relevant = match provider {
-            Provider::Grok => find(WindowKind::Weekly),
+            Provider::Grok => window_in(windows, WindowKind::Weekly),
             Provider::Codex | Provider::Claude | Provider::Agy => {
-                find(WindowKind::FiveHour).or_else(|| find(WindowKind::Weekly))
+                window_in(windows, WindowKind::FiveHour)
+                    .or_else(|| window_in(windows, WindowKind::Weekly))
             }
         };
         relevant
             .map(|window| Severity::for_window(window, now_unix))
             .unwrap_or(Severity::Unknown)
+    }
+}
+
+pub(crate) fn window_in(windows: &[UsageWindow], kind: WindowKind) -> Option<&UsageWindow> {
+    windows.iter().find(|window| window.kind == kind)
+}
+
+/// Restore an omitted 5h/weekly window from a previous observation of the
+/// *same* account or session. Callers that key windows by session must pass
+/// that session's previous list, not another account's top-level snapshot.
+pub(crate) fn merge_omitted_window_list(
+    windows: &mut Vec<UsageWindow>,
+    previous: &[UsageWindow],
+    fetched_at_unix: u64,
+) {
+    if windows.is_empty() {
+        return;
+    }
+    if sibling_quota_reset_in(windows, previous) {
+        return;
+    }
+    for kind in [WindowKind::FiveHour, WindowKind::Weekly] {
+        if window_in(windows, kind).is_some() {
+            continue;
+        }
+        let Some(previous_window) = window_in(previous, kind).cloned() else {
+            continue;
+        };
+        let Some(reset) = previous_window.resets_at else {
+            continue;
+        };
+        if reset.unix_seconds() <= fetched_at_unix {
+            continue;
+        }
+        windows.push(previous_window);
     }
 }
 
@@ -543,13 +563,13 @@ fn same_quota_account(current: &ProviderSnapshot, previous: &ProviderSnapshot) -
     }
 }
 
-fn sibling_quota_reset(current: &ProviderSnapshot, previous: &ProviderSnapshot) -> bool {
+fn sibling_quota_reset_in(current: &[UsageWindow], previous: &[UsageWindow]) -> bool {
     const USED_PERCENT_RESET_DROP: f64 = 5.0;
     [WindowKind::FiveHour, WindowKind::Weekly]
         .into_iter()
         .any(|kind| {
             let (Some(current_window), Some(previous_window)) =
-                (current.window(kind), previous.window(kind))
+                (window_in(current, kind), window_in(previous, kind))
             else {
                 return false;
             };
@@ -906,5 +926,72 @@ mod tests {
         );
         current.merge_omitted_windows(&previous);
         assert!(current.window(WindowKind::FiveHour).is_none());
+    }
+
+    #[test]
+    fn account_level_windows_are_shared_when_no_session_has_reported() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Grok,
+            vec![quota_window(WindowKind::Weekly, 31.0, 10_000)],
+            1,
+        );
+        assert_eq!(
+            snapshot
+                .windows_for_session(Some("session-1"))
+                .first()
+                .map(|window| window.used_percent),
+            Some(31.0)
+        );
+        assert_eq!(
+            snapshot
+                .windows_for_session(None)
+                .first()
+                .unwrap()
+                .used_percent,
+            31.0
+        );
+    }
+
+    #[test]
+    fn statusline_windows_do_not_leak_across_sessions() {
+        let mut snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![quota_window(WindowKind::Weekly, 90.0, 10_000)],
+            1,
+        );
+        snapshot.session_windows.insert(
+            "work".to_string(),
+            vec![quota_window(WindowKind::Weekly, 10.0, 10_000)],
+        );
+        snapshot.session_windows.insert(
+            "personal".to_string(),
+            vec![quota_window(WindowKind::Weekly, 90.0, 10_000)],
+        );
+
+        assert_eq!(
+            snapshot
+                .windows_for_session(Some("work"))
+                .first()
+                .unwrap()
+                .used_percent,
+            10.0
+        );
+        assert_eq!(
+            snapshot
+                .windows_for_session(Some("personal"))
+                .first()
+                .unwrap()
+                .used_percent,
+            90.0
+        );
+        assert!(snapshot.windows_for_session(Some("unknown")).is_empty());
+        assert_eq!(
+            snapshot
+                .windows_for_session(None)
+                .first()
+                .unwrap()
+                .used_percent,
+            90.0
+        );
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -355,6 +355,15 @@ pub struct ProviderSnapshot {
     /// pane's local rollout usage.
     #[serde(default)]
     pub session_contexts: BTreeMap<String, ContextUsage>,
+    /// Quota windows (5h/7d) keyed by the provider's session id. StatusLine
+    /// providers (Claude, Agy) can run more than one signed-in account
+    /// concurrently on the same machine (for example a work and a personal
+    /// login in separate config directories); the top-level `windows` field
+    /// only ever holds whichever account reported most recently, so a pane
+    /// with a known session id must read its own account's windows here
+    /// instead of falling back to that shared, potentially wrong value.
+    #[serde(default)]
+    pub session_windows: BTreeMap<String, Vec<UsageWindow>>,
     /// Login identity the snapshot was fetched for (Grok `user_id`, Codex
     /// `tokens.account_id`). Used to drop another account's cached quota after
     /// `grok login` / Codex account switch. Absent on snapshots written before
@@ -375,6 +384,7 @@ impl ProviderSnapshot {
             session_summaries: BTreeMap::new(),
             session_models: BTreeMap::new(),
             session_contexts: BTreeMap::new(),
+            session_windows: BTreeMap::new(),
             account_id: None,
         }
     }
@@ -413,6 +423,23 @@ impl ProviderSnapshot {
             return Some(context);
         }
         None
+    }
+
+    /// Return the quota windows for a pane's session. A known session never
+    /// falls back to provider-level data: the top-level `windows` field is
+    /// shared across every concurrently signed-in account for this provider,
+    /// so an unrecognized session must render as unavailable rather than
+    /// borrow another account's numbers. The global value is used only when
+    /// the caller has no session id at all (Herdr could not identify the
+    /// pane).
+    pub fn windows_for_session(&self, session_id: Option<&str>) -> &[UsageWindow] {
+        let Some(session_id) = session_id else {
+            return &self.windows;
+        };
+        match self.session_windows.get(session_id) {
+            Some(windows) => windows,
+            None => &[],
+        }
     }
 
     pub fn with_account_id(mut self, account_id: Option<String>) -> Self {
@@ -482,11 +509,23 @@ impl ProviderSnapshot {
     }
 
     pub fn severity(&self, now_unix: u64) -> Severity {
-        let relevant = match self.provider {
-            Provider::Grok => self.window(WindowKind::Weekly),
-            Provider::Codex | Provider::Claude | Provider::Agy => self
-                .window(WindowKind::FiveHour)
-                .or_else(|| self.window(WindowKind::Weekly)),
+        Self::severity_for_windows(self.provider, &self.windows, now_unix)
+    }
+
+    /// Same runway-health calculation as [`Self::severity`], but over an
+    /// explicit window slice so a pane can be scored against its own
+    /// session/account windows instead of the provider-wide top-level ones.
+    pub fn severity_for_windows(
+        provider: Provider,
+        windows: &[UsageWindow],
+        now_unix: u64,
+    ) -> Severity {
+        let find = |kind: WindowKind| windows.iter().find(|window| window.kind == kind);
+        let relevant = match provider {
+            Provider::Grok => find(WindowKind::Weekly),
+            Provider::Codex | Provider::Claude | Provider::Agy => {
+                find(WindowKind::FiveHour).or_else(|| find(WindowKind::Weekly))
+            }
         };
         relevant
             .map(|window| Severity::for_window(window, now_unix))

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1,5 +1,6 @@
 use crate::model::{
-    format_percent, Provider, ProviderSnapshot, ResetAt, Severity, UsageWindow, WindowKind,
+    format_percent, window_in, Provider, ProviderSnapshot, ResetAt, Severity, UsageWindow,
+    WindowKind,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -45,10 +46,9 @@ impl MetadataTokens {
     /// is still useful for the identity row, but context/cache values are
     /// session data and must stay blank until their session id is known.
     ///
-    /// Quota windows are also resolved per session rather than from the
-    /// shared top-level snapshot: StatusLine providers (Claude, Agy) can have
-    /// more than one signed-in account reporting concurrently, and the
-    /// top-level windows only ever hold whichever account reported last.
+    /// Quota windows follow the same session lookup as model/context, except
+    /// they fall back to the account-level snapshot when no session has
+    /// reported windows (Grok/Codex, or a legacy StatusLine cache).
     pub fn from_snapshot_for_pane(
         snapshot: &ProviderSnapshot,
         now_unix: u64,
@@ -128,11 +128,7 @@ fn provider_model_label(provider: &str, model: &str) -> String {
 }
 
 fn window_severity(windows: &[UsageWindow], kind: WindowKind, now_unix: u64) -> Option<Severity> {
-    find_window(windows, kind).map(|window| Severity::for_window(window, now_unix))
-}
-
-fn find_window(windows: &[UsageWindow], kind: WindowKind) -> Option<&UsageWindow> {
-    windows.iter().find(|window| window.kind == kind)
+    window_in(windows, kind).map(|window| Severity::for_window(window, now_unix))
 }
 
 pub fn sidebar_summary(snapshot: &ProviderSnapshot, now_unix: u64) -> String {
@@ -146,7 +142,7 @@ pub fn dashboard_summary(snapshot: &ProviderSnapshot, now_unix: u64) -> String {
 fn summary_from_windows(windows: &[UsageWindow], now_unix: u64, include_left: bool) -> String {
     [WindowKind::FiveHour, WindowKind::Weekly]
         .into_iter()
-        .filter_map(|kind| find_window(windows, kind))
+        .filter_map(|kind| window_in(windows, kind))
         .map(|window| format_window(window, now_unix, include_left))
         .collect::<Vec<_>>()
         .join(" · ")
@@ -158,7 +154,7 @@ fn sidebar_window(
     kind: WindowKind,
     now_unix: u64,
 ) -> String {
-    if let Some(window) = find_window(windows, kind) {
+    if let Some(window) = window_in(windows, kind) {
         return format_compact_window(window, now_unix);
     }
     if kind == WindowKind::FiveHour {
@@ -545,6 +541,65 @@ mod tests {
         let values = MetadataTokens::from_snapshot(&snapshot, 0);
         assert_eq!(values.quota_5h, "");
         assert_eq!(values.quota_5h_severity, None);
+    }
+
+    #[test]
+    fn grok_and_codex_panes_keep_account_quota_when_the_session_is_known() {
+        let grok = ProviderSnapshot::new(
+            Provider::Grok,
+            vec![window(WindowKind::Weekly, 31.0, 518_400)],
+            0,
+        );
+        let grok_pane = MetadataTokens::from_snapshot_for_pane(&grok, 0, Some("session-1"));
+        assert_eq!(grok_pane.quota_week, "7d 69% 6d0h");
+        assert_eq!(grok_pane.quota_5h, "");
+
+        let codex = ProviderSnapshot::new(
+            Provider::Codex,
+            vec![
+                window(WindowKind::FiveHour, 40.0, 14_820),
+                window(WindowKind::Weekly, 31.0, 518_400),
+            ],
+            0,
+        );
+        let codex_pane = MetadataTokens::from_snapshot_for_pane(&codex, 0, Some("session-1"));
+        assert_eq!(codex_pane.quota_5h, "5h 60% 4h07m");
+        assert_eq!(codex_pane.quota_week, "7d 69% 6d0h");
+    }
+
+    #[test]
+    fn claude_pane_quota_follows_the_pane_session() {
+        let mut snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![window(WindowKind::Weekly, 90.0, 518_400)],
+            0,
+        );
+        snapshot.session_windows.insert(
+            "work".to_string(),
+            vec![
+                window(WindowKind::FiveHour, 18.0, 14_820),
+                window(WindowKind::Weekly, 10.0, 518_400),
+            ],
+        );
+        snapshot.session_windows.insert(
+            "personal".to_string(),
+            vec![
+                window(WindowKind::FiveHour, 82.0, 14_820),
+                window(WindowKind::Weekly, 90.0, 518_400),
+            ],
+        );
+
+        let work = MetadataTokens::from_snapshot_for_pane(&snapshot, 0, Some("work"));
+        assert_eq!(work.quota_5h, "5h 82% 4h07m");
+        assert_eq!(work.quota_week, "7d 90% 6d0h");
+
+        let personal = MetadataTokens::from_snapshot_for_pane(&snapshot, 0, Some("personal"));
+        assert_eq!(personal.quota_5h, "5h 18% 4h07m");
+        assert_eq!(personal.quota_week, "7d 10% 6d0h");
+
+        let unknown = MetadataTokens::from_snapshot_for_pane(&snapshot, 0, Some("other"));
+        assert_eq!(unknown.quota_5h, "5h N/A");
+        assert_eq!(unknown.quota_week, "");
     }
 
     #[test]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -36,6 +36,7 @@ impl MetadataTokens {
             now_unix,
             snapshot.model_for_session(session_id),
             snapshot.context_for_session(session_id),
+            snapshot.windows_for_session(session_id),
         )
     }
 
@@ -43,6 +44,11 @@ impl MetadataTokens {
     /// when Herdr cannot identify that pane's session. A provider-level model
     /// is still useful for the identity row, but context/cache values are
     /// session data and must stay blank until their session id is known.
+    ///
+    /// Quota windows are also resolved per session rather than from the
+    /// shared top-level snapshot: StatusLine providers (Claude, Agy) can have
+    /// more than one signed-in account reporting concurrently, and the
+    /// top-level windows only ever hold whichever account reported last.
     pub fn from_snapshot_for_pane(
         snapshot: &ProviderSnapshot,
         now_unix: u64,
@@ -54,7 +60,8 @@ impl MetadataTokens {
         };
         let context =
             session_id.and_then(|session_id| snapshot.context_for_session(Some(session_id)));
-        Self::from_snapshot_parts(snapshot, now_unix, quota_model, context)
+        let windows = snapshot.windows_for_session(session_id);
+        Self::from_snapshot_parts(snapshot, now_unix, quota_model, context, windows)
     }
 
     fn from_snapshot_parts(
@@ -62,23 +69,25 @@ impl MetadataTokens {
         now_unix: u64,
         model: Option<&str>,
         context: Option<&crate::model::ContextUsage>,
+        windows: &[UsageWindow],
     ) -> Self {
         let quota_provider = snapshot.provider.display_name().to_string();
         let quota_model = model.unwrap_or_default().to_string();
-        let quota_5h = sidebar_window(snapshot, WindowKind::FiveHour, now_unix);
+        let quota_5h = sidebar_window(windows, snapshot.provider, WindowKind::FiveHour, now_unix);
+        let severity = ProviderSnapshot::severity_for_windows(snapshot.provider, windows, now_unix);
         Self {
-            quota_state: snapshot.severity(now_unix).symbol().to_string(),
+            quota_state: severity.symbol().to_string(),
             quota_icon: snapshot.provider.icon().to_string(),
             quota_provider_model: provider_model_label(&quota_provider, &quota_model),
             quota_provider,
             quota_model,
-            quota_status: snapshot.severity(now_unix).label().to_string(),
-            quota_5h_severity: window_severity(snapshot, WindowKind::FiveHour, now_unix)
+            quota_status: severity.label().to_string(),
+            quota_5h_severity: window_severity(windows, WindowKind::FiveHour, now_unix)
                 .or_else(|| missing_five_hour_severity(snapshot.provider, &quota_5h)),
             quota_5h,
-            quota_week: sidebar_window(snapshot, WindowKind::Weekly, now_unix),
-            quota_week_severity: window_severity(snapshot, WindowKind::Weekly, now_unix),
-            quota_summary: sidebar_summary(snapshot, now_unix),
+            quota_week: sidebar_window(windows, snapshot.provider, WindowKind::Weekly, now_unix),
+            quota_week_severity: window_severity(windows, WindowKind::Weekly, now_unix),
+            quota_summary: summary_from_windows(windows, now_unix, false),
             quota_context: sidebar_context(context),
             quota_cache: sidebar_cache(context),
             quota_cache_ttl: sidebar_cache_ttl(context, now_unix),
@@ -118,39 +127,42 @@ fn provider_model_label(provider: &str, model: &str) -> String {
     }
 }
 
-fn window_severity(
-    snapshot: &ProviderSnapshot,
-    kind: WindowKind,
-    now_unix: u64,
-) -> Option<Severity> {
-    snapshot
-        .window(kind)
-        .map(|window| Severity::for_window(window, now_unix))
+fn window_severity(windows: &[UsageWindow], kind: WindowKind, now_unix: u64) -> Option<Severity> {
+    find_window(windows, kind).map(|window| Severity::for_window(window, now_unix))
+}
+
+fn find_window(windows: &[UsageWindow], kind: WindowKind) -> Option<&UsageWindow> {
+    windows.iter().find(|window| window.kind == kind)
 }
 
 pub fn sidebar_summary(snapshot: &ProviderSnapshot, now_unix: u64) -> String {
-    summary(snapshot, now_unix, false)
+    summary_from_windows(&snapshot.windows, now_unix, false)
 }
 
 pub fn dashboard_summary(snapshot: &ProviderSnapshot, now_unix: u64) -> String {
-    summary(snapshot, now_unix, true)
+    summary_from_windows(&snapshot.windows, now_unix, true)
 }
 
-fn summary(snapshot: &ProviderSnapshot, now_unix: u64, include_left: bool) -> String {
+fn summary_from_windows(windows: &[UsageWindow], now_unix: u64, include_left: bool) -> String {
     [WindowKind::FiveHour, WindowKind::Weekly]
         .into_iter()
-        .filter_map(|kind| snapshot.window(kind))
+        .filter_map(|kind| find_window(windows, kind))
         .map(|window| format_window(window, now_unix, include_left))
         .collect::<Vec<_>>()
         .join(" · ")
 }
 
-fn sidebar_window(snapshot: &ProviderSnapshot, kind: WindowKind, now_unix: u64) -> String {
-    if let Some(window) = snapshot.window(kind) {
+fn sidebar_window(
+    windows: &[UsageWindow],
+    provider: Provider,
+    kind: WindowKind,
+    now_unix: u64,
+) -> String {
+    if let Some(window) = find_window(windows, kind) {
         return format_compact_window(window, now_unix);
     }
     if kind == WindowKind::FiveHour {
-        return missing_five_hour_label(snapshot.provider)
+        return missing_five_hour_label(provider)
             .unwrap_or_default()
             .to_string();
     }

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -493,6 +493,60 @@ fn statusline_without_context_keeps_the_last_context_snapshot() {
 }
 
 #[test]
+fn concurrent_claude_accounts_keep_their_own_quota_windows() {
+    // Two Claude panes signed in to different accounts (for example a work
+    // and a personal login in separate CLAUDE_CONFIG_DIR checkouts) each send
+    // their own statusLine ticks. Before session-scoped windows, the second
+    // account's tick clobbered a single provider-wide snapshot, so both panes
+    // showed whichever account reported most recently.
+    let state = tempdir().unwrap();
+    let (herdr_stub, herdr_log) = install_herdr_stub(
+        state.path(),
+        r#"{"result":{"agents":[
+            {"agent":"claude","pane_id":"w1:p1","agent_session":{"value":"work-session"}},
+            {"agent":"claude","pane_id":"w2:p1","agent_session":{"value":"personal-session"}}
+        ]}}"#,
+    );
+    run_claude_collector(
+        state.path(),
+        &herdr_stub,
+        br#"{
+            "session_id": "work-session",
+            "rate_limits": {
+                "five_hour": {"used_percentage": 18.0},
+                "seven_day": {"used_percentage": 10.0}
+            }
+        }"#,
+    );
+    run_claude_collector(
+        state.path(),
+        &herdr_stub,
+        br#"{
+            "session_id": "personal-session",
+            "rate_limits": {
+                "five_hour": {"used_percentage": 82.0},
+                "seven_day": {"used_percentage": 90.0}
+            }
+        }"#,
+    );
+
+    run_claude_refresh(state.path(), &herdr_stub);
+    let report = fs::read_to_string(herdr_log).unwrap();
+    let work_report = report
+        .lines()
+        .find(|line| line.contains("w1:p1"))
+        .expect("work pane reported");
+    let personal_report = report
+        .lines()
+        .find(|line| line.contains("w2:p1"))
+        .expect("personal pane reported");
+    assert!(work_report.contains("quota_5h=5h 82%"));
+    assert!(work_report.contains("quota_week=7d 90%"));
+    assert!(personal_report.contains("quota_5h=5h 18%"));
+    assert!(personal_report.contains("quota_week=7d 10%"));
+}
+
+#[test]
 fn quota_refresh_does_not_report_metadata_to_a_scrolled_pane() {
     let state = tempdir().unwrap();
     let log = state.path().join("herdr.log");

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -496,9 +496,8 @@ fn statusline_without_context_keeps_the_last_context_snapshot() {
 fn concurrent_claude_accounts_keep_their_own_quota_windows() {
     // Two Claude panes signed in to different accounts (for example a work
     // and a personal login in separate CLAUDE_CONFIG_DIR checkouts) each send
-    // their own statusLine ticks. Before session-scoped windows, the second
-    // account's tick clobbered a single provider-wide snapshot, so both panes
-    // showed whichever account reported most recently.
+    // their own statusLine ticks. Sidebar percentages are remaining, not used:
+    // work 18%/10% used → 82%/90% remaining; personal 82%/90% used → 18%/10%.
     let state = tempdir().unwrap();
     let (herdr_stub, herdr_log) = install_herdr_stub(
         state.path(),
@@ -540,10 +539,16 @@ fn concurrent_claude_accounts_keep_their_own_quota_windows() {
         .lines()
         .find(|line| line.contains("w2:p1"))
         .expect("personal pane reported");
-    assert!(work_report.contains("quota_5h=5h 82%"));
-    assert!(work_report.contains("quota_week=7d 90%"));
-    assert!(personal_report.contains("quota_5h=5h 18%"));
-    assert!(personal_report.contains("quota_week=7d 10%"));
+    assert!(work_report.contains("quota_5h=5h 82%"), "{work_report}");
+    assert!(work_report.contains("quota_week=7d 90%"), "{work_report}");
+    assert!(
+        personal_report.contains("quota_5h=5h 18%"),
+        "{personal_report}"
+    );
+    assert!(
+        personal_report.contains("quota_week=7d 10%"),
+        "{personal_report}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Based on @joshfinnie's work in #30. His original commit is the first commit on this branch so the authorship stays in git history.

**What #30 got right.** Two Claude (or Agy) logins on the same machine write into one provider snapshot. The top-level `windows` field is last-write-wins, so every pane showed whichever account ticked last. Recording each statusLine tick under `session_windows[session_id]` is the right shape — it mirrors `session_contexts` / `session_models`, and statusLine does not give us a stable account id to key by.

**What this follow-up changes.** Quota is still account-level for every provider. Grok and Codex fetch one login's windows and never fill `session_windows`. #30 copied the context/model rule ("a known session never falls back"), which would blank Grok/Codex panes that have a Herdr session id. Lookup is now:

1. No session id → top-level `windows`
2. Session is in the map → that session's windows
3. Map is empty → top-level `windows` (Grok/Codex, and a legacy StatusLine cache)
4. Map is non-empty but this session is missing → empty (do not borrow another account)

An omitted 5h/7d window is restored from the **same session** only. Doing that from the top-level snapshot would leak one Claude account's short window into another.

**Merge please use a merge commit, not squash**, so @joshfinnie's commit stays attributed to him. A squash merge will still add him as `Co-authored-by` from that commit.

Supersedes #30.