### PR TITLE
Inherit Herdr theme for sidebar text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Sidebar tab names, topics, cache details, context, and unknown quota states
+  now inherit Herdr's active theme instead of using text colors tuned for a
+  dark background. Provider brand hues and quota severity colors remain
+  plugin-owned because they carry plugin-specific meaning.
+
 ## [1.3.0] - 2026-09-01
 
 ### Added

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -57,13 +57,10 @@ const REFRESH_ACTION: &str = "herdr-agent-quota.refresh";
 const SETTINGS_KEY: &str = "prefix+shift+q";
 const SETTINGS_ACTION: &str = "herdr-agent-quota.open-settings";
 const CONFIG_PRESENCE_FILE: &str = "herdr-config.original.present";
-// Brand answers "who"; status answers "how much is left". Selected state
-// may change background only — never the provider hue. Herdr 0.8.0 rejects
-// selection_bg / active_row_bg (0.8.2 added them); intended selected fill
-// is #42474f when those keys exist.
-const TEXT_COLOR: &str = "#eceef2";
-const BODY_COLOR: &str = "#c8cdd6";
-const MUTED_COLOR: &str = "#969eae";
+// Brand answers "who"; status answers "how much is left". All other text
+// inherits Herdr's active theme. Selected state may change background only —
+// never the provider hue. Herdr 0.8.0 rejects selection_bg / active_row_bg
+// (0.8.2 added them); intended selected fill is #42474f when those keys exist.
 const QUOTA_SAFE_COLOR: &str = "#82d978";
 const QUOTA_WARNING_COLOR: &str = "#e4b957";
 const QUOTA_DANGER_COLOR: &str = "#f16f7e";
