### PR TITLE
feat: read Claude cache TTL from prompt_cache.expires_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Claude cache TTL now comes from statusLine `prompt_cache.expires_at`
+  (Claude Code v2.1.251+). Transcript-tail guesses from
+  `ephemeral_5m`/`ephemeral_1h` buckets are gone. A cold or missing prefix
+  hides the countdown instead of keeping a stale estimate. Pi/Anthropic still
+  uses its recorded `cacheWrite1h` split.
+
 ### Fixed
 
 - Switching Codex ChatGPT accounts no longer keeps the previous login's 5h
@@ -18,11 +26,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Notes
 
-- Cache TTL is still published only from a recorded provider bucket: Claude
-  statusLine `cache_creation.ephemeral_5m/1h` and Pi/Anthropic `cacheWrite1h`.
-  Codex, Grok, Agy, OpenCode, and other Pi backends have no entry expiry in
-  their local contracts, so they keep cache hit rate and leave TTL blank
-  rather than guessing a one-hour countdown.
+- Cache TTL is published only from a recorded expiry: Claude Code
+  `prompt_cache.expires_at` and Pi/Anthropic `cacheWrite1h`. Codex, Grok, Agy,
+  OpenCode, and other Pi backends have no entry expiry in their local
+  contracts, so they keep cache hit rate and leave TTL blank rather than
+  guessing a one-hour countdown.
 
 ## [1.0.0] - 2026-08-29
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ herdr plugin action invoke herdr-agent-quota.refresh
 
 | Harness | Subscription quota | Exact-session diagnostics | Attribution rule |
 | --- | --- | --- | --- |
-| Claude Code | 5h + 7d | model, context, cache, recorded 5m/1h TTL | Claude statusLine session |
+| Claude Code | 5h + 7d | model, context, cache, statusLine `prompt_cache` expiry | Claude statusLine session |
 | OpenAI Codex | 5h + 7d | model, context, cache, session summary | Canonical ChatGPT login; API keys are not subscription quota |
 | Grok CLI | 7d | model, context, cache | Canonical Grok login |
 | Agy / Antigravity | 5h + 7d | model, context, cache | Agy statusLine session and active model pool |
@@ -82,10 +82,10 @@ herdr plugin action invoke herdr-agent-quota.refresh
 
 Quota values are percentages remaining plus reset time. Context is percentage
 used. Cache is a session hit ratio where the upstream session format supports
-one. TTL is shown only when a recorded provider bucket makes it defensible:
-Claude and Pi/Anthropic 5-minute or 1-hour cache creation. Codex, Grok, Agy,
-OpenCode, and other Pi backends have no cache-entry expiry in their local
-contracts, so they keep cache hit rate and leave TTL blank.
+one. TTL is shown only when a recorded expiry is present: Claude Code
+`prompt_cache.expires_at` (v2.1.251+) and Pi/Anthropic `cacheWrite1h`. Codex,
+Grok, Agy, OpenCode, and other Pi backends have no cache-entry expiry in their
+local contracts, so they keep cache hit rate and leave TTL blank.
 
 Pi reads only the absolute JSONL path reported by Herdr under `~/.pi/agent` or
 `PI_CODING_AGENT_DIR`. It does not scan every session. API-key sessions are

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,7 +69,7 @@ herdr plugin action invoke herdr-agent-quota.refresh
 
 | Harness | 订阅额度 | 精确 session 信息 | 归属规则 |
 | --- | --- | --- | --- |
-| Claude Code | 5h + 7d | model、context、cache、已记录的 5m/1h TTL | Claude statusLine session |
+| Claude Code | 5h + 7d | model、context、cache、statusLine `prompt_cache` 过期时间 | Claude statusLine session |
 | OpenAI Codex | 5h + 7d | model、context、cache、session 摘要 | 规范 ChatGPT 登录；API key 不冒充订阅额度 |
 | Grok CLI | 7d | model、context、cache | 规范 Grok 登录 |
 | Agy / Antigravity | 5h + 7d | model、context、cache | Agy statusLine session 与当前模型池 |
@@ -77,9 +77,10 @@ herdr plugin action invoke herdr-agent-quota.refresh
 | Pi | 能安全匹配时复用现有 Codex 额度 | model、context、cache；Anthropic 已记录 TTL | 仅 account id 与规范 Codex 相同的 `openai-codex` OAuth |
 
 额度显示剩余百分比和重置时间；context 显示已用百分比；cache 在上游 session 格式可支持时
