### PR TITLE
fix: drop previous Codex 5h after ChatGPT account switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Switching Codex ChatGPT accounts no longer keeps the previous login's 5h
+  row. The live `account/rateLimits/read` result is the account-level source;
+  a local rollout may fill an omitted 5h window only when that file is at
+  least as new as `auth.json` and its weekly window still matches. A cache
+  from another account, or from before the current credential file, is not
+  merged back. Weekly-only accounts now hide 5h immediately instead of after
+  the next turn.
+
+### Notes
+
+- Cache TTL is still published only from a recorded provider bucket: Claude
+  statusLine `cache_creation.ephemeral_5m/1h` and Pi/Anthropic `cacheWrite1h`.
+  Codex, Grok, Agy, OpenCode, and other Pi backends have no entry expiry in
+  their local contracts, so they keep cache hit rate and leave TTL blank
+  rather than guessing a one-hour countdown.
+
 ## [1.0.0] - 2026-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ herdr plugin action invoke herdr-agent-quota.refresh
 Quota values are percentages remaining plus reset time. Context is percentage
 used. Cache is a session hit ratio where the upstream session format supports
 one. TTL is shown only when a recorded provider bucket makes it defensible:
-Claude and Pi/Anthropic 5-minute or 1-hour cache creation. Codex and other Pi
-providers keep cache hit rate but leave TTL blank.
+Claude and Pi/Anthropic 5-minute or 1-hour cache creation. Codex, Grok, Agy,
+OpenCode, and other Pi backends have no cache-entry expiry in their local
+contracts, so they keep cache hit rate and leave TTL blank.
 
 Pi reads only the absolute JSONL path reported by Herdr under `~/.pi/agent` or
 `PI_CODING_AGENT_DIR`. It does not scan every session. API-key sessions are
@@ -150,6 +151,7 @@ The default watcher interval is 60 seconds and can be changed during install:
 | Pi model/context is old | Send one Pi turn; a model selection is confirmed after a successful assistant message. |
 | OpenCode has model/context but no quota | This is expected for Zen, PAYG, OAuth, or an unverified/missing Go key. |
 | A refresh fails | The last good same-account value is intentionally retained. |
+| Codex 5h is from a previous ChatGPT login | `codex login` rewrites `~/.codex/auth.json`; the next refresh should hide 5h when the new account has only 7d. Send one turn if the sidebar still looks stale. |
 
 ## Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,7 +78,8 @@ herdr plugin action invoke herdr-agent-quota.refresh
 
 额度显示剩余百分比和重置时间；context 显示已用百分比；cache 在上游 session 格式可支持时
 显示命中率。TTL 只在 provider/session 记录了可信 bucket 时出现：Claude 和 Pi/Anthropic
-的 5 分钟或 1 小时缓存。Codex 和其他 Pi provider 保留 cache 命中率，但不猜 TTL。
+的 5 分钟或 1 小时缓存。Codex、Grok、Agy、OpenCode 和其他 Pi backend 的本地合同没有
+cache entry 过期时间，因此只保留命中率，不猜 TTL。
 
 Pi 只读取 Herdr 报告的那个绝对 JSONL 路径，来源为 `~/.pi/agent` 或
 `PI_CODING_AGENT_DIR`，不会扫描所有 session。API key session 确认为 PAYG 并清除旧额度；
@@ -132,6 +133,7 @@ OpenCode 1.18.20 上验证；成功响应结构来自
 | Pi model/context 旧 | 发送一轮 Pi 消息；成功 assistant message 后才确认模型切换。 |
 | OpenCode 有 model/context 但无额度 | Zen、PAYG、OAuth 或缺少/未验证 Go key 时属于正常行为。 |
 | 刷新失败 | 插件会保留同一账户最后一次成功值。 |
