### PR TITLE
fix: keep custom sidebar rows intact and stop faking Devin session models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   from `~/.local/share/devin/credentials.toml` (or `$DEVIN_CREDENTIALS_FILE`).
   Daily and weekly remaining percentages are flipped to used. The active model
   comes from `~/.config/devin/config.json` when present, otherwise the API
-  `planInfo.planName`. Snapshots are stamped with `sha256("devin\0" || key)`
+  `planInfo.planName`. That name is the CLI's current default, not per-session
+  evidence, so it is published as `snapshot.model` rather than `session_models`.
+  Snapshots are stamped with `sha256("devin\0" || key)`
   so a credential swap cannot keep the previous account's last-good value.
   The API key is never logged, stored, or included in error messages.
 - `configure --apply` rewrites the shared `ui.sidebar.agents.rows` array only
@@ -31,6 +33,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `configure` no longer runs `normalize_official_row` when generating
+  `rows_by_agent` from user-owned shared rows, so tokens such as `pane` and
+  `terminal_title_stripped` stay intact. With brand colors off, those custom
+  shared rows still get plugin-managed per-agent quota rows — only the brand
+  hue is omitted. Default Herdr rows are unchanged: brand off still writes no
+  `rows_by_agent` copies.
+- `configure` prints which user-owned `rows_by_agent` entries it left alone,
+  instead of succeeding silently without installing quota for those agents.
 - Sidebar tab names, topics, cache details, context, and unknown quota states
   now inherit Herdr's active theme instead of using text colors tuned for a
   dark background. Provider brand hues and quota severity colors remain

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 
 | Dimension | Source and behavior |
 | --- | --- |
-| Provider / model | Exact route and active model for the pane's session. Devin CLI uses the active model from `~/.config/devin/config.json` (or `$XDG_CONFIG_HOME/devin/config.json`) and falls back to the quota API's `planInfo.planName` when unavailable. |
+| Provider / model | Exact route and active model for the pane's session. Devin uses the CLI's configured active model when available, with `planInfo.planName` as a fallback. Session-specific model attribution is only used when session-level evidence is available. |
 | Topic | Current visible user prompt; the previous topic survives when it scrolls away. |
 | Context | Used percentage of the active model's context window. |
 | Cache | Session cache hit rate when the agent exposes trustworthy counters. |
@@ -115,7 +115,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 | OpenCode | OpenCode Go 5h + 7d; 30d in dashboard | exact local session model/context |
 | Pi | Canonical Codex quota on an exact account match | model, context, cache, supported TTL data |
 | omp (oh-my-pi) | OMP-normalized windows such as `5h`, `1d`, `7d`, `Monthly` | model, context, cache, supported TTL data |
-| Devin CLI | 1d + 7d | active model from `~/.config/devin/config.json`, falling back to the API `planInfo.planName` (e.g. `Pro`) |
+| Devin CLI | 1d + 7d | CLI configured active model from `~/.config/devin/config.json`, falling back to the API `planInfo.planName` (e.g. `Pro`). Not per-session unless session evidence exists. |
 
 OMP is a generic adapter, not a second set of provider adapters. The plugin runs
 `omp usage --json --provider <id>`, retains OMP's window labels, and attributes

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,7 +94,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 
 | 维度 | 来源与行为 |
 | --- | --- |
-| 供应商 / 模型 | 当前 pane 精确 session 的路由和模型。Devin CLI 优先读 `~/.config/devin/config.json`（或 `$XDG_CONFIG_HOME/devin/config.json`）里的当前模型，缺失时回退到额度 API 的 `planInfo.planName`。 |
+| 供应商 / 模型 | 当前 pane 精确 session 的路由和模型。Devin 在有 CLI 当前配置模型时使用它，否则回退到额度 API 的 `planInfo.planName`。只有拿到 session 级证据时才按 session 归属模型。 |
 | Topic | 当前可见的用户问题；滚出屏幕后保留已发布主题。 |
 | Context | 当前模型上下文窗口的已用比例。 |
 | Cache | 上游提供可信计数时显示 session 缓存命中率。 |
@@ -111,7 +111,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 | OpenCode | OpenCode Go 5h + 7d；dashboard 含 30d | 精确本地 session 的 model/context |
 | Pi | 只有账户精确匹配时复用规范 Codex 额度 | model、context、cache、可支持的 TTL |
 | omp（oh-my-pi） | 原样展示 `omp usage` 归一化窗口，如 `5h`、`1d`、`7d`、`Monthly` | model、context、cache、可支持的 TTL |
