### PR TITLE
feat: estimate Codex prompt cache TTL from the last request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Codex now publishes an estimated prompt cache TTL. The rollout JSONL records
+  no TTL and no expiry, so the countdown is the documented 30 minute
+  `prompt_cache_options.ttl` anchored to the timestamp of the last recorded
+  request. The same estimate covers Pi `openai-codex` sessions, anchored to the
+  latest assistant message with cache activity. `cache_write_input_tokens` is
+  not used as the anchor: ChatGPT-backed sessions report 0 there even while
+  cached reads are large.
+
 ### Changed
 
 - Claude cache TTL now comes from statusLine `prompt_cache.expires_at`
@@ -26,11 +36,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Notes
 
-- Cache TTL is published only from a recorded expiry: Claude Code
-  `prompt_cache.expires_at` and Pi/Anthropic `cacheWrite1h`. Codex, Grok, Agy,
-  OpenCode, and other Pi backends have no entry expiry in their local
-  contracts, so they keep cache hit rate and leave TTL blank rather than
-  guessing a one-hour countdown.
+- Recorded expiries still win where they exist: Claude Code
+  `prompt_cache.expires_at` and Pi/Anthropic `cacheWrite1h`. Codex is the one
+  place where a documented, model-independent TTL makes an estimate worth
+  publishing. Grok, Agy, OpenCode, and other Pi backends have neither an entry
+  expiry nor a documented TTL in their local contracts, so they keep cache hit
+  rate and leave TTL blank rather than guessing a one-hour countdown.
 
 ## [1.0.0] - 2026-08-29
 

--- a/README.md
+++ b/README.md
@@ -74,18 +74,25 @@ herdr plugin action invoke herdr-agent-quota.refresh
 | Harness | Subscription quota | Exact-session diagnostics | Attribution rule |
 | --- | --- | --- | --- |
 | Claude Code | 5h + 7d | model, context, cache, statusLine `prompt_cache` expiry | Claude statusLine session |
-| OpenAI Codex | 5h + 7d | model, context, cache, session summary | Canonical ChatGPT login; API keys are not subscription quota |
+| OpenAI Codex | 5h + 7d | model, context, cache, estimated cache TTL, session summary | Canonical ChatGPT login; API keys are not subscription quota |
 | Grok CLI | 7d | model, context, cache | Canonical Grok login |
 | Agy / Antigravity | 5h + 7d | model, context, cache | Agy statusLine session and active model pool |
 | OpenCode | OpenCode Go 5h + 7d; 30d in dashboard | model and context for the exact local session | Go only for `opencode-go` with its matching key; other backends never borrow it |
-| Pi | Existing Codex quota when safely matched | model, context, cache; Anthropic recorded TTL | Only `openai-codex` OAuth with the same canonical Codex account id |
+| Pi | Existing Codex quota when safely matched | model, context, cache; Anthropic recorded TTL, Codex estimated TTL | Only `openai-codex` OAuth with the same canonical Codex account id |
 
 Quota values are percentages remaining plus reset time. Context is percentage
 used. Cache is a session hit ratio where the upstream session format supports
-one. TTL is shown only when a recorded expiry is present: Claude Code
-`prompt_cache.expires_at` (v2.1.251+) and Pi/Anthropic `cacheWrite1h`. Codex,
-Grok, Agy, OpenCode, and other Pi backends have no cache-entry expiry in their
-local contracts, so they keep cache hit rate and leave TTL blank.
+one. TTL comes from a recorded expiry where one exists: Claude Code
+`prompt_cache.expires_at` (v2.1.251+) and Pi/Anthropic `cacheWrite1h`. Codex
+records neither a TTL nor an expiry - its rollout JSONL carries only the cache
+token counts and the request timestamp - so the sidebar estimates it as the
+30 minute `prompt_cache_options.ttl` that the Responses API documents as its
+default and only supported value, anchored to the last recorded request. It is
+labelled `ttl≈` like every other countdown and it is an estimate: a changed
+prefix, a compaction, or a changed tool/system definition can drop the hit rate
+before that timer runs out. Grok, Agy, OpenCode, and other Pi backends have no
+cache-entry expiry and no documented TTL in their local contracts, so they keep
+cache hit rate and leave TTL blank.
 
 Pi reads only the absolute JSONL path reported by Herdr under `~/.pi/agent` or
 `PI_CODING_AGENT_DIR`. It does not scan every session. API-key sessions are

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,17 +70,21 @@ herdr plugin action invoke herdr-agent-quota.refresh
 | Harness | 订阅额度 | 精确 session 信息 | 归属规则 |
 | --- | --- | --- | --- |
 | Claude Code | 5h + 7d | model、context、cache、statusLine `prompt_cache` 过期时间 | Claude statusLine session |
