### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-29
+
 ### Added
 
 - `configure --agent` installs and removes one agent at a time. Values are
@@ -274,6 +276,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - A popup dashboard pane, event-driven refresh, and a local snapshot cache that
   survives provider failures.
 
-[Unreleased]: https://github.com/levi-qiao/herdr-agent-quota/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/levi-qiao/herdr-agent-quota/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/levi-qiao/herdr-agent-quota/compare/v0.2.0...v1.0.0
 [0.2.0]: https://github.com/levi-qiao/herdr-agent-quota/releases/tag/v0.2.0
 [0.1.0]: https://github.com/levi-qiao/herdr-agent-quota/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-agent-quota"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-agent-quota"
-version = "0.2.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.95"
 description = "Credential-scoped AI quota and context in Herdr for Claude, Codex, Grok, Agy, OpenCode, and Pi"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr-agent-quota"
 name = "Herdr Agent Quota"
-version = "0.2.0"
+version = "1.0.0"
 min_herdr_version = "0.8.0"
 description = "Credential-scoped AI quota and context for Claude, Codex, Grok, Agy, OpenCode, and Pi."
 platforms = ["macos", "linux"]


### PR DESCRIPTION
Promote the current stable feature set to 1.0.0.\n\nThis release includes credential-scoped quota and exact-session diagnostics for Claude, Codex, Grok, Agy, OpenCode, and Pi; conservative PAYG and indeterminate handling; packed non-destructive sidebar rows; and the documented OpenCode Go verification caveat.\n\nRelease gates passed locally:\n- cargo fmt --all -- --check\n- cargo test --all-targets --all-features --locked (289 tests)\n- cargo clippy --release --all-targets --all-features --locked -- -D warnings\n- cargo build --release --locked