+| Codex 的 5h 还是上一个 ChatGPT 账号的 | `codex login` 会重写 `~/.codex/auth.json`；下一次刷新应在新账号只有 7d 时立刻隐藏 5h。若侧栏仍旧，发一轮对话即可。 |
 
 ## 开发检查
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -79,11 +79,12 @@ impl CacheStore {
     /// Keep provider-local diagnostics when a successful quota refresh cannot
     /// read one of the session files for a moment. Quota windows from the
     /// latest fetch replace the cache; an omitted 5h/weekly window is restored
-    /// from the previous snapshot only when that window is still current.
-    /// Diagnostics are merged only for the same signed in account so a login
-    /// switch can never inherit another user's data.
+    /// from the previous snapshot only when that window is still current and
+    /// the signed-in account has not changed. A newer credential file drops
+    /// the previous login's windows even when neither snapshot has an
+    /// `account_id`.
     pub fn save_preserving_diagnostics(&self, mut snapshot: ProviderSnapshot) -> Result<()> {
-        self.save_preserving_diagnostics_for_sessions(&mut snapshot, &[])
+        self.save_preserving_diagnostics_for_sessions(&mut snapshot, &[], None)
     }
 
     /// Variant used by the refresh path, which knows the session ids currently
@@ -93,9 +94,11 @@ impl CacheStore {
         &self,
         snapshot: &mut ProviderSnapshot,
         session_ids: &[String],
+        credentials_mtime_unix: Option<u64>,
     ) -> Result<()> {
         if let Some(previous) = self.load(snapshot.provider).ok().flatten() {
-            let same_account = snapshot.account_id == previous.account_id;
+            let same_account =
+                previous.usable_for_account(snapshot.account_id.as_deref(), credentials_mtime_unix);
             if same_account {
                 snapshot.merge_omitted_windows(&previous);
                 if session_ids.is_empty() {
@@ -1027,7 +1030,11 @@ mod tests {
 
         let mut latest = snapshot();
         cache
-            .save_preserving_diagnostics_for_sessions(&mut latest, &["new-session".to_string()])
+            .save_preserving_diagnostics_for_sessions(
+                &mut latest,
+                &["new-session".to_string()],
+                None,
+            )
             .unwrap();
         let saved = cache.load(Provider::Grok).unwrap().unwrap();
         assert!(saved.context_for_session(Some("new-session")).is_none());
@@ -1053,6 +1060,89 @@ mod tests {
         let saved = cache.load(Provider::Grok).unwrap().unwrap();
         assert_eq!(saved.session_models.len(), MAX_STATUSLINE_SESSIONS);
         assert_eq!(saved.session_contexts.len(), MAX_STATUSLINE_SESSIONS);
+    }
+
+    fn codex_windows(five_hour: Option<f64>, weekly: f64, fetched_at: u64) -> ProviderSnapshot {
+        let mut windows = Vec::new();
+        if let Some(used) = five_hour {
+            windows.push(
+                UsageWindow::new(
+                    WindowKind::FiveHour,
+                    used,
+                    Some(ResetAt::from_unix_seconds(2_000)),
+                )
+                .unwrap(),
+            );
+        }
+        windows.push(
+            UsageWindow::new(
+                WindowKind::Weekly,
+                weekly,
+                Some(ResetAt::from_unix_seconds(10_000)),
+            )
+            .unwrap(),
+        );
+        ProviderSnapshot::new(Provider::Codex, windows, fetched_at)
+    }
+
+    #[test]
+    fn direct_provider_refresh_does_not_restore_five_hour_window_after_account_switch() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save(
+                &codex_windows(Some(80.0), 31.0, 1_000)
+                    .with_account_id(Some("account-a".to_string())),
+            )
+            .unwrap();
+
+        let mut latest =
+            codex_windows(None, 12.0, 1_100).with_account_id(Some("account-b".to_string()));
+        cache
+            .save_preserving_diagnostics_for_sessions(&mut latest, &[], None)
+            .unwrap();
+        let saved = cache.load(Provider::Codex).unwrap().unwrap();
+        assert!(saved.window(WindowKind::FiveHour).is_none());
+        assert_eq!(saved.window(WindowKind::Weekly).unwrap().used_percent, 12.0);
+    }
+
+    #[test]
+    fn unstamped_refresh_does_not_restore_five_hour_window_after_newer_credentials() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache.save(&codex_windows(Some(80.0), 31.0, 1_000)).unwrap();
+
+        let mut latest = codex_windows(None, 12.0, 1_100);
+        cache
+            .save_preserving_diagnostics_for_sessions(&mut latest, &[], Some(1_050))
+            .unwrap();
+        let saved = cache.load(Provider::Codex).unwrap().unwrap();
+        assert!(saved.window(WindowKind::FiveHour).is_none());
+        assert_eq!(saved.window(WindowKind::Weekly).unwrap().used_percent, 12.0);
+    }
+
+    #[test]
+    fn same_account_still_restores_an_omitted_five_hour_window() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save(
+                &codex_windows(Some(22.0), 65.0, 1_000)
+                    .with_account_id(Some("account-a".to_string())),
+            )
+            .unwrap();
+
+        let mut latest =
+            codex_windows(None, 66.0, 1_100).with_account_id(Some("account-a".to_string()));
+        cache
+            .save_preserving_diagnostics_for_sessions(&mut latest, &[], Some(900))
+            .unwrap();
+        let saved = cache.load(Provider::Codex).unwrap().unwrap();
+        assert_eq!(
+            saved.window(WindowKind::FiveHour).unwrap().used_percent,
+            22.0
+        );
+        assert_eq!(saved.window(WindowKind::Weekly).unwrap().used_percent, 66.0);
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -594,8 +594,9 @@ impl ProviderSnapshot {
     /// A failed refresh must keep the last good value for the *current*
     /// account, not a previous login. After an account switch:
     /// - snapshots stamped with another `account_id` are unusable;
-    /// - legacy snapshots (no stamp) are unusable when the credential file is
-    ///   newer than `fetched_at_unix`, which is what `grok login` does.
+    /// - unstamped snapshots are unusable when the credential file is newer
+    ///   than `fetched_at_unix`, including Codex `auth.json` rewrites that do
+    ///   not expose an id.
     pub fn usable_for_account(
         &self,
         current_account_id: Option<&str>,
@@ -604,10 +605,9 @@ impl ProviderSnapshot {
         match (self.account_id.as_deref(), current_account_id) {
             (Some(saved), Some(current)) => saved == current,
             (Some(_), None) => false,
-            (None, Some(_)) => {
+            (None, Some(_)) | (None, None) => {
                 credentials_mtime_unix.is_none_or(|mtime| mtime <= self.fetched_at_unix)
             }
-            (None, None) => true,
         }
     }
 
@@ -696,11 +696,12 @@ fn same_quota_account(current: &ProviderSnapshot, previous: &ProviderSnapshot) -
         previous.account_id.as_deref(),
     ) {
         (Some(current_id), Some(previous_id)) => current_id == previous_id,
-        _ => true,
+        (None, None) => true,
+        _ => false,
     }
 }
 
-fn sibling_quota_reset_in(current: &[UsageWindow], previous: &[UsageWindow]) -> bool {
+pub(crate) fn sibling_quota_reset_in(current: &[UsageWindow], previous: &[UsageWindow]) -> bool {
     const USED_PERCENT_RESET_DROP: f64 = 5.0;
     [WindowKind::FiveHour, WindowKind::Weekly]
         .into_iter()
@@ -870,6 +871,8 @@ mod tests {
         assert!(!snapshot.usable_for_account(Some("account-b"), Some(150)));
         assert!(snapshot.usable_for_account(Some("account-b"), Some(100)));
         assert!(snapshot.usable_for_account(Some("account-b"), Some(50)));
+        assert!(!snapshot.usable_for_account(None, Some(150)));
+        assert!(snapshot.usable_for_account(None, Some(50)));
     }
 
     #[test]
@@ -1081,6 +1084,51 @@ mod tests {
             current.window(WindowKind::Weekly).unwrap().used_percent,
             66.0
         );
+    }
+
+    #[test]
+    fn omitted_five_hour_window_is_not_kept_for_a_different_account() {
+        let previous = ProviderSnapshot::new(
+            Provider::Codex,
+            vec![
+                quota_window(WindowKind::FiveHour, 80.0, 2_000),
+                quota_window(WindowKind::Weekly, 31.0, 10_000),
+            ],
+            1_000,
+        )
+        .with_account_id(Some("account-a".to_string()));
+        let mut current = ProviderSnapshot::new(
+            Provider::Codex,
+            vec![quota_window(WindowKind::Weekly, 12.0, 10_000)],
+            1_100,
+        )
+        .with_account_id(Some("account-b".to_string()));
+        current.merge_omitted_windows(&previous);
+        assert!(current.window(WindowKind::FiveHour).is_none());
+        assert_eq!(
+            current.window(WindowKind::Weekly).unwrap().used_percent,
+            12.0
+        );
+    }
+
+    #[test]
+    fn omitted_five_hour_window_is_not_kept_when_only_one_snapshot_has_an_account_id() {
+        let previous = ProviderSnapshot::new(
+            Provider::Codex,
+            vec![
+                quota_window(WindowKind::FiveHour, 80.0, 2_000),
+                quota_window(WindowKind::Weekly, 31.0, 10_000),
+            ],
+            1_000,
+        )
+        .with_account_id(Some("account-a".to_string()));
+        let mut current = ProviderSnapshot::new(
+            Provider::Codex,
+            vec![quota_window(WindowKind::Weekly, 31.0, 10_000)],
+            1_100,
+        );
+        current.merge_omitted_windows(&previous);
+        assert!(current.window(WindowKind::FiveHour).is_none());
     }
 
     #[test]

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -1,7 +1,7 @@
 use crate::cache::CacheStore;
 use crate::model::{
-    CacheTotals, CacheUsage, ContextUsage, Provider, ProviderSnapshot, ResetAt, UsageWindow,
-    WindowKind,
+    sibling_quota_reset_in, CacheTotals, CacheUsage, ContextUsage, Provider, ProviderSnapshot,
+    ResetAt, UsageWindow, WindowKind,
 };
 use crate::providers::ProviderError;
 use anyhow::{Context, Result};
@@ -279,10 +279,15 @@ fn enrich_local_sessions(snapshot: &mut ProviderSnapshot, session_ids: &[String]
     let Some(home) = codex_home().ok() else {
         return;
     };
-    enrich_local_sessions_at(snapshot, &home, session_ids);
+    enrich_local_sessions_at(snapshot, &home, session_ids, auth_mtime_unix());
 }
 
-fn enrich_local_sessions_at(snapshot: &mut ProviderSnapshot, home: &Path, session_ids: &[String]) {
+fn enrich_local_sessions_at(
+    snapshot: &mut ProviderSnapshot,
+    home: &Path,
+    session_ids: &[String],
+    auth_mtime_unix: Option<u64>,
+) {
     if session_ids.is_empty() {
         return;
     }
@@ -304,7 +309,12 @@ fn enrich_local_sessions_at(snapshot: &mut ProviderSnapshot, home: &Path, sessio
             .ok()
             .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
             .map_or(0, |duration| duration.as_secs());
-        if newest_windows
+        if rollout_windows_can_fill_account_quota(
+            snapshot,
+            &observation.windows,
+            modified,
+            auth_mtime_unix,
+        ) && newest_windows
             .as_ref()
             .is_none_or(|(current, _)| modified >= *current)
         {
@@ -337,6 +347,25 @@ fn enrich_local_sessions_at(snapshot: &mut ProviderSnapshot, home: &Path, sessio
         }
         snapshot.context = Some(context);
     }
+}
+
+/// Account-level 5h/7d comes from `account/rateLimits/read`. A local rollout
+/// may fill a window the API omitted this tick, but only when that rollout
+/// still belongs to the signed-in account: written at or after the current
+/// `auth.json`, and with a weekly window that has not itself reset.
+fn rollout_windows_can_fill_account_quota(
+    snapshot: &ProviderSnapshot,
+    rollout_windows: &[UsageWindow],
+    rollout_mtime: u64,
+    auth_mtime_unix: Option<u64>,
+) -> bool {
+    if rollout_windows.is_empty() {
+        return false;
+    }
+    if auth_mtime_unix.is_some_and(|auth| rollout_mtime < auth) {
+        return false;
+    }
+    !sibling_quota_reset_in(&snapshot.windows, rollout_windows)
 }
 
 fn find_rollout_paths(home: &Path, session_ids: &[String]) -> BTreeMap<String, PathBuf> {
@@ -643,16 +672,20 @@ pub fn account_id_from_auth(path: &Path) -> Option<String> {
 
     #[derive(Deserialize)]
     struct TokenMetadata {
+        #[serde(default)]
         account_id: Option<String>,
+        #[serde(default, alias = "chatgptAccountId")]
+        chatgpt_account_id: Option<String>,
     }
 
     // Only materialize the stable account id. Token fields are ignored by the
     // streaming deserializer and never enter an owned Rust value.
     let metadata: AuthMetadata =
         serde_json::from_reader(BufReader::new(fs::File::open(path).ok()?)).ok()?;
-    metadata
-        .tokens?
+    let tokens = metadata.tokens?;
+    tokens
         .account_id
+        .or(tokens.chatgpt_account_id)
         .filter(|value| !value.is_empty())
 }
 
@@ -874,6 +907,7 @@ mod tests {
             &mut snapshot,
             directory.path(),
             &["session-1".to_string(), "other-session".to_string()],
+            None,
         );
         assert_eq!(snapshot.model.as_deref(), Some("gpt-5.6"));
         assert!(snapshot.session_contexts.contains_key("session-1"));
@@ -899,7 +933,12 @@ mod tests {
             1,
         )
         .unwrap();
-        enrich_local_sessions_at(&mut snapshot, directory.path(), &["session-1".to_string()]);
+        enrich_local_sessions_at(
+            &mut snapshot,
+            directory.path(),
+            &["session-1".to_string()],
+            None,
+        );
         assert_eq!(
             snapshot.window(WindowKind::FiveHour).unwrap().used_percent,
             12.0
@@ -930,11 +969,92 @@ mod tests {
             1,
         )
         .unwrap();
-        enrich_local_sessions_at(&mut snapshot, directory.path(), &["session-1".to_string()]);
+        enrich_local_sessions_at(
+            &mut snapshot,
+            directory.path(),
+            &["session-1".to_string()],
+            None,
+        );
         assert!(snapshot.window(WindowKind::FiveHour).is_none());
         assert_eq!(
             snapshot.window(WindowKind::Weekly).unwrap().used_percent,
             0.0
         );
+    }
+
+    #[test]
+    fn older_rollout_five_hour_window_is_not_used_after_auth_switch() {
+        let directory = tempfile::tempdir().unwrap();
+        let rollout_dir = directory.path().join("sessions/2026/08/27");
+        fs::create_dir_all(&rollout_dir).unwrap();
+        fs::write(
+            rollout_dir.join("rollout-session-1.jsonl"),
+            r#"{"type":"event_msg","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":80.0,"window_minutes":300,"resets_at":1786795200},"secondary":{"used_percent":31.0,"window_minutes":10080,"resets_at":1787400000}},"info":{"last_token_usage":{"total_tokens":25000},"model_context_window":100000}}}
+"#,
+        )
+        .unwrap();
+        let mut snapshot = parse_rate_limits(
+            &json!({"result":{"rateLimits":{
+                "primary":{"usedPercent":12.0,"windowDurationMins":10080,"resetsAt":1787400000},
+                "secondary":null
+            }}}),
+            1,
+        )
+        .unwrap();
+        enrich_local_sessions_at(
+            &mut snapshot,
+            directory.path(),
+            &["session-1".to_string()],
+            Some(u64::MAX),
+        );
+        assert!(snapshot.window(WindowKind::FiveHour).is_none());
+        assert_eq!(
+            snapshot.window(WindowKind::Weekly).unwrap().used_percent,
+            12.0
+        );
+    }
+
+    #[test]
+    fn rollout_five_hour_window_is_not_used_when_weekly_reset_disagrees() {
+        let directory = tempfile::tempdir().unwrap();
+        let rollout_dir = directory.path().join("sessions/2026/08/27");
+        fs::create_dir_all(&rollout_dir).unwrap();
+        fs::write(
+            rollout_dir.join("rollout-session-1.jsonl"),
+            r#"{"type":"event_msg","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":80.0,"window_minutes":300,"resets_at":1786795200},"secondary":{"used_percent":31.0,"window_minutes":10080,"resets_at":1787400000}},"info":{"last_token_usage":{"total_tokens":25000},"model_context_window":100000}}}
+"#,
+        )
+        .unwrap();
+        let mut snapshot = parse_rate_limits(
+            &json!({"result":{"rateLimits":{
+                "primary":{"usedPercent":12.0,"windowDurationMins":10080,"resetsAt":1787397000},
+                "secondary":null
+            }}}),
+            1,
+        )
+        .unwrap();
+        enrich_local_sessions_at(
+            &mut snapshot,
+            directory.path(),
+            &["session-1".to_string()],
+            None,
+        );
+        assert!(snapshot.window(WindowKind::FiveHour).is_none());
+        assert_eq!(
+            snapshot.window(WindowKind::Weekly).unwrap().used_percent,
+            12.0
+        );
+    }
+
+    #[test]
+    fn reads_codex_account_id_from_chatgpt_account_id_when_account_id_is_absent() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("auth.json");
+        fs::write(
+            &path,
+            r#"{"auth_mode":"chatgpt","tokens":{"chatgpt_account_id":"acc-2","access_token":"secret"}}"#,
+        )
+        .unwrap();
+        assert_eq!(account_id_from_auth(&path).as_deref(), Some("acc-2"));
     }
 }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -427,7 +427,12 @@ fn refresh_provider(
             if preserve_context {
                 cache.save_preserving_context_for_session(snapshot, session_id.as_deref())?;
             } else if matches!(provider, Provider::Codex | Provider::Grok) {
-                cache.save_preserving_diagnostics_for_sessions(&mut snapshot, &session_ids)?;
+                let (_, mtime) = current_account_gate(provider);
+                cache.save_preserving_diagnostics_for_sessions(
+                    &mut snapshot,
+                    &session_ids,
+                    mtime,
+                )?;
             } else {
                 cache.save(&snapshot)?;
             }


### PR DESCRIPTION
## What this changes

Switching Codex ChatGPT accounts no longer keeps the previous login's 5h row. A weekly-only account now hides 5h on the next refresh instead of after the next turn.

The live `account/rateLimits/read` result is the account-level source. A local rollout may still fill an omitted 5h window, but only when that file is at least as new as `auth.json` and its weekly window still matches. A cache from another account, or from before the current credential file, is not merged back.

Cache TTL is unchanged: it is still published only from a recorded provider bucket (Claude `ephemeral_5m/1h` and Pi/Anthropic `cacheWrite1h`). Codex, Grok, Agy, OpenCode, and other Pi backends have no entry expiry in their local contracts, so they keep cache hit rate and leave TTL blank.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features --locked`
- [x] A parser change comes with a fixture in `tests/fixtures/` and a test
- [x] No new network call, background process, or credential write

## Provider impact

Codex. Grok/Claude/Agy/OpenCode/Pi quota collectors are unchanged except that unstamped snapshots now also drop when the credential file is newer than the fetch.