-| OpenAI Codex | 5h + 7d | model、context、cache、session 摘要 | 规范 ChatGPT 登录；API key 不冒充订阅额度 |
+| OpenAI Codex | 5h + 7d | model、context、cache、估算 cache TTL、session 摘要 | 规范 ChatGPT 登录；API key 不冒充订阅额度 |
 | Grok CLI | 7d | model、context、cache | 规范 Grok 登录 |
 | Agy / Antigravity | 5h + 7d | model、context、cache | Agy statusLine session 与当前模型池 |
 | OpenCode | OpenCode Go 5h + 7d；dashboard 含 30d | 精确本地 session 的 model 与 context | 仅 `opencode-go` 和其匹配 key；其他 backend 不借用 Go 凭据 |
-| Pi | 能安全匹配时复用现有 Codex 额度 | model、context、cache；Anthropic 已记录 TTL | 仅 account id 与规范 Codex 相同的 `openai-codex` OAuth |
+| Pi | 能安全匹配时复用现有 Codex 额度 | model、context、cache；Anthropic 已记录 TTL、Codex 估算 TTL | 仅 account id 与规范 Codex 相同的 `openai-codex` OAuth |
 
 额度显示剩余百分比和重置时间；context 显示已用百分比；cache 在上游 session 格式可支持时
-显示命中率。TTL 只在有记录的过期时间时出现：Claude Code 的
+显示命中率。有记录的过期时间优先：Claude Code 的
 `prompt_cache.expires_at`（v2.1.251+）和 Pi/Anthropic 的 `cacheWrite1h`。
-Codex、Grok、Agy、OpenCode 和其他 Pi backend 的本地合同没有 cache entry 过期时间，
-因此只保留命中率，不猜 TTL。
+Codex 本地既没有 TTL 也没有 expiry——rollout JSONL 只有 cache token 计数和请求
+时间戳——所以按 Responses API 文档中默认且当前唯一支持的
+`prompt_cache_options.ttl`（30 分钟）估算，锚点是最后一次已记录的请求。显示同样是
+`ttl≈`，但它是估算：前缀变化、compaction、system/tool 定义变化都可能让命中率在计时
+结束前先掉下去。Grok、Agy、OpenCode 和其他 Pi backend 的本地合同既没有过期时间也没有
+可依据的 TTL，因此只保留命中率，不猜 TTL。
 
 Pi 只读取 Herdr 报告的那个绝对 JSONL 路径，来源为 `~/.pi/agent` 或
 `PI_CODING_AGENT_DIR`，不会扫描所有 session。API key session 确认为 PAYG 并清除旧额度；