@@ -654,7 +651,7 @@ fn is_tab_token(value: &Value) -> bool {
 }
 
 fn styled_tab() -> Value {
-    styled_token("tab", Some(TEXT_COLOR), Some(true), Some(false))
+    styled_token("tab", None, Some(true), Some(false))
 }
 
 fn normalize_official_row(row: Array) -> Array {
@@ -764,7 +761,7 @@ fn append_quota_rows(rows: &mut Array, layout: SidebarLayout) {
 
     rows.push(Value::Array(styled_row(
         "$quota_topic",
-        Some(BODY_COLOR),
+        None,
         Some(false),
         Some(false),
     )));
@@ -833,12 +830,7 @@ fn stacked_identity_row(row: &Array) -> Array {
 fn append_packed_quota_rows(rows: &mut Array) {
     append_cache_row(rows);
 
-    let mut context_row = styled_row(
-        "$quota_context",
-        Some(MUTED_COLOR),
-        Some(false),
-        Some(false),
-    );
+    let mut context_row = styled_row("$quota_context", None, Some(false), Some(false));
     append_window_style_tokens(&mut context_row, "quota_week_inline");
     rows.push(Value::Array(context_row));
 
@@ -848,13 +840,13 @@ fn append_packed_quota_rows(rows: &mut Array) {
 fn append_stacked_quota_rows(rows: &mut Array) {
     rows.push(Value::Array(styled_row(
         "$quota_cache",
-        Some(MUTED_COLOR),
+        None,
         Some(false),
         Some(false),
     )));
     rows.push(Value::Array(styled_row(
         "$quota_cache_ttl",
-        Some(MUTED_COLOR),
+        None,
         Some(false),
         Some(false),
     )));
@@ -872,7 +864,7 @@ fn append_stacked_quota_rows(rows: &mut Array) {
     )));
     rows.push(Value::Array(styled_row(
         "$quota_context",
-        Some(MUTED_COLOR),
+        None,
         Some(false),
         Some(false),
     )));
@@ -944,13 +936,8 @@ fn field_for_token(token: &str) -> Option<SidebarField> {
 
 fn append_cache_row(rows: &mut Array) {
     rows.push(Value::Array(Array::from_iter([
-        styled_token("$quota_cache", Some(MUTED_COLOR), Some(false), Some(false)),
-        styled_token(
-            "$quota_cache_ttl",
-            Some(MUTED_COLOR),
-            Some(false),
-            Some(false),
-        ),
+        styled_token("$quota_cache", None, Some(false), Some(false)),
+        styled_token("$quota_cache_ttl", None, Some(false), Some(false)),
         styled_token(
             "$quota_cache_state",
             Some(QUOTA_WARNING_COLOR),
@@ -973,14 +960,14 @@ fn append_window_style_tokens(row: &mut Array, base: &str) {
     // "caution" row: that variant was unreachable, so the token could never
     // be filled and only ever consumed a slot.
     for (suffix, color) in [
-        ("normal", QUOTA_SAFE_COLOR),
-        ("warning", QUOTA_WARNING_COLOR),
-        ("danger", QUOTA_DANGER_COLOR),
-        ("unknown", MUTED_COLOR),
+        ("normal", Some(QUOTA_SAFE_COLOR)),
+        ("warning", Some(QUOTA_WARNING_COLOR)),
+        ("danger", Some(QUOTA_DANGER_COLOR)),
+        ("unknown", None),
     ] {
         row.push(styled_token(
             &format!("${base}_{suffix}"),
-            Some(color),
+            color,
             Some(false),
             Some(false),
         ));
@@ -1273,7 +1260,7 @@ rows = [["state_icon", "agent"]]
     }
 
     #[test]
-    fn tab_labels_use_primary_text_instead_of_herdr_dim_gray() {
+    fn tab_labels_inherit_herdr_theme_and_remain_bold() {
         let updated =
             add_quota_row("[ui.sidebar.agents]\nrows = [[\"state_icon\", \"tab\", \"agent\"]]\n")
                 .unwrap();
@@ -1295,7 +1282,7 @@ rows = [["state_icon", "agent"]]
             .find(|item| configured_token_name(item) == Some("tab"))
             .and_then(Value::as_inline_table)
             .unwrap();
-        assert_eq!(tab.get("fg").and_then(Value::as_str), Some(TEXT_COLOR));
+        assert!(!tab.contains_key("fg"));
         assert_eq!(tab.get("bold").and_then(Value::as_bool), Some(true));
         assert_eq!(tab.get("dim").and_then(Value::as_bool), Some(false));
     }

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -184,14 +184,14 @@ fn default_herdr_rows_become_plane_provider_usage_and_topic_lines() {
     assert!(applied.contains("$quota_topic"));
     assert!(applied.contains("$quota_context"));
     assert!(applied.contains("$quota_provider_model"));
-    assert!(applied.contains("fg = \"#969eae\""));
+    assert!(!applied.contains("fg = \"#969eae\""));
     assert!(applied.find("$quota_provider_model").unwrap() < applied.find("$quota_topic").unwrap());
     assert!(applied.contains("$quota_cache"));
     assert!(applied.contains("$quota_cache_ttl"));
     assert!(applied.contains("$quota_cache_state"));
     assert!(!applied.contains("$quota_5h_label"));
     assert!(!applied.contains("$quota_5h_eta"));
-    assert!(applied.contains("fg = \"#969eae\""));
+    assert!(!applied.contains("fg = \"#c8cdd6\""));
     assert!(applied.contains("row_gap = 1 # herdr-agent-quota"));
     assert!(applied.find("$quota_topic").unwrap() < applied.find("$quota_5h_normal").unwrap());
     assert!(applied.contains("fg = \"#82d978\""));
@@ -199,7 +199,7 @@ fn default_herdr_rows_become_plane_provider_usage_and_topic_lines() {
     assert!(!applied.contains("fg = \"#c6d768\""));
     assert!(!applied.contains("fg = \"#e2bd58\""));
     assert!(applied.contains("fg = \"#f16f7e\""));
-    assert!(applied.contains("fg = \"#eceef2\""));
+    assert!(!applied.contains("fg = \"#eceef2\""));
     assert!(!applied.contains("selection_bg"));
     assert!(!applied.contains("active_row_bg"));
     assert!(applied.contains("[ui.sidebar.agents.rows_by_agent]"));
@@ -209,6 +209,45 @@ fn default_herdr_rows_become_plane_provider_usage_and_topic_lines() {
     assert!(applied.contains("fg = \"#8ab4f8\""));
     assert!(applied.contains("fg = \"#bba3e8\""));
     assert!(applied.contains("fg = \"#d4a0c8\""));
+}
+
+#[test]
+fn non_semantic_text_inherits_the_active_herdr_theme() {
+    let applied = add_quota_row(concat!(
+        "[theme]\n",
+        "name = \"one-light\"\n\n",
+        "[ui.sidebar.agents]\n",
+        "rows = [[\"state_icon\", \"tab\", \"agent\"]]\n",
+    ))
+    .unwrap();
+    let document = applied.parse::<toml_edit::DocumentMut>().unwrap();
+    let rows = document["ui"]["sidebar"]["agents"]["rows"]
+        .as_array()
+        .unwrap();
+    let inherited = [
+        "tab",
+        "$quota_topic",
+        "$quota_cache",
+        "$quota_cache_ttl",
+        "$quota_context",
+        "$quota_5h_unknown",
+        "$quota_week_unknown",
+        "$quota_week_inline_unknown",
+    ];
+
+    for token in inherited {
+        let style = rows
+            .iter()
+            .filter_map(toml_edit::Value::as_array)
+            .flat_map(|row| row.iter())
+            .find(|item| configured_token(item) == Some(token))
+            .and_then(toml_edit::Value::as_inline_table)
+            .unwrap_or_else(|| panic!("missing styled token {token}"));
+        assert!(
+            !style.contains_key("fg"),
+            "{token} must inherit Herdr's foreground: {style}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- let tab names, topics, cache details, context, and unknown quota states inherit Herdr's active foreground color
- keep provider brand hues and quota severity colors plugin-owned because they carry semantic meaning
- add a one-light regression test that rejects explicit foreground colors on theme-owned text

## Tests

- `cargo test --all-targets --all-features --locked`
- `cargo clippy --release --all-targets --all-features --locked -- -D warnings`
- `cargo build --release --locked`
- `cargo fmt --all -- --check`