-显示命中率。TTL 只在 provider/session 记录了可信 bucket 时出现：Claude 和 Pi/Anthropic
-的 5 分钟或 1 小时缓存。Codex、Grok、Agy、OpenCode 和其他 Pi backend 的本地合同没有
-cache entry 过期时间，因此只保留命中率，不猜 TTL。
+显示命中率。TTL 只在有记录的过期时间时出现：Claude Code 的
+`prompt_cache.expires_at`（v2.1.251+）和 Pi/Anthropic 的 `cacheWrite1h`。
+Codex、Grok、Agy、OpenCode 和其他 Pi backend 的本地合同没有 cache entry 过期时间，
+因此只保留命中率，不猜 TTL。
 
 Pi 只读取 Herdr 报告的那个绝对 JSONL 路径，来源为 `~/.pi/agent` 或
 `PI_CODING_AGENT_DIR`，不会扫描所有 session。API key session 确认为 PAYG 并清除旧额度；

--- a/docs/research/oss-prompt-cache-ttl.md
+++ b/docs/research/oss-prompt-cache-ttl.md
@@ -1,0 +1,112 @@
+# 高星开源项目如何判断 prompt cache 过期时间
+
+研究日期：2026-08-30（Asia/Shanghai）  
+范围：按 GitHub 星数看用量/statusline/HUD 项目，以及各家官方 prompt-caching 合同。  
+问题：别人是怎么得到 `ttl≈58m` 这种倒计时的？有没有 Codex / Grok / Agy 可以照抄的做法？
+
+## 结论先行
+
+1. **真正做“cache 还剩几分钟”的高星项目，几乎全是 Claude 专用。** 它们用同一套本地估算：从 transcript 尾部找最近一次带 cache 活动的 assistant 时间戳，加上 5 分钟或 1 小时的滑动窗口。没有项目能从 Codex / Grok / Gemini 的本地 usage 里读出 entry 级 `expires_at`。
+2. **TTL 时长从哪来，分四档，诚实度递减：**
+   1. 官方给了绝对过期时间（Claude Code `prompt_cache.expires_at`，v2.1.251+）
+   2. 官方给了写入桶（`ephemeral_5m` / `ephemeral_1h`），本地用“最后一次命中 + 桶时长”
+   3. 用户或配置写死 5m / 1h
+   4. 按厂商文档猜一个默认值（OpenCode 插件表：Anthropic 5m、OpenAI 5m、Google 1h）
+3. **星数最高的用量工具并不显示 TTL 倒计时。** CodexBar（~20.7k）和 ccusage（~18.2k）只统计 cache 读写 token / 成本。它们的 “TTL” 是自己磁盘缓存的刷新间隔（60s、1h），不是模型 prompt cache 的剩余寿命。
+4. **对本插件：** Claude 已改为读官方 `prompt_cache.expires_at`（Claude Code v2.1.251+），不再从 transcript 桶估算。Codex / Grok / Agy 没有对等字段，高星项目也没发明一个；硬猜 1 小时会和 OpenAI「5–10 分钟、最长 1 小时、也可能更久」以及 xAI「随时驱逐」的合同打架。
+
+## 高星项目对照
+
+| 项目 | 约星数 | 做什么 | prompt cache 过期怎么判 | 证据 |
+| --- | ---: | --- | --- | --- |
+| [CodexBar](https://github.com/steipete/CodexBar) | 20.7k | 菜单栏额度 / 本地 cost | **不显示** prompt-cache 倒计时。内部 `tokenFetchTTL = 1h`、扫描 `refreshMinIntervalSeconds = 60` 是自己的数据刷新间隔 | [README](https://github.com/steipete/CodexBar/blob/main/README.md)、[#2103](https://github.com/steipete/CodexBar/issues/2103)、[#411](https://github.com/steipete/CodexBar/issues/411) |
+| [ccusage](https://github.com/ccusage/ccusage) | 18.2k | 本地 token / 成本报表 | **不显示倒计时。** 把 `cache_creation` / `cache_read` 计入成本；1h 写入应按 2× 而不是 5m 的 1.25× 计价 | [ccusage.com](https://ccusage.com/guide/)、[#899](https://github.com/ryoppippi/ccusage/issues/899) |
+| [ccstatusline](https://github.com/sirmalloc/ccstatusline) | 12.6k | Claude statusLine | transcript 尾部最近一次有 cache 活动的 assistant 时间戳 + **用户可切换的 5m/1h**（默认 5m）。文档写明 transcript **没有真正的 expiry**，倒计时是 best effort | [USAGE.md Cache Timer](https://github.com/sirmalloc/ccstatusline/blob/main/docs/USAGE.md)、[DEVELOPMENT.md](https://github.com/sirmalloc/ccstatusline/blob/main/docs/DEVELOPMENT.md) |
+| [claude-code-usage-bar](https://github.com/leeguooooo/claude-code-usage-bar) / `claude-statusbar` | 0.3k+ | Claude statusLine | 反向读 transcript ≤320 KiB；`ephemeral_1h > 0` → 3600s，`ephemeral_5m > 0` → 300s，否则回退 300s；`remaining = TTL − (now − last assistant ts)` | [docs/cache-countdown.md](https://github.com/leeguooooo/claude-code-usage-bar/blob/main/docs/cache-countdown.md) |
+| [ilia-pluzhnikov/claude-code-statusline](https://github.com/ilia-pluzhnikov/claude-code-statusline) | 低星 | Claude statusLine | 同：stdin 计数 + 约 16 KiB transcript 尾 + 桶 + timestamp。承认 stdin 没有 TTL | 本仓库既有调研 [`cache-observability-open-source.md`](cache-observability-open-source.md) |
+| OpenCode `opencode-cache-hit` / `opencode-cache-timer` | 插件级 | OpenCode 面板 | **按 provider 写死默认 TTL**：Anthropic 5m、OpenAI 5m、Google 1h、DeepSeek 2h、xAI 5m。显示的是「已经活了多久」相对这个猜测值，不是 entry expiry | [npm opencode-cache-hit](https://www.npmjs.com/package/opencode-cache-hit) |
+| [GandzyTM/claude-cache-statusline](https://github.com/GandzyTM/claude-cache-statusline) | 0 | Claude statusLine | 假定滑动 1h；用 transcript **字节增长**当 last-activity（不用 mtime） | 项目 README |
+| [duyet/codex-claude-plugins](https://github.com/duyet/codex-claude-plugins) | — | Claude statusLine | Anthropic 才显示 TTL；`cache_ttl` 配置 `"5m"` 或 `"1h"`，新请求重置时钟 | [statusline README](https://github.com/duyet/codex-claude-plugins/blob/master/statusline/README.md) |
+
+星数只作筛选权重。低星项目里只要算法被高星复用（transcript + 桶），仍记为同一族。
+
+## Claude：大家实际在算什么
+
+### 共同公式
+
+Anthropic 官方：命中会刷新 TTL，TTL 从请求开始计时，只有 `5m` 和 `1h` 两档。
+
+[Claude Code prompt caching：Cache lifetime](https://code.claude.com/docs/en/prompt-caching#cache-lifetime)  
+[Anthropic API prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)
+
+开源倒计时几乎都是：
+
+```text
+anchor  = 最近一次带 cache_read 或 cache_creation 的 assistant 时间戳
+ttl     = 3600  若 ephemeral_1h_input_tokens > 0
+        = 300   若 ephemeral_5m_input_tokens > 0
+        = 用户配置或 300  （无桶时）
+remaining = max(0, ttl − (now − anchor))
+```
+
+关键选择：
+
+| 选择 | 高星怎么做 | 为什么 |
+| --- | --- | --- |
+| 锚点 | assistant 记录，不是 user 消息，不是文件 mtime | mtime 会被非 turn 的写入碰到；user 消息不刷新服务端 cache |
+| 读多少 | 尾部 16–320 KiB，或增量 offset | 全量 JSONL 会把 statusLine CPU 打满（ccstatusline #137） |
+| 无桶时 | ccstatusline 默认 5m；usage-bar 回退 5m；本插件 **不显示** | 回退会把未知策略伪装成 5m |
+| 滑动窗口 | 每一轮新 assistant 重置 | 与官方 “hit refreshes TTL” 一致 |
+
+这正是本插件 `src/providers/statusline.rs` 现在对 Claude 做的事（桶 + timestamp，无桶则隐藏）。
+
+### 2026 年桶会变，所以不能写死 1h
+
+Claude Code 客户端曾经整段时间只写 `ephemeral_1h`，后又整段只写 `ephemeral_5m`（约 2.1.218 起，见 [anthropics/claude-code#84253](https://github.com/anthropics/claude-code/issues/84253)）。订阅超额会降到 5m。所以 **看计划名猜 TTL 会错**；高星后来都改成读桶。
+
+### 新合同：官方已经给了 `expires_at`
+
+Claude Code **v2.1.251+** 的 statusLine stdin 增加 `prompt_cache`（[官方 statusLine：prompt cache fields](https://code.claude.com/docs/en/statusline#prompt-cache-fields)）：
+
+| 字段 | 含义 |
+| --- | --- |
+| `warm` | 前缀是否仍在 TTL 内 |
+| `ttl` | `"5m"` 或 `"1h"` |
+| `expires_at` | Unix 秒，前缀变冷的时刻；无 cache token 时为 `null` |
+| `hit_ratio` | session 累计命中 |
+
+Claude Code 还会在 warm cache 到达 `expires_at` 时主动再跑一次 statusLine。这是目前唯一的 **entry 级绝对过期时间**。
+
+截至本调研：ccstatusline 文档仍写 “transcript 没有真正 expiry，倒计时 best effort”；尚未看到它改读 `prompt_cache.expires_at`。本插件也还没读这个对象。
+
+## Codex / OpenAI：高星项目不倒计时
+
+官方合同（[OpenAI Prompt caching：Cache lifetime](https://developers.openai.com/api/docs/guides/prompt-caching#cache-lifetime)）：
+
+| 模型 | 控制项 | 寿命 |
+| --- | --- | --- |
+| GPT-5.6+ | `prompt_cache_options.ttl`，目前只有 `"30m"` | **至少** 30 分钟，服务端可以留更久 |
+| 更早 | `prompt_cache_retention`：`in_memory` 或 `24h` | in_memory 空闲约 5–10 分钟、最长约 1 小时；24h 约 30 分钟起、最长 24 小时 |
+
+Codex app-server 的 `thread/tokenUsage/updated` 只有 `cachedInputTokens` / `cacheWriteInputTokens`，没有 expiry。CodexBar、ccusage 的 Codex 路径都只做 token/cost，不做 TTL HUD。
+
+把 “1 小时” 当成 Codex 倒计时，会同时错过 30m 默认、5–10 分钟 in_memory、以及 “可能留更久”。没有高星项目这么做。
+
+## Grok / Gemini / OpenCode
+
+- **xAI**：缓存因内存压力和路由随时淘汰，没有公开 TTL。[How it works](https://docs.x.ai/developers/advanced-api-usage/prompt-caching/how-it-works) 原文：*not 100% guaranteed. Cache entries can be evicted due to memory pressure*。
+- **Gemini implicit cache**：只报 `usage.total_cached_tokens`，没有 TTL。[Gemini context caching](https://ai.google.dev/gemini-api/docs/caching) 只建议 “短时间内发相似前缀”。显式 `CachedContent.expireTime` 是另一套资源 API，Antigravity statusLine 不暴露。
+- **OpenCode 插件** 用文档默认值表做颜色带（绿/黄/红），那是 **elapsed vs 猜测 TTL**，不是过期时刻。
+
+## 对本插件的含义
+
+| Provider | 高星共识 | 本插件现状 | 可做的下一步 |
+| --- | --- | --- | --- |
+| Claude | transcript 桶估算；新版可直接读 `expires_at` | 已读 `prompt_cache.expires_at`，不再猜桶 | 保持；旧 Claude 不兼容 |
+| Pi / Anthropic | 同 Claude 桶 | 已用 `cacheWrite1h` | 保持 |
+| Codex | 不显示 TTL | 不显示 | 保持空白，除非 app-server 出现 expiry 字段 |
+| Grok | 官方说随时驱逐 | 不显示 | 保持空白 |
+| Agy / Gemini | implicit cache 无 TTL | 不显示 | 保持空白 |
+| OpenCode | 插件猜表 | 不显示 | 不要抄硬编码表 |
+
+不要把 quota `resets_at`、文件 mtime、或 “OpenAI 最长一小时” 当成 cache expiry。高星项目里，做对的都没这么干。

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -638,6 +638,9 @@ fn merge_preserved_context(
                 if current_cache.last_activity_unix.is_none() {
                     current_cache.last_activity_unix = previous_cache.last_activity_unix;
                 }
+                if current_cache.expires_at_unix.is_none() {
+                    current_cache.expires_at_unix = previous_cache.expires_at_unix;
+                }
             }
         }
     }

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -802,6 +802,7 @@ mod tests {
                     hit_percent: 96.4,
                     ttl_seconds: Some(3_540),
                     last_activity_unix: None,
+                    expires_at_unix: None,
                     session_totals: None,
                     session_id: None,
                     transcript_offset: 0,

--- a/src/model.rs
+++ b/src/model.rs
@@ -356,6 +356,10 @@ pub struct CacheUsage {
     pub ttl_seconds: Option<u64>,
     #[serde(default)]
     pub last_activity_unix: Option<u64>,
+    /// Absolute expiry from Claude Code's `prompt_cache.expires_at`.
+    /// Preferred over `ttl_seconds` + `last_activity_unix` when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at_unix: Option<u64>,
     /// Cumulative cache counters for the current provider session.
     ///
     /// `current_usage` is a latest-request view for Claude/Agy, so the
@@ -438,6 +442,7 @@ impl CacheUsage {
             hit_percent: read_tokens as f64 / total as f64 * 100.0,
             ttl_seconds: None,
             last_activity_unix: None,
+            expires_at_unix: None,
             session_totals: None,
             session_id: None,
             transcript_offset: 0,
@@ -451,6 +456,9 @@ impl CacheUsage {
     }
 
     pub fn remaining_ttl_seconds(&self, now_unix: u64) -> Option<u64> {
+        if let Some(expires_at) = self.expires_at_unix {
+            return Some(expires_at.saturating_sub(now_unix));
+        }
         let ttl = self.ttl_seconds?;
         let last_activity = self.last_activity_unix?;
         Some(last_activity.saturating_add(ttl).saturating_sub(now_unix))
@@ -891,6 +899,16 @@ mod tests {
             .with_ttl_estimate(300, 1_000);
         assert_eq!(cache.remaining_ttl_seconds(1_100), Some(200));
         assert_eq!(cache.remaining_ttl_seconds(1_301), Some(0));
+    }
+
+    #[test]
+    fn recorded_expiry_is_preferred_over_a_ttl_estimate() {
+        let mut cache = CacheUsage::from_token_counts(1, 1, 0)
+            .unwrap()
+            .with_ttl_estimate(300, 1_000);
+        cache.expires_at_unix = Some(1_500);
+        assert_eq!(cache.remaining_ttl_seconds(1_400), Some(100));
+        assert_eq!(cache.remaining_ttl_seconds(1_500), Some(0));
     }
 
     #[test]

--- a/src/providers/claude.rs
+++ b/src/providers/claude.rs
@@ -1,6 +1,6 @@
 use crate::cache::CacheStore;
-use crate::model::{Provider, ProviderSnapshot, ResetAt, UsageWindow, WindowKind};
-use crate::providers::statusline::{enrich_cache_ttl, parse_context, parse_model};
+use crate::model::{ContextUsage, Provider, ProviderSnapshot, ResetAt, UsageWindow, WindowKind};
+use crate::providers::statusline::{parse_context, parse_model};
 use crate::providers::ProviderError;
 use serde_json::Value;
 
@@ -8,12 +8,18 @@ pub fn parse_statusline(
     value: &Value,
     fetched_at_unix: u64,
 ) -> std::result::Result<ProviderSnapshot, ProviderError> {
-    let context = parse_context(
+    let mut context = parse_context(
         value
             .get("context_window")
             .or_else(|| value.get("contextWindow")),
     )
     .unwrap_or(None);
+    apply_prompt_cache(
+        &mut context,
+        value
+            .get("prompt_cache")
+            .or_else(|| value.get("promptCache")),
+    );
     let model = parse_model(value);
     let Some(limits) = value.get("rate_limits") else {
         return Ok(
@@ -70,13 +76,71 @@ fn parse_window(
         .map_err(|error| ProviderError::UnsupportedResponse(error.to_string()))
 }
 
+/// Claude Code v2.1.251+ reports the live prefix expiry on statusLine stdin.
+/// Cold or missing expiry clears any previous countdown instead of guessing
+/// from a transcript bucket.
+pub(crate) fn apply_prompt_cache(context: &mut Option<ContextUsage>, prompt_cache: Option<&Value>) {
+    let Some(prompt_cache) = prompt_cache.filter(|value| !value.is_null()) else {
+        return;
+    };
+    let Some(object) = prompt_cache.as_object() else {
+        return;
+    };
+    let Some(cache) = context.as_mut().and_then(|context| context.cache.as_mut()) else {
+        return;
+    };
+    let warm = object.get("warm").and_then(Value::as_bool) != Some(false);
+    let expires_at = object.get("expires_at").and_then(parse_expires_at);
+    match (warm, expires_at) {
+        (true, Some(expires_at)) => {
+            cache.expires_at_unix = Some(expires_at);
+            cache.ttl_seconds = object
+                .get("ttl")
+                .and_then(Value::as_str)
+                .and_then(parse_prompt_cache_ttl);
+            if let Some(ttl_seconds) = cache.ttl_seconds {
+                cache.last_activity_unix = Some(expires_at.saturating_sub(ttl_seconds));
+            }
+        }
+        _ => {
+            cache.expires_at_unix = Some(0);
+            cache.ttl_seconds = None;
+            cache.last_activity_unix = None;
+        }
+    }
+}
+
+fn parse_prompt_cache_ttl(value: &str) -> Option<u64> {
+    match value.trim() {
+        "5m" => Some(5 * 60),
+        "1h" => Some(60 * 60),
+        _ => None,
+    }
+}
+
+fn parse_expires_at(value: &Value) -> Option<u64> {
+    if value.is_null() {
+        return None;
+    }
+    value
+        .as_u64()
+        .or_else(|| {
+            let number = value.as_f64()?;
+            (number.is_finite() && number >= 0.0).then_some(number.round() as u64)
+        })
+        .or_else(|| {
+            value
+                .as_str()
+                .and_then(ResetAt::parse)
+                .map(ResetAt::unix_seconds)
+        })
+}
+
 pub fn run_statusline(input: &[u8]) -> std::result::Result<ProviderSnapshot, ProviderError> {
     let value: Value = serde_json::from_slice(input).map_err(|_| {
         ProviderError::UnsupportedResponse("statusLine input is not JSON".to_string())
     })?;
-    let mut snapshot = parse_statusline(&value, CacheStore::now_unix())?;
-    enrich_cache_ttl(&mut snapshot, &value);
-    Ok(snapshot)
+    parse_statusline(&value, CacheStore::now_unix())
 }
 
 #[cfg(test)]
@@ -140,15 +204,8 @@ mod tests {
     }
 
     #[test]
-    fn estimates_claude_cache_ttl_from_a_bounded_transcript_tail() {
-        let transcript = tempfile::NamedTempFile::new().unwrap();
-        std::fs::write(
-            transcript.path(),
-            r#"{"type":"assistant","timestamp":"2026-08-22T10:00:00Z","message":{"usage":{"input_tokens":10,"cache_read_input_tokens":80,"cache_creation_input_tokens":10,"cache_creation":{"ephemeral_1h_input_tokens":10,"ephemeral_5m_input_tokens":0}}}}"#,
-        )
-        .unwrap();
+    fn reads_prompt_cache_expiry_from_statusline() {
         let value = json!({
-            "transcript_path": transcript.path(),
             "context_window": {
                 "used_percentage": 23.5,
                 "current_usage": {
@@ -157,12 +214,71 @@ mod tests {
                     "cache_creation_input_tokens": 10
                 }
             },
-            "rate_limits": {"five_hour": {"used_percentage": 58.0}}
+            "prompt_cache": {
+                "warm": true,
+                "ttl": "1h",
+                "expires_at": 1_787_396_400
+            },
+            "rate_limits": {
+                "five_hour": {"used_percentage": 58.0}
+            }
         });
-        let snapshot = run_statusline(value.to_string().as_bytes()).unwrap();
+        let snapshot = parse_statusline(&value, 1).unwrap();
         let cache = snapshot.context.unwrap().cache.unwrap();
+        assert_eq!(cache.expires_at_unix, Some(1_787_396_400));
         assert_eq!(cache.ttl_seconds, Some(60 * 60));
         assert_eq!(cache.last_activity_unix, Some(1_787_392_800));
+        assert_eq!(cache.remaining_ttl_seconds(1_787_392_800), Some(3_600));
+    }
+
+    #[test]
+    fn cold_prompt_cache_clears_ttl() {
+        let value = json!({
+            "context_window": {
+                "used_percentage": 23.5,
+                "current_usage": {
+                    "input_tokens": 10,
+                    "cache_read_input_tokens": 80,
+                    "cache_creation_input_tokens": 0
+                }
+            },
+            "prompt_cache": {
+                "warm": false,
+                "ttl": "1h",
+                "expires_at": null
+            },
+            "rate_limits": {
+                "five_hour": {"used_percentage": 58.0}
+            }
+        });
+        let snapshot = parse_statusline(&value, 1).unwrap();
+        let cache = snapshot.context.unwrap().cache.unwrap();
+        assert_eq!(cache.expires_at_unix, Some(0));
+        assert!(cache.ttl_seconds.is_none());
+        assert_eq!(cache.remaining_ttl_seconds(1_787_392_800), Some(0));
+    }
+
+    #[test]
+    fn ignores_transcript_buckets_when_prompt_cache_is_absent() {
+        let value = json!({
+            "transcript_path": "/tmp/unused.jsonl",
+            "context_window": {
+                "used_percentage": 23.5,
+                "current_usage": {
+                    "input_tokens": 10,
+                    "cache_read_input_tokens": 80,
+                    "cache_creation_input_tokens": 10
+                }
+            },
+            "rate_limits": {
+                "five_hour": {"used_percentage": 58.0}
+            }
+        });
+        let snapshot = parse_statusline(&value, 1).unwrap();
+        let cache = snapshot.context.unwrap().cache.unwrap();
+        assert!(cache.expires_at_unix.is_none());
+        assert!(cache.ttl_seconds.is_none());
+        assert!(cache.last_activity_unix.is_none());
     }
 
     #[test]

--- a/src/providers/statusline.rs
+++ b/src/providers/statusline.rs
@@ -1,11 +1,9 @@
-use crate::model::{CacheTotals, CacheUsage, ContextUsage, ProviderSnapshot, ResetAt};
+use crate::model::{CacheTotals, CacheUsage, ContextUsage, ProviderSnapshot};
 use crate::providers::ProviderError;
 use serde_json::Value;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
-
-const TRANSCRIPT_TAIL_BYTES: u64 = 16 * 1024;
 
 /// Read the provider's human-readable active model label from a statusLine
 /// payload. The display name is intentionally preferred over the model id so
@@ -86,33 +84,6 @@ fn token_count(object: &serde_json::Map<String, Value>, snake: &str, camel: &str
         .unwrap_or_default()
 }
 
-/// Add a best-effort Claude cache TTL estimate from the local transcript.
-///
-/// Claude's statusLine contract exposes cache counters but not an entry
-/// expiry timestamp. The transcript tail contains the latest assistant usage
-/// bucket and timestamp, so this can show an explicitly approximate countdown
-/// without scanning the full conversation or making a network request.
-pub fn enrich_cache_ttl(snapshot: &mut ProviderSnapshot, statusline: &Value) {
-    let Some(context) = snapshot.context.as_mut() else {
-        return;
-    };
-    let Some(cache) = context.cache.as_mut() else {
-        return;
-    };
-    let Some(path) = statusline.get("transcript_path").and_then(Value::as_str) else {
-        return;
-    };
-    let Some(tail) = read_transcript_tail(Path::new(path)) else {
-        return;
-    };
-    let Some((Some(ttl_seconds), Some(last_activity_unix))) = latest_cache_activity(&tail) else {
-        return;
-    };
-    *cache = cache
-        .clone()
-        .with_ttl_estimate(ttl_seconds, last_activity_unix);
-}
-
 /// Accumulate cache counters from the provider session transcript.
 ///
 /// StatusLine's `current_usage` is deliberately a latest-request view. The
@@ -143,7 +114,7 @@ pub fn enrich_cache_session(
     };
     // Keep the session boundary even when this payload has no transcript
     // path. That prevents a later statusLine update from inheriting another
-    // session's TTL estimate.
+    // session's cache totals.
     cache.session_id = Some(session_id.to_string());
     let Some(path) = statusline.get("transcript_path").and_then(Value::as_str) else {
         return;
@@ -155,8 +126,6 @@ pub fn enrich_cache_session(
         .map(|previous| previous.transcript_offset)
         .unwrap_or_default();
     let mut increment_totals: Option<CacheTotals> = None;
-    let mut latest_activity = None;
-    let mut latest_ttl = None;
     let Some((next_offset, transcript_reset)) = read_transcript_increment(
         Path::new(path),
         if matching_previous.is_some() {
@@ -186,12 +155,6 @@ pub fn enrich_cache_session(
             } else {
                 increment_totals = CacheTotals::from_token_counts(fresh, read, creation);
             }
-            if read > 0 || creation > 0 {
-                latest_activity = Some(entry.get("timestamp").and_then(parse_timestamp));
-                if let Some(ttl_seconds) = cache_ttl_seconds(usage) {
-                    latest_ttl = Some(ttl_seconds);
-                }
-            }
         },
     ) else {
         return;
@@ -216,28 +179,6 @@ pub fn enrich_cache_session(
 
     cache.session_totals = totals;
     cache.transcript_offset = next_offset;
-
-    if let Some(ttl_seconds) = latest_ttl {
-        cache.ttl_seconds = Some(ttl_seconds);
-    }
-    if let Some(Some(last_activity_unix)) = latest_activity {
-        cache.last_activity_unix = Some(last_activity_unix);
-    }
-}
-
-fn read_transcript_tail(path: &Path) -> Option<String> {
-    let mut file = File::open(path).ok()?;
-    let length = file.metadata().ok()?.len();
-    let start = length.saturating_sub(TRANSCRIPT_TAIL_BYTES);
-    file.seek(SeekFrom::Start(start)).ok()?;
-    let mut bytes = Vec::with_capacity((length - start) as usize);
-    file.read_to_end(&mut bytes).ok()?;
-    let text = String::from_utf8_lossy(&bytes);
-    if start == 0 {
-        return Some(text.into_owned());
-    }
-    text.split_once('\n')
-        .map(|(_, complete_lines)| complete_lines.to_string())
 }
 
 fn read_transcript_increment<F>(path: &Path, offset: u64, mut on_line: F) -> Option<(u64, bool)>
@@ -275,75 +216,6 @@ fn assistant_usage(entry: &Value) -> Option<&serde_json::Map<String, Value>> {
         .and_then(|message| message.get("usage"))
         .or_else(|| entry.get("usage"))
         .and_then(Value::as_object)
-}
-
-fn latest_cache_activity(text: &str) -> Option<(Option<u64>, Option<u64>)> {
-    let mut last_activity = None;
-    let mut ttl_seconds = None;
-    for line in text.lines().rev() {
-        let Ok(entry) = serde_json::from_str::<Value>(line) else {
-            continue;
-        };
-        let Some(usage) = assistant_usage(&entry) else {
-            continue;
-        };
-        let read = token_count(usage, "cache_read_input_tokens", "cacheReadInputTokens");
-        let creation = token_count(
-            usage,
-            "cache_creation_input_tokens",
-            "cacheCreationInputTokens",
-        );
-        if read == 0 && creation == 0 {
-            continue;
-        }
-        if last_activity.is_none() {
-            last_activity = entry.get("timestamp").and_then(parse_timestamp);
-        }
-        if ttl_seconds.is_none() {
-            ttl_seconds = cache_ttl_seconds(usage);
-        }
-        if ttl_seconds.is_some() && last_activity.is_some() {
-            return Some((ttl_seconds, last_activity));
-        }
-    }
-    if ttl_seconds.is_some() || last_activity.is_some() {
-        Some((ttl_seconds, last_activity))
-    } else {
-        None
-    }
-}
-
-fn cache_ttl_seconds(usage: &serde_json::Map<String, Value>) -> Option<u64> {
-    let creation = usage
-        .get("cache_creation")
-        .or_else(|| usage.get("cacheCreation"))?
-        .as_object()?;
-    if token_count(
-        creation,
-        "ephemeral_1h_input_tokens",
-        "ephemeral1hInputTokens",
-    ) > 0
-    {
-        return Some(60 * 60);
-    }
-    if token_count(
-        creation,
-        "ephemeral_5m_input_tokens",
-        "ephemeral5mInputTokens",
-    ) > 0
-    {
-        return Some(5 * 60);
-    }
-    None
-}
-
-fn parse_timestamp(value: &Value) -> Option<u64> {
-    value.as_u64().or_else(|| {
-        value
-            .as_str()
-            .and_then(ResetAt::parse)
-            .map(ResetAt::unix_seconds)
-    })
 }
 
 #[cfg(test)]
@@ -399,8 +271,8 @@ mod tests {
         assert_eq!(first_totals.fresh_input_tokens, 150);
         assert_eq!(first_totals.read_tokens, 1_250);
         assert_eq!(first_totals.creation_tokens, 100);
-        assert_eq!(first_cache.ttl_seconds, Some(60 * 60));
-        assert_eq!(first_cache.last_activity_unix, Some(1_787_392_860));
+        assert!(first_cache.ttl_seconds.is_none());
+        assert!(first_cache.last_activity_unix.is_none());
         assert!(first_cache.transcript_offset > 0);
 
         let third = br#"{"type":"assistant","timestamp":"2026-08-22T10:02:00Z","message":{"usage":{"input_tokens":20,"cache_read_input_tokens":180,"cache_creation_input_tokens":0}}}

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -517,6 +517,14 @@ fn load_statusline_snapshot(cache: &CacheStore, provider: Provider) -> Result<Fe
         .and_then(|snapshot| snapshot.context)
         .and_then(|context| context.cache);
     enrich_cache_session(&mut snapshot, &value, previous_cache.as_ref());
+    if provider == Provider::Claude {
+        crate::providers::claude::apply_prompt_cache(
+            &mut snapshot.context,
+            value
+                .get("prompt_cache")
+                .or_else(|| value.get("promptCache")),
+        );
+    }
     let session_id = value
         .get("session_id")
         .or_else(|| value.get("sessionId"))


### PR DESCRIPTION
## What this changes

Claude cache TTL now comes from statusLine `prompt_cache.expires_at` (Claude Code v2.1.251+). The transcript-tail guess from `ephemeral_5m`/`ephemeral_1h` buckets is removed.

Cold or missing prefix expiry hides the countdown instead of keeping a stale estimate. Session cache hit-rate accumulation from the transcript is unchanged. Pi/Anthropic still uses `cacheWrite1h`.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features --locked`
- [x] A parser change comes with a fixture in `tests/fixtures/` and a test
- [x] No new network call, background process, or credential write

## Provider impact

Claude Code v2.1.251+. Older Claude versions no longer get a guessed TTL.