--- a/src/pi.rs
+++ b/src/pi.rs
@@ -451,9 +451,34 @@ fn usage_counters(usage: &Value) -> Option<UsageCounters> {
 }
 
 fn cache_activity(branch: &[&Value], provider_id: &str) -> Option<CacheActivity> {
-    if provider_id != "anthropic" {
-        return None;
+    match provider_id {
+        "anthropic" => anthropic_cache_activity(branch, provider_id),
+        // Codex records no TTL and no expiry, so the estimate is the
+        // documented 30 minute prompt cache lifetime anchored to the last
+        // request that touched the cache. Pi only reports `cacheRead` for this
+        // provider; `cacheWrite` stays 0 even on a warm session.
+        "openai-codex" => codex_cache_activity(branch, provider_id),
+        _ => None,
     }
+}
+
+fn codex_cache_activity(branch: &[&Value], provider_id: &str) -> Option<CacheActivity> {
+    let last_activity_unix = branch.iter().rev().find_map(|entry| {
+        if entry.pointer("/message/provider").and_then(Value::as_str) != Some(provider_id) {
+            return None;
+        }
+        let usage = assistant_usage(entry)?;
+        (usage.cache_read > 0 || usage.cache_write > 0)
+            .then(|| message_started_at(entry))
+            .flatten()
+    })?;
+    Some(CacheActivity {
+        ttl_seconds: crate::providers::codex::CODEX_PROMPT_CACHE_TTL_SECONDS,
+        last_activity_unix,
+    })
+}
+
+fn anthropic_cache_activity(branch: &[&Value], provider_id: &str) -> Option<CacheActivity> {
     let mut ttl_seconds = None;
     let mut last_activity_unix = None;
     for entry in branch.iter().rev() {
@@ -770,6 +795,25 @@ mod tests {
             cache_activity(&branch, "anthropic").unwrap().ttl_seconds,
             5 * 60
         );
+    }
+
+    #[test]
+    fn codex_cache_ttl_estimates_thirty_minutes_from_the_latest_cached_request() {
+        let entries = vec![
+            serde_json::json!({"type":"message","id":"first","parentId":null,"message":{"role":"assistant","provider":"openai-codex","model":"model-a","stopReason":"stop","timestamp":1_700_000_000_000_u64,"usage":{"cacheRead":0,"cacheWrite":0,"totalTokens":100}}}),
+            serde_json::json!({"type":"message","id":"cached","parentId":"first","message":{"role":"assistant","provider":"openai-codex","model":"model-a","stopReason":"stop","timestamp":1_700_000_060_000_u64,"usage":{"cacheRead":800,"cacheWrite":0,"totalTokens":900}}}),
+        ];
+        let branch = active_branch(&entries).unwrap();
+        let activity = cache_activity(&branch, "openai-codex").unwrap();
+        assert_eq!(
+            activity.ttl_seconds,
+            crate::providers::codex::CODEX_PROMPT_CACHE_TTL_SECONDS
+        );
+        assert_eq!(activity.last_activity_unix, 1_700_000_060);
+
+        let cold = vec![entries[0].clone()];
+        let branch = active_branch(&cold).unwrap();
+        assert!(cache_activity(&branch, "openai-codex").is_none());
     }
 
     #[test]

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -25,6 +25,16 @@ const WEEKLY_WINDOW_MINUTES: u64 = 7 * 24 * 60;
 const ROLLOUT_TAIL_BYTES: u64 = 256 * 1024;
 const ROLLOUT_HEAD_BYTES: u64 = 256 * 1024;
 const CODEX_CONTEXT_BASELINE_TOKENS: u64 = 12_000;
+/// Prompt cache lifetime assumed for a Codex request.
+///
+/// Codex never records a TTL or an expiry: the rollout JSONL only carries
+/// `cached_input_tokens` / `cache_write_input_tokens` and the request
+/// timestamp, and the `prompt_cache_options` the Responses API returns is
+/// dropped by the Codex SSE parser before it reaches disk. OpenAI documents
+/// `30m` as the default and currently only supported `prompt_cache_options.ttl`,
+/// so the sidebar anchors that TTL to the last recorded request. This is an
+/// estimate, not a server-reported expiry — the sidebar labels it `ttl≈`.
+pub(crate) const CODEX_PROMPT_CACHE_TTL_SECONDS: u64 = 30 * 60;
 
 pub fn parse_rate_limits(
     value: &Value,
@@ -504,7 +514,17 @@ fn parse_rollout_observation(text: &str, session_id: &str) -> Option<RolloutObse
                 cache.read_tokens,
                 cache.creation_tokens,
             );
-            cache.with_session_totals(totals, session_id, 0)
+            let cache = cache.with_session_totals(totals, session_id, 0);
+            // Every request refreshes the prefix cache, so the entry's own
+            // timestamp is the anchor. `cache_write_input_tokens` stays 0 on
+            // ChatGPT-backed sessions even while reads are large, so it cannot
+            // be used to pick the anchor.
+            match parse_rollout_timestamp(&entry) {
+                Some(requested_at) => {
+                    cache.with_ttl_estimate(CODEX_PROMPT_CACHE_TTL_SECONDS, requested_at)
+                }
+                None => cache,
+            }
         });
         let context_value = ContextUsage::new(used.clamp(0.0, 100.0))
             .ok()?
