### PR TITLE
fix: skip omp in configure when it is not installed

### DIFF
--- a/src/configure/integration.rs
+++ b/src/configure/integration.rs
@@ -49,7 +49,11 @@ pub fn report_missing(agents: &[Harness]) {
 /// Install the omp integration when omp is selected and Herdr explicitly says
 /// it is absent. A missing `herdr` binary or an unrecognized status format is
 /// not guessed at; the existing advisory remains the fallback.
-pub fn ensure_omp(agents: &[Harness]) -> Result<()> {
+///
+/// `full_selection` is the every-agent default a Herdr plugin action always
+/// runs with. There, a machine without omp skips the omp collector and keeps
+/// configuring the others; only an explicit omp selection fails.
+pub fn ensure_omp(agents: &[Harness], full_selection: bool) -> Result<()> {
     let Some(status) = read_status() else {
         return Ok(());
     };
@@ -62,10 +66,20 @@ pub fn ensure_omp(agents: &[Harness]) -> Result<()> {
         .output()?;
     if !output.status.success() {
         let detail = String::from_utf8_lossy(&output.stderr);
-        bail!("install Herdr omp integration: {}", detail.trim());
+        return omp_install_failed(full_selection, detail.trim());
     }
     println!("Installed Herdr's omp integration. Restart already-running omp panes once.");
     Ok(())
+}
+
+fn omp_install_failed(full_selection: bool, detail: &str) -> Result<()> {
+    if full_selection {
+        println!(
+            "Skipped omp: {detail}. Once omp is installed, select it in the settings pane or run configure with --agent omp."
+        );
+        return Ok(());
+    }
+    bail!("install Herdr omp integration: {detail}");
 }
 
 fn needs_omp_install(agents: &[Harness], status: &str) -> bool {
@@ -131,6 +145,19 @@ grok: outdated (v0) (/home/u/.grok/hooks/herdr-agent-state.sh)
         assert_eq!(integration_id(Harness::OpenCode), Some("opencode"));
         assert_eq!(integration_id(Harness::Pi), Some("pi"));
         assert_eq!(integration_id(Harness::Omp), Some("omp"));
+    }
+
+    /// The marketplace `configure` action runs a fixed command line, so it
+    /// always selects every supported agent. A machine without omp must still
+    /// get its other collectors instead of a hard failure.
+    #[test]
+    fn a_failed_omp_install_only_aborts_an_explicit_omp_selection() {
+        let detail =
+            "omp extension directory not found at /home/u/.omp/agent/extensions. install omp first";
+        assert!(omp_install_failed(true, detail).is_ok());
+        let explicit =
+            omp_install_failed(false, detail).expect_err("explicit omp must fail loudly");
+        assert!(explicit.to_string().contains(detail), "{explicit}");
     }
 
     #[test]

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -82,7 +82,7 @@ pub fn run(
             }
         }
     } else if apply {
-        integration::ensure_omp(agents)?;
+        integration::ensure_omp(agents, full)?;
         let cache = CacheStore::from_env()?;
         cache.clear_turn_watcher_stop()?;
         let interval = options


### PR DESCRIPTION
## Problem

The `herdr-agent-quota.configure` plugin action runs a fixed command line, so `configure --apply` always resolves to every supported agent. On a machine without omp, `integration::ensure_omp` runs `herdr integration install omp`, which fails, and the `?` aborts the whole apply before any sidebar row or collector is written.

Observed on macOS, Herdr 0.8.2, plugin 1.3.0 installed via `herdr plugin install levi-qiao/herdr-agent-quota`:

```
$ herdr plugin action invoke configure --plugin herdr-agent-quota
Error: install Herdr omp integration: omp extension directory not found at /Users/…/.omp/agent/extensions. install omp first
```

Since the agent selection is only persisted by the settings pane, the primary configure action is unusable for a fresh marketplace install unless the user first opens the settings pane and deselects omp.

## Change

`ensure_omp` takes the `full` flag that `configure::run` already computes. With the every-agent default, a failed omp install prints a skip notice and configuring continues for the remaining agents. An explicit narrower selection that includes omp still fails loudly, so nobody who asked for omp gets a silent skip.

## Verification

- New unit test `a_failed_omp_install_only_aborts_an_explicit_omp_selection`, written first and failing before the change.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-targets --all-features --locked` all pass locally.