-| Devin CLI | 1d + 7d | 当前模型来自 `~/.config/devin/config.json`，否则回退到 API `planInfo.planName`（例如 `Pro`） |
+| Devin CLI | 1d + 7d | CLI 当前配置模型来自 `~/.config/devin/config.json`，否则回退到 API `planInfo.planName`（例如 `Pro`）。没有 session 级证据时不按 session 归属 |
 
 OMP 是通用适配，不为内部每个供应商维护第二套规则。插件只调用
 `omp usage --json --provider <id>`，保留 OMP 给出的窗口标签，再用 session 的

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -99,7 +99,8 @@ pub fn check(
 ) -> Result<()> {
     let path = config_path()?;
     let original = fs::read_to_string(&path).unwrap_or_default();
-    let updated = add_quota_row_with(&original, agents, layout, row_gap, fields, brand)?;
+    let (updated, skipped) =
+        rewrite_quota_sidebar(&original, agents, layout, row_gap, fields, brand)?;
     if updated == original {
         println!(
             "Herdr sidebar already contains quota tokens: {}",
@@ -112,6 +113,9 @@ pub fn check(
             path.display()
         );
         print_diff_hint(layout, fields, brand);
+    }
+    if let Some(line) = skipped_provider_notice(&skipped) {
+        println!("{line}");
     }
     Ok(())
 }
@@ -126,7 +130,11 @@ pub fn apply(
     let path = config_path()?;
     let existed = path.exists();
     let original = fs::read_to_string(&path).unwrap_or_default();
-    let updated = add_quota_row_with(&original, agents, layout, row_gap, fields, brand)?;
+    let (updated, skipped) =
+        rewrite_quota_sidebar(&original, agents, layout, row_gap, fields, brand)?;
+    if let Some(line) = skipped_provider_notice(&skipped) {
+        println!("{line}");
+    }
     if updated == original {
         return Ok(());
     }
@@ -315,6 +323,17 @@ pub fn add_quota_row_with(
     fields: FieldSet,
     brand: BrandColors,
 ) -> Result<String> {
+    Ok(rewrite_quota_sidebar(input, agents, layout, row_gap, fields, brand)?.0)
+}
+
+fn rewrite_quota_sidebar(
+    input: &str,
+    agents: &[Harness],
+    layout: SidebarLayout,
+    row_gap: SidebarRowGap,
+    fields: FieldSet,
+    brand: BrandColors,
+) -> Result<(String, Vec<&'static str>)> {
     let mut document = if input.trim().is_empty() {
         DocumentMut::new()
     } else {
@@ -352,15 +371,24 @@ pub fn add_quota_row_with(
         .and_then(Item::as_value)
         .is_some_and(has_rows_marker);
     let rows_safe = rows_managed || original_rows.is_none_or(is_safe_to_take_over);
-    let managed_rows = build_managed_rows(original_rows, layout, fields)?;
-    if brand.is_on() {
-        add_provider_rows(table, &managed_rows, agents)?;
+    let managed_rows = build_managed_rows(
+        original_rows,
+        layout,
+        fields,
+        if rows_safe {
+            RowRewrite::Takeover
+        } else {
+            RowRewrite::Preserve
+        },
+    )?;
+    let skipped = if !rows_safe || brand.is_on() {
+        add_provider_rows(table, &managed_rows, agents, brand.is_on())?
     } else {
-        // Without brand hues a per-agent row set would be identical to the
-        // shared one, so the plugin removes its own entries rather than
-        // writing copies Herdr would have to keep in sync.
+        // Shared rows already carry quota. Per-agent copies would be identical
+        // without brand hues, so the plugin removes its own entries.
         remove_managed_provider_rows(table, agents);
-    }
+        Vec::new()
+    };
     if rows_safe {
         let mut rows_value = Value::Array(managed_rows);
         rows_value
@@ -369,18 +397,28 @@ pub fn add_quota_row_with(
         table.insert("rows", Item::Value(rows_value));
     }
     remove_managed_selection_theme(&mut document);
-    Ok(document.to_string())
+    Ok((document.to_string(), skipped))
+}
+
+#[derive(Clone, Copy)]
+enum RowRewrite {
+    Takeover,
+    Preserve,
 }
 
 fn build_managed_rows(
     original: Option<&Array>,
     layout: SidebarLayout,
     fields: FieldSet,
+    rewrite: RowRewrite,
 ) -> Result<Array> {
     let mut updated_rows = Array::new();
     if let Some(rows) = original {
         for row in rows.iter() {
-            let cleaned = normalize_official_row(strip_quota_tokens(row, true));
+            let cleaned = match rewrite {
+                RowRewrite::Takeover => normalize_official_row(strip_quota_tokens(row, true)),
+                RowRewrite::Preserve => strip_quota_tokens(row, false),
+            };
             if !cleaned.is_empty() {
                 updated_rows.push(Value::Array(cleaned));
             }
@@ -389,10 +427,10 @@ fn build_managed_rows(
 
     // If an older version replaced every row with quota-only rows, restore
     // Herdr's official state/tab row before adding provider, usage, and topic.
-    if updated_rows.is_empty() {
+    if updated_rows.is_empty() && matches!(rewrite, RowRewrite::Takeover) {
         updated_rows.push(Value::Array(default_state_row()));
     }
-    append_quota_rows(&mut updated_rows, layout);
+    append_quota_rows(&mut updated_rows, layout, rewrite);
     retain_selected_fields(&mut updated_rows, fields);
     Ok(updated_rows)
 }
@@ -598,28 +636,36 @@ fn configured_token_name(value: &Value) -> Option<&str> {
     })
 }
 
-fn add_provider_rows(table: &mut Table, rows: &Array, agents: &[Harness]) -> Result<()> {
+fn add_provider_rows(
+    table: &mut Table,
+    rows: &Array,
+    agents: &[Harness],
+    color: bool,
+) -> Result<Vec<&'static str>> {
     let rows_by_agent = table
         .entry("rows_by_agent")
         .or_insert(Item::Table(Table::new()))
         .as_table_mut()
         .context("Herdr ui.sidebar.agents.rows_by_agent must be a table")?;
 
+    let mut skipped = Vec::new();
     for (provider, brand, dim) in selected_styles(agents) {
         let is_managed = rows_by_agent
             .get(provider)
             .and_then(Item::as_value)
             .is_some_and(has_provider_style_marker);
         if rows_by_agent.contains_key(provider) && !is_managed {
+            skipped.push(provider);
             continue;
         }
+        let (brand, dim) = if color { (brand, dim) } else { (None, None) };
         let mut value = Value::Array(provider_rows(rows, brand, dim));
         value
             .decor_mut()
             .set_suffix(format!(" # {PROVIDER_STYLE_MARKER}"));
         rows_by_agent.insert(provider, Item::Value(value));
     }
-    Ok(())
+    Ok(skipped)
 }
 
 fn provider_rows(rows: &Array, brand: Option<&str>, dim: Option<&str>) -> Array {
@@ -739,7 +785,7 @@ fn normalize_official_row(row: Array) -> Array {
     normalized
 }
 
-fn append_quota_rows(rows: &mut Array, layout: SidebarLayout) {
+fn append_quota_rows(rows: &mut Array, layout: SidebarLayout, rewrite: RowRewrite) {
     // Context can carry the weekly token when 5h is empty. Limits stay on the
     // next row so a present 5h window never shares a line with context. Herdr
     // drops empty tokens and empty rows. Stacked keeps that publish rule and
@@ -761,8 +807,9 @@ fn append_quota_rows(rows: &mut Array, layout: SidebarLayout) {
                 continue;
             }
             match item.as_str() {
-                Some("terminal_title_stripped") | Some("$quota_topic") => {}
-                Some("agent") if !has_state_icon => {}
+                Some("terminal_title_stripped") if matches!(rewrite, RowRewrite::Takeover) => {}
+                Some("$quota_topic") => {}
+                Some("agent") if !has_state_icon && matches!(rewrite, RowRewrite::Takeover) => {}
                 _ => cleaned.push(item.clone()),
             }
         }
@@ -784,9 +831,11 @@ fn append_quota_rows(rows: &mut Array, layout: SidebarLayout) {
 
     if let Some(index) = official_index {
         if let Some(row) = rows.get_mut(index).and_then(Value::as_array_mut) {
-            *row = match layout {
-                SidebarLayout::Packed => packed_identity_row(row),
-                SidebarLayout::Stacked => stacked_identity_row(row),
+            *row = match (rewrite, layout) {
+                (RowRewrite::Preserve, SidebarLayout::Packed) => preserve_identity_row(row),
+                (RowRewrite::Preserve, SidebarLayout::Stacked) => row.clone(),
+                (RowRewrite::Takeover, SidebarLayout::Packed) => packed_identity_row(row),
+                (RowRewrite::Takeover, SidebarLayout::Stacked) => stacked_identity_row(row),
             };
         }
     }
@@ -814,6 +863,30 @@ fn append_quota_rows(rows: &mut Array, layout: SidebarLayout) {
         SidebarLayout::Packed => append_packed_quota_rows(rows),
         SidebarLayout::Stacked => append_stacked_quota_rows(rows),
     }
+}
+
+fn preserve_identity_row(row: &Array) -> Array {
+    let mut kept = Array::new();
+    let mut has_provider_model = false;
+    for item in row.iter() {
+        if configured_token_name(item) == Some("$quota_provider_model") {
+            if !has_provider_model {
+                kept.push(item.clone());
+                has_provider_model = true;
+            }
+        } else {
+            kept.push(item.clone());
+        }
+    }
+    if !has_provider_model {
+        kept.push(styled_token(
+            "$quota_provider_model",
+            None,
+            Some(true),
+            Some(false),
+        ));
+    }
+    kept
 }
 
 fn packed_identity_row(row: &Array) -> Array {
@@ -1071,6 +1144,39 @@ fn styled_token(token: &str, fg: Option<&str>, bold: Option<bool>, dim: Option<b
         value.insert("dim", Value::from(dim));
     }
     Value::InlineTable(value)
+}
+
+fn skipped_provider_notice(providers: &[&str]) -> Option<String> {
+    if providers.is_empty() {
+        return None;
+    }
+    let keys = providers
+        .iter()
+        .map(|name| format!("rows_by_agent.{name}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let labels = providers
+        .iter()
+        .map(|name| skipped_provider_label(name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!(
+        "Preserved user-owned {keys}; quota rows were not installed for {labels}."
+    ))
+}
+
+fn skipped_provider_label(provider: &str) -> &str {
+    match provider {
+        "claude" => "Claude",
+        "codex" => "Codex",
+        "grok" => "Grok",
+        "agy" => "Agy",
+        "opencode" => "OpenCode",
+        "pi" => "Pi",
+        "omp" => "OMP",
+        "devin" => "Devin",
+        other => other,
+    }
 }
 
 fn print_diff_hint(layout: SidebarLayout, fields: FieldSet, brand: BrandColors) {
@@ -1430,6 +1536,17 @@ claude = [["state_icon", "agent"]]
         assert!(updated.contains("claude = [[\"state_icon\", \"agent\"]]"));
         assert!(updated.contains("codex ="));
         assert!(updated.contains("opencode ="));
+        let skipped = rewrite_quota_sidebar(
+            original,
+            &AgentSelection::SUPPORTED,
+            SidebarLayout::Packed,
+            SidebarRowGap::default(),
+            FieldSet::all(),
+            BrandColors::On,
+        )
+        .unwrap()
+        .1;
+        assert_eq!(skipped, ["claude"]);
         let removed = remove_quota_row(&updated).unwrap();
         assert!(removed.contains("claude = [[\"state_icon\", \"agent\"]]"));
         assert!(!removed.contains("codex ="));
@@ -1664,6 +1781,160 @@ rows = [["lantern_status"], ["state_icon", "my_plugin_token"]]
         assert!(updated.contains(REFRESH_ACTION));
     }
 
+    fn custom_shared_rows() -> &'static str {
+        "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"pane\", \"terminal_title_stripped\"]]\n"
+    }
+
+    fn shared_row_names(toml: &str) -> Vec<String> {
+        let document = toml.parse::<DocumentMut>().unwrap();
+        let rows = document["ui"]["sidebar"]["agents"]["rows"]
+            .as_array()
+            .unwrap();
+        assert_eq!(rows.len(), 1, "{toml}");
+        token_names(rows.get(0).unwrap())
+    }
+
+    fn token_names(row: &Value) -> Vec<String> {
+        row.as_array()
+            .unwrap()
+            .iter()
+            .filter_map(configured_token_name)
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn provider_token_names(toml: &str, provider: &str) -> Vec<String> {
+        let document = toml.parse::<DocumentMut>().unwrap();
+        let rows = document["ui"]["sidebar"]["agents"]["rows_by_agent"][provider]
+            .as_array()
+            .expect(provider);
+        rows.iter().flat_map(token_names).collect()
+    }
+
+    fn provider_fg_colors(toml: &str, provider: &str) -> Vec<String> {
+        let document = toml.parse::<DocumentMut>().unwrap();
+        let rows = document["ui"]["sidebar"]["agents"]["rows_by_agent"][provider]
+            .as_array()
+            .expect(provider);
+        rows.iter()
+            .filter_map(Value::as_array)
+            .flat_map(|row| row.iter())
+            .filter_map(|item| {
+                item.as_inline_table()
+                    .and_then(|table| table.get("fg"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn custom_rows_with_brand_on_preserve_all_user_tokens_in_provider_rows() {
+        let updated = add_quota_row(custom_shared_rows()).unwrap();
+        assert_eq!(
+            shared_row_names(&updated),
+            ["state_icon", "pane", "terminal_title_stripped"]
+        );
+        let document = updated.parse::<DocumentMut>().unwrap();
+        let rows_value = document["ui"]["sidebar"]["agents"]["rows"]
+            .as_value()
+            .unwrap();
+        assert!(!has_rows_marker(rows_value), "{updated}");
+        let claude = provider_token_names(&updated, "claude");
+        for token in ["state_icon", "pane", "terminal_title_stripped"] {
+            assert!(
+                claude.iter().any(|name| name == token),
+                "{token} missing: {claude:?}\n{updated}"
+            );
+        }
+        assert!(
+            claude.iter().any(|name| name.starts_with("$quota_")),
+            "quota missing: {claude:?}\n{updated}"
+        );
+    }
+
+    #[test]
+    fn custom_rows_with_brand_off_still_render_quota_in_provider_rows() {
+        let updated = add_quota_row_with(
+            custom_shared_rows(),
+            &AgentSelection::SUPPORTED,
+            SidebarLayout::Packed,
+            SidebarRowGap::default(),
+            FieldSet::all(),
+            BrandColors::Off,
+        )
+        .unwrap();
+        assert_eq!(
+            shared_row_names(&updated),
+            ["state_icon", "pane", "terminal_title_stripped"]
+        );
+        let claude = provider_token_names(&updated, "claude");
+        for token in ["state_icon", "pane", "terminal_title_stripped"] {
+            assert!(
+                claude.iter().any(|name| name == token),
+                "{token} missing: {claude:?}\n{updated}"
+            );
+        }
+        assert!(
+            claude.iter().any(|name| name.starts_with("$quota_")),
+            "quota missing: {claude:?}\n{updated}"
+        );
+        assert!(
+            updated.contains("claude ="),
+            "provider rows missing:\n{updated}"
+        );
+        let claude_fgs = provider_fg_colors(&updated, "claude");
+        assert!(
+            !claude_fgs.iter().any(|fg| fg == "#e88461"),
+            "brand hue survived brand-off: {claude_fgs:?}\n{updated}"
+        );
+    }
+
+    #[test]
+    fn custom_rows_reapply_is_idempotent() {
+        let once = add_quota_row(custom_shared_rows()).unwrap();
+        let twice = add_quota_row(&once).unwrap();
+        assert_eq!(once, twice);
+        let off = add_quota_row_with(
+            custom_shared_rows(),
+            &AgentSelection::SUPPORTED,
+            SidebarLayout::Packed,
+            SidebarRowGap::default(),
+            FieldSet::all(),
+            BrandColors::Off,
+        )
+        .unwrap();
+        let off_again = add_quota_row_with(
+            &off,
+            &AgentSelection::SUPPORTED,
+            SidebarLayout::Packed,
+            SidebarRowGap::default(),
+            FieldSet::all(),
+            BrandColors::Off,
+        )
+        .unwrap();
+        assert_eq!(off, off_again);
+    }
+
+    #[test]
+    fn skipped_provider_notice_names_each_preserved_row() {
+        assert_eq!(
+            skipped_provider_notice(&["claude"]),
+            Some(
+                "Preserved user-owned rows_by_agent.claude; quota rows were not installed for Claude."
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            skipped_provider_notice(&["claude", "codex"]),
+            Some(
+                "Preserved user-owned rows_by_agent.claude, rows_by_agent.codex; quota rows were not installed for Claude, Codex."
+                    .to_string()
+            )
+        );
+        assert_eq!(skipped_provider_notice(&[]), None);
+    }
+
     #[test]
     fn idempotent_reapply_does_not_grow_rows() {
         let original = "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n";
@@ -1774,8 +2045,8 @@ mod field_tests {
         }
     }
 
-    /// Without brand hues the per-agent rows would duplicate the shared ones,
-    /// so the plugin writes none at all.
+    /// Without brand hues, plugin-managed shared rows already carry quota, so
+    /// per-agent copies would be identical and are omitted.
     #[test]
     fn brand_colours_off_writes_no_per_agent_rows() {
         let plain = applied(FieldSet::all(), BrandColors::Off);

--- a/src/providers/devin.rs
+++ b/src/providers/devin.rs
@@ -62,9 +62,8 @@ impl std::fmt::Debug for DevinCredentials {
     }
 }
 
-/// Fetch Devin CLI's quota and attribute the global active model to each
-/// requested session. Panes without a session id still fall back to
-/// `snapshot.model`.
+/// Fetch Devin CLI's quota. The CLI config's active model is process-global,
+/// so it is published as `snapshot.model`, not as per-session evidence.
 pub fn fetch_for_sessions(session_ids: &[String]) -> Result<ProviderSnapshot> {
     let path = auth_path().context("resolve Devin credentials path")?;
     let credentials = read_credentials(&path).map_err(anyhow::Error::from)?;
@@ -96,17 +95,21 @@ pub fn fetch_for_sessions(session_ids: &[String]) -> Result<ProviderSnapshot> {
         .context("decode Devin GetUserStatus response")?;
     let mut snapshot = parse_user_status(&value, active_model.as_deref(), CacheStore::now_unix())
         .map_err(anyhow::Error::from)?;
-    // Devin CLI's active model is global (from config.json), so attribute it to
-    // every requested session. Panes without a session id still fall back to
-    // snapshot.model.
-    if let Some(model) = active_model {
-        for session_id in session_ids {
-            snapshot
-                .session_models
-                .insert(session_id.clone(), model.clone());
-        }
-    }
+    apply_configured_model(&mut snapshot, active_model, session_ids);
     Ok(snapshot.with_account_id(Some(account_id)))
+}
+
+/// `config.json` names the CLI's current default model, not each session's
+/// model. Until a Devin session file exposes per-session evidence, keep that
+/// name on `snapshot.model` and leave `session_models` empty.
+fn apply_configured_model(
+    snapshot: &mut ProviderSnapshot,
+    active_model: Option<String>,
+    _session_ids: &[String],
+) {
+    if let Some(model) = active_model {
+        snapshot.model = Some(model);
+    }
 }
 
 /// Resolve the credentials file path.
@@ -376,6 +379,18 @@ mod tests {
         let snapshot =
             parse_user_status(&pro_fixture(), Some("swe-1-7-medium"), 1).expect("snapshot");
         assert_eq!(snapshot.model.as_deref(), Some("swe-1-7-medium"));
+    }
+
+    #[test]
+    fn devin_global_model_is_not_written_as_session_model() {
+        let mut snapshot = parse_user_status(&pro_fixture(), None, 1).expect("snapshot");
+        apply_configured_model(
+            &mut snapshot,
+            Some("swe-1-7-medium".to_string()),
+            &["session-a".to_string(), "session-b".to_string()],
+        );
+        assert_eq!(snapshot.model.as_deref(), Some("swe-1-7-medium"));
+        assert!(snapshot.session_models.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What this changes

`configure` no longer rewrites user-owned shared sidebar rows when generating `rows_by_agent`, keeps quota visible when brand colors are off, warns when a user-owned per-agent row is left alone, and publishes Devin's CLI active model as `snapshot.model` instead of pretending it is per-session evidence.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --release --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --all-targets --all-features --locked`
- [x] `cargo build --release --locked`
- [ ] A parser change comes with a fixture in `tests/fixtures/` and a test
- [x] No new network call, background process, or credential write

## Provider impact

Devin only for model attribution: the CLI `config.json` active model (with `planName` fallback) stays on `snapshot.model`. Quota windows, account pin `sha256("devin\0" || key)`, and cache identity are unchanged. Other providers' refresh, cache, and account gating are untouched.

Sidebar configure still takes over default Herdr `state_icon` + `agent`/`tab` rows. User-owned shared rows are left unchanged; brand-off still writes plugin-managed provider rows in that case so quota does not disappear.


Made with [Cursor](https://cursor.com)