@@ -516,6 +536,14 @@ fn parse_rollout_observation(text: &str, session_id: &str) -> Option<RolloutObse
         context,
         windows,
     })
+}
+
+fn parse_rollout_timestamp(entry: &Value) -> Option<u64> {
+    entry
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .and_then(ResetAt::parse_rfc3339)
+        .map(ResetAt::unix_seconds)
 }
 
 fn parse_rollout_model(text: &str) -> Option<String> {
@@ -886,6 +914,36 @@ mod tests {
         assert_eq!(cache.creation_tokens, 100);
         assert_eq!(cache.session_id.as_deref(), Some("session-1"));
         assert_eq!(cache.session_totals.unwrap().hit_percent, 72.72727272727273);
+        assert_eq!(cache.ttl_seconds, Some(CODEX_PROMPT_CACHE_TTL_SECONDS));
+        assert_eq!(cache.last_activity_unix, Some(1_787_711_322));
+        assert_eq!(cache.expires_at_unix, None);
+    }
+
+    #[test]
+    fn rollout_cache_without_a_timestamp_has_no_ttl_estimate() {
+        let observation = parse_rollout_observation(
+            &format!(
+                "{}\n",
+                serde_json::to_string(&json!({
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {"total_tokens": 50_000},
+                            "total_token_usage": {
+                                "input_tokens": 1_000,
+                                "cached_input_tokens": 800
+                            },
+                            "model_context_window": 100_000
+                        }
+                    }
+                }))
+                .unwrap()
+            ),
+            "session-1",
+        )
+        .unwrap();
+        let cache = observation.context.unwrap().cache.unwrap();
         assert_eq!(cache.ttl_seconds, None);
         assert_eq!(cache.last_activity_unix, None);
     }


### PR DESCRIPTION
## What

Codex sessions now show a `ttl≈` countdown in the sidebar, both for the Codex provider and for Pi `openai-codex` sessions.

## Why this is an estimate

Codex records neither a TTL nor an expiry locally. The rollout JSONL carries only `cached_input_tokens`, `cache_write_input_tokens` and the request timestamp — the `prompt_cache_options` the Responses API returns is dropped by the Codex SSE parser before anything reaches disk. Verified against a real local rollout: no `ttl` or `expires_at` field anywhere.

OpenAI documents `30m` as the default and currently only supported `prompt_cache_options.ttl`, so the countdown is that TTL anchored to the timestamp of the last recorded request.

## Anchor choice

`cache_write_input_tokens` is **not** the anchor. A live ChatGPT-backed session reports `cache_write_input_tokens: 0` on every turn while `cached_input_tokens` is in the millions, so a write-based anchor would almost never fire. Every request refreshes the prefix cache, so the request timestamp is the correct anchor.

Pi reports only `cacheRead` for this provider, so its anchor is the latest assistant message with any cache activity.

## Unchanged

Recorded expiries still win where they exist (Claude `prompt_cache.expires_at`, Pi/Anthropic `cacheWrite1h`). Grok, Agy, OpenCode and other Pi backends have neither an expiry nor a documented TTL in their local contracts, so they still leave TTL blank. An expired estimate falls through to the existing `no cached` label rather than showing a stale timer.

## Verification

- `cargo fmt`, `cargo test` (302 tests), `cargo clippy --release` — clean
- New tests: Codex rollout TTL anchor + no-timestamp fallback; Pi `openai-codex` anchor + cold-session fallback
- Live check against the real local state file: `ttl_seconds: 1800`, `last_activity_unix` matching the last recorded request

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKjf4M3V94udUKQwGCjqkW