### PR TITLE
fix: keep Devin plan, default model, and session model distinct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and a sidebar row with a Devin brand color. Quota comes from the same
   Connect RPC `GetUserStatus` contract the Devin CLI uses, with the key read
   from `~/.local/share/devin/credentials.toml` (or `$DEVIN_CREDENTIALS_FILE`).
-  Daily and weekly remaining percentages are flipped to used. The active model
-  comes from `~/.config/devin/config.json` when present, otherwise the API
-  `planInfo.planName`. That name is the CLI's current default, not per-session
-  evidence, so it is published as `snapshot.model` rather than `session_models`.
+  Daily and weekly remaining percentages are flipped to used. The configured
+  default model comes from `~/.config/devin/config.json` `agent.model` when
+  present, then mapped through local `devin-models.json` for a display name.
+  That value is the CLI default, not a session's `/model` selection, so it is
+  published as `snapshot.model` rather than `session_models`. The API
+  `planInfo.planName` is the subscription plan and is not used as a model.
+  A missing or malformed models catalog leaves the raw id and does not fail
+  the quota fetch.
   Snapshots are stamped with `sha256("devin\0" || key)`
   so a credential swap cannot keep the previous account's last-good value.
   The API key is never logged, stored, or included in error messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   default model comes from `~/.config/devin/config.json` `agent.model` when
   present, then mapped through local `devin-models.json` for a display name.
   That value is the CLI default, not a session's `/model` selection, so it is
-  published as `snapshot.model` rather than `session_models`. The API
+  published as `snapshot.model` rather than `session_models`. A Devin pane
+  with a Herdr session id still displays that configured default until real
+  session-model evidence exists. The API
   `planInfo.planName` is the subscription plan and is not used as a model.
   A missing or malformed models catalog leaves the raw id and does not fail
   the quota fetch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Daily and weekly remaining percentages are flipped to used. The configured
   default model comes from `~/.config/devin/config.json` `agent.model` when
   present, then mapped through local `devin-models.json` for a display name.
-  That value is the CLI default, not a session's `/model` selection, so it is
-  published as `snapshot.model` rather than `session_models`. A Devin pane
-  with a Herdr session id still displays that configured default until real
-  session-model evidence exists. The API
+  New sessions that never run `/model` use this same value. It is published
+  as `snapshot.model` and shown on every Devin pane. The API
   `planInfo.planName` is the subscription plan and is not used as a model.
   A missing or malformed models catalog leaves the raw id and does not fail
   the quota fetch.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 | OpenCode | OpenCode Go 5h + 7d; 30d in dashboard | exact local session model/context |
 | Pi | Canonical Codex quota on an exact account match | model, context, cache, supported TTL data |
 | omp (oh-my-pi) | OMP-normalized windows such as `5h`, `1d`, `7d`, `Monthly` | model, context, cache, supported TTL data |
-| Devin CLI | 1d + 7d | CLI configured active model from `~/.config/devin/config.json`, falling back to the API `planInfo.planName` (e.g. `Pro`). Not per-session unless session evidence exists. |
+| Devin CLI | 1d + 7d | CLI configured/default model from `~/.config/devin/config.json` `agent.model`, mapped through local `devin-models.json` when present. Not a session model, and not the API `planName`. |
 
 OMP is a generic adapter, not a second set of provider adapters. The plugin runs
 `omp usage --json --provider <id>`, retains OMP's window labels, and attributes

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 
 | Dimension | Source and behavior |
 | --- | --- |
-| Provider / model | Exact route and active model for the pane's session. Devin has no verified per-session model file; Herdr's official session id is used for identity/resume, and the sidebar falls back to `config.json` `agent.model` (mapped through `devin-models.json` when present). |
+| Provider / model | Exact route and active model for the pane's session. Devin uses `config.json` `agent.model` for every pane, including a new session that never ran `/model`. |
 | Topic | Current visible user prompt; the previous topic survives when it scrolls away. |
 | Context | Used percentage of the active model's context window. |
 | Cache | Session cache hit rate when the agent exposes trustworthy counters. |
@@ -115,7 +115,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 | OpenCode | OpenCode Go 5h + 7d; 30d in dashboard | exact local session model/context |
 | Pi | Canonical Codex quota on an exact account match | model, context, cache, supported TTL data |
 | omp (oh-my-pi) | OMP-normalized windows such as `5h`, `1d`, `7d`, `Monthly` | model, context, cache, supported TTL data |
-| Devin CLI | 1d + 7d | CLI configured/default model from `~/.config/devin/config.json` `agent.model`, mapped through local `devin-models.json` when present. Herdr session ids are official; the configured default is the display fallback, not per-session evidence, and not the API `planName`. |
+| Devin CLI | 1d + 7d | Model from `~/.config/devin/config.json` `agent.model` (Issue #53), mapped through local `devin-models.json` when present. New sessions that never run `/model` use this default. Not the API `planName`. |
 
 OMP is a generic adapter, not a second set of provider adapters. The plugin runs
 `omp usage --json --provider <id>`, retains OMP's window labels, and attributes

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 
 | Dimension | Source and behavior |
 | --- | --- |
-| Provider / model | Exact route and active model for the pane's session. Devin uses the CLI's configured active model when available, with `planInfo.planName` as a fallback. Session-specific model attribution is only used when session-level evidence is available. |
+| Provider / model | Exact route and active model for the pane's session. Devin has no verified per-session model file; Herdr's official session id is used for identity/resume, and the sidebar falls back to `config.json` `agent.model` (mapped through `devin-models.json` when present). |
 | Topic | Current visible user prompt; the previous topic survives when it scrolls away. |
 | Context | Used percentage of the active model's context window. |
 | Cache | Session cache hit rate when the agent exposes trustworthy counters. |
@@ -115,7 +115,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 | OpenCode | OpenCode Go 5h + 7d; 30d in dashboard | exact local session model/context |
 | Pi | Canonical Codex quota on an exact account match | model, context, cache, supported TTL data |
 | omp (oh-my-pi) | OMP-normalized windows such as `5h`, `1d`, `7d`, `Monthly` | model, context, cache, supported TTL data |
-| Devin CLI | 1d + 7d | CLI configured/default model from `~/.config/devin/config.json` `agent.model`, mapped through local `devin-models.json` when present. Not a session model, and not the API `planName`. |
+| Devin CLI | 1d + 7d | CLI configured/default model from `~/.config/devin/config.json` `agent.model`, mapped through local `devin-models.json` when present. Herdr session ids are official; the configured default is the display fallback, not per-session evidence, and not the API `planName`. |
 
 OMP is a generic adapter, not a second set of provider adapters. The plugin runs
 `omp usage --json --provider <id>`, retains OMP's window labels, and attributes

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,7 +94,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 
 | 维度 | 来源与行为 |
 | --- | --- |
-| 供应商 / 模型 | 当前 pane 精确 session 的路由和模型。Devin 没有已验证的 session 模型文件；Herdr 官方 session id 只用于身份/恢复，侧栏兜底显示 `config.json` 的 `agent.model`（有 `devin-models.json` 时映射为显示名）。 |
+| 供应商 / 模型 | 当前 pane 精确 session 的路由和模型。Devin 每个 pane 都用 `config.json` 的 `agent.model`，包括从未执行 `/model` 的新 session。 |
 | Topic | 当前可见的用户问题；滚出屏幕后保留已发布主题。 |
 | Context | 当前模型上下文窗口的已用比例。 |
 | Cache | 上游提供可信计数时显示 session 缓存命中率。 |
@@ -111,7 +111,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 | OpenCode | OpenCode Go 5h + 7d；dashboard 含 30d | 精确本地 session 的 model/context |
 | Pi | 只有账户精确匹配时复用规范 Codex 额度 | model、context、cache、可支持的 TTL |
 | omp（oh-my-pi） | 原样展示 `omp usage` 归一化窗口，如 `5h`、`1d`、`7d`、`Monthly` | model、context、cache、可支持的 TTL |
-| Devin CLI | 1d + 7d | CLI 配置的默认模型来自 `~/.config/devin/config.json` 的 `agent.model`，若本地有 `devin-models.json` 则映射为显示名。Herdr 的 session id 是官方的；这个默认模型只作展示兜底，不是 session 证据，也不使用 API 的 `planName`。 |
+| Devin CLI | 1d + 7d | 模型来自 `~/.config/devin/config.json` 的 `agent.model`（Issue #53），有 `devin-models.json` 时映射为显示名。新 session 不切 `/model` 也用这个默认值。不使用 API 的 `planName`。 |
 
 OMP 是通用适配，不为内部每个供应商维护第二套规则。插件只调用
 `omp usage --json --provider <id>`，保留 OMP 给出的窗口标签，再用 session 的

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,7 +94,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 
 | 维度 | 来源与行为 |
 | --- | --- |
-| 供应商 / 模型 | 当前 pane 精确 session 的路由和模型。Devin 在有 CLI 当前配置模型时使用它，否则回退到额度 API 的 `planInfo.planName`。只有拿到 session 级证据时才按 session 归属模型。 |
+| 供应商 / 模型 | 当前 pane 精确 session 的路由和模型。Devin 没有已验证的 session 模型文件；Herdr 官方 session id 只用于身份/恢复，侧栏兜底显示 `config.json` 的 `agent.model`（有 `devin-models.json` 时映射为显示名）。 |
 | Topic | 当前可见的用户问题；滚出屏幕后保留已发布主题。 |
 | Context | 当前模型上下文窗口的已用比例。 |
 | Cache | 上游提供可信计数时显示 session 缓存命中率。 |
@@ -111,7 +111,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 | OpenCode | OpenCode Go 5h + 7d；dashboard 含 30d | 精确本地 session 的 model/context |
 | Pi | 只有账户精确匹配时复用规范 Codex 额度 | model、context、cache、可支持的 TTL |
 | omp（oh-my-pi） | 原样展示 `omp usage` 归一化窗口，如 `5h`、`1d`、`7d`、`Monthly` | model、context、cache、可支持的 TTL |
-| Devin CLI | 1d + 7d | CLI 配置的默认模型来自 `~/.config/devin/config.json` 的 `agent.model`，若本地有 `devin-models.json` 则映射为显示名。这不是 session 模型，也不会使用 API 的 `planName`。 |
+| Devin CLI | 1d + 7d | CLI 配置的默认模型来自 `~/.config/devin/config.json` 的 `agent.model`，若本地有 `devin-models.json` 则映射为显示名。Herdr 的 session id 是官方的；这个默认模型只作展示兜底，不是 session 证据，也不使用 API 的 `planName`。 |
 
 OMP 是通用适配，不为内部每个供应商维护第二套规则。插件只调用
 `omp usage --json --provider <id>`，保留 OMP 给出的窗口标签，再用 session 的

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -111,7 +111,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 | OpenCode | OpenCode Go 5h + 7d；dashboard 含 30d | 精确本地 session 的 model/context |
 | Pi | 只有账户精确匹配时复用规范 Codex 额度 | model、context、cache、可支持的 TTL |
 | omp（oh-my-pi） | 原样展示 `omp usage` 归一化窗口，如 `5h`、`1d`、`7d`、`Monthly` | model、context、cache、可支持的 TTL |
-| Devin CLI | 1d + 7d | CLI 当前配置模型来自 `~/.config/devin/config.json`，否则回退到 API `planInfo.planName`（例如 `Pro`）。没有 session 级证据时不按 session 归属 |
+| Devin CLI | 1d + 7d | CLI 配置的默认模型来自 `~/.config/devin/config.json` 的 `agent.model`，若本地有 `devin-models.json` 则映射为显示名。这不是 session 模型，也不会使用 API 的 `planName`。 |
 
 OMP 是通用适配，不为内部每个供应商维护第二套规则。插件只调用
 `omp usage --json --provider <id>`，保留 OMP 给出的窗口标签，再用 session 的

--- a/src/model.rs
+++ b/src/model.rs
@@ -557,9 +557,10 @@ pub struct ProviderSnapshot {
     ///
     /// StatusLine providers also keep the per-session value below so panes
     /// running the same provider can be distinguished from one another.
-    /// Devin stores the CLI configured/default model here (`agent.model`);
-    /// it is not a session's `/model` selection and is never copied into
-    /// `session_models`.
+    /// Devin stores the CLI configured/default model here (`agent.model`).
+    /// That is the only local model source we have verified; a pane with a
+    /// Herdr session id still uses it as a display fallback until real
+    /// session-model evidence exists. It is never copied into `session_models`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default)]
@@ -615,8 +616,15 @@ impl ProviderSnapshot {
         self
     }
 
-    /// Return the model for a pane's session. A known session never falls back
-    /// to provider-level data, because that value may belong to another pane.
+    /// Return the model for a pane's session.
+    ///
+    /// StatusLine and local-file providers never fall back to provider-level
+    /// data for a known session, because that value may belong to another pane.
+    /// Devin is the exception: `snapshot.model` is the CLI configured/default
+    /// from `config.json`, not "the last pane that reported". Herdr's official
+    /// Devin integration gives us a session id for resume, but we have no
+    /// verified per-session model file, so the configured default is the
+    /// display fallback until `session_models` has an exact hit.
     pub fn model_for_session(&self, session_id: Option<&str>) -> Option<&str> {
         let Some(session_id) = session_id else {
             return self.model.as_deref();
@@ -624,7 +632,10 @@ impl ProviderSnapshot {
         if let Some(model) = self.session_models.get(session_id) {
             return Some(model);
         }
-        None
+        match self.provider {
+            Provider::Devin => self.model.as_deref(),
+            _ => None,
+        }
     }
 
     /// Return context/cache diagnostics for a pane's session. A known session
@@ -1293,6 +1304,46 @@ mod tests {
         );
         current.merge_omitted_windows(&previous);
         assert!(current.window(WindowKind::FiveHour).is_none());
+    }
+
+    #[test]
+    fn claude_known_session_does_not_borrow_the_provider_model() {
+        let mut snapshot = ProviderSnapshot::new(Provider::Claude, vec![], 0)
+            .with_model(Some("latest".to_string()));
+        snapshot
+            .session_models
+            .insert("session-1".to_string(), "Sonnet".to_string());
+        assert_eq!(
+            snapshot.model_for_session(Some("session-1")),
+            Some("Sonnet")
+        );
+        assert_eq!(snapshot.model_for_session(Some("session-2")), None);
+        assert_eq!(snapshot.model_for_session(None), Some("latest"));
+    }
+
+    #[test]
+    fn devin_known_session_falls_back_to_configured_default() {
+        let mut snapshot = ProviderSnapshot::new(Provider::Devin, vec![], 0)
+            .with_model(Some("SWE-1.7 Medium".to_string()));
+        assert_eq!(
+            snapshot.model_for_session(Some("session-a")),
+            Some("SWE-1.7 Medium")
+        );
+        assert_eq!(
+            snapshot.model_for_session(Some("session-b")),
+            Some("SWE-1.7 Medium")
+        );
+        snapshot
+            .session_models
+            .insert("session-a".to_string(), "Opus 4.6".to_string());
+        assert_eq!(
+            snapshot.model_for_session(Some("session-a")),
+            Some("Opus 4.6")
+        );
+        assert_eq!(
+            snapshot.model_for_session(Some("session-b")),
+            Some("SWE-1.7 Medium")
+        );
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -557,10 +557,8 @@ pub struct ProviderSnapshot {
     ///
     /// StatusLine providers also keep the per-session value below so panes
     /// running the same provider can be distinguished from one another.
-    /// Devin stores the CLI configured/default model here (`agent.model`).
-    /// That is the only local model source we have verified; a pane with a
-    /// Herdr session id still uses it as a display fallback until real
-    /// session-model evidence exists. It is never copied into `session_models`.
+    /// Devin stores the CLI `config.json` model here. Panes read it through
+    /// [`Self::model_for_session`] when they have no per-session entry.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default)]
@@ -618,13 +616,11 @@ impl ProviderSnapshot {
 
     /// Return the model for a pane's session.
     ///
-    /// StatusLine and local-file providers never fall back to provider-level
-    /// data for a known session, because that value may belong to another pane.
-    /// Devin is the exception: `snapshot.model` is the CLI configured/default
-    /// from `config.json`, not "the last pane that reported". Herdr's official
-    /// Devin integration gives us a session id for resume, but we have no
-    /// verified per-session model file, so the configured default is the
-    /// display fallback until `session_models` has an exact hit.
+    /// A known Claude/Agy/Codex/Grok session never borrows the provider-level
+    /// value, because that may belong to another pane. Devin's `snapshot.model`
+    /// is the CLI `config.json` default, so a pane without a `session_models`
+    /// entry still shows it — including a brand-new session that never ran
+    /// `/model`.
     pub fn model_for_session(&self, session_id: Option<&str>) -> Option<&str> {
         let Some(session_id) = session_id else {
             return self.model.as_deref();
@@ -1322,9 +1318,10 @@ mod tests {
     }
 
     #[test]
-    fn devin_known_session_falls_back_to_configured_default() {
+    fn devin_new_session_without_model_switch_uses_config_default() {
         let mut snapshot = ProviderSnapshot::new(Provider::Devin, vec![], 0)
             .with_model(Some("SWE-1.7 Medium".to_string()));
+        // A brand-new Devin session has a Herdr session id but no /model entry.
         assert_eq!(
             snapshot.model_for_session(Some("session-a")),
             Some("SWE-1.7 Medium")

--- a/src/model.rs
+++ b/src/model.rs
@@ -557,6 +557,9 @@ pub struct ProviderSnapshot {
     ///
     /// StatusLine providers also keep the per-session value below so panes
     /// running the same provider can be distinguished from one another.
+    /// Devin stores the CLI configured/default model here (`agent.model`);
+    /// it is not a session's `/model` selection and is never copied into
+    /// `session_models`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default)]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -655,6 +655,24 @@ mod tests {
     }
 
     #[test]
+    fn devin_pane_uses_configured_default_when_session_model_is_unknown() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Devin,
+            vec![window(WindowKind::Weekly, 10.0, 183_600)],
+            0,
+        )
+        .with_model(Some("SWE-1.7 Medium".to_string()));
+        let pane = MetadataTokens::from_snapshot_for_pane(
+            &snapshot,
+            0,
+            Some("session-a"),
+            PercentStyle::default(),
+        );
+        assert_eq!(pane.quota_model, "SWE-1.7 Medium");
+        assert_eq!(pane.quota_provider_model, "Devin/SWE-1.7 Medium");
+    }
+
+    #[test]
     fn metadata_uses_context_and_cache_for_the_pane_session() {
         let mut snapshot = ProviderSnapshot::new(Provider::Codex, vec![], 0);
         snapshot.session_contexts.insert(

--- a/src/providers/devin.rs
+++ b/src/providers/devin.rs
@@ -17,13 +17,16 @@
 //!
 //! Model fields are scoped, not interchangeable:
 //!
+//! - Herdr's official Devin integration reports a native session id (used for
+//!   `devin --resume`). That id is real. It is **not** a model name.
 //! - `snapshot.model` is the CLI **configured/default** model from
 //!   `~/.config/devin/config.json` `agent.model` (officially "Default AI
-//!   model"). A session can still switch with `/model`, so this is never
-//!   copied into `session_models`.
+//!   model"). Issue #53's live `config.json` is the same file. A session can
+//!   still switch with `/model`; we have not live-tested whether that write
+//!   goes back to `config.json`, so this is a display fallback, not per-session
+//!   evidence, and it is never copied into `session_models`.
 //! - `session_models` stays empty until a Devin session file exposes
-//!   per-session evidence. There is no official read-only session-model
-//!   contract today, so we do not guess.
+//!   per-session evidence that we can match to Herdr's session id.
 //! - `planInfo.planName` is the subscription plan (`Pro`), not a model.
 //! - `devin-models.json` is display metadata only: raw id → `variant.label`.
 //!   A missing, oversized, or malformed catalog leaves the raw id in place
@@ -122,10 +125,12 @@ pub fn fetch_for_sessions(session_ids: &[String]) -> Result<ProviderSnapshot> {
 }
 
 /// `config.json` names the CLI's configured/default model, not each session's
-/// `/model` selection. Until a Devin session file exposes per-session
-/// evidence, keep that name on `snapshot.model` and leave `session_models`
-/// empty. `session_ids` is accepted so callers cannot "forget" the sessions
-/// they asked about; they are never written here.
+/// `/model` selection. Keep it on `snapshot.model` and leave `session_models`
+/// empty. Display may fall back to this value for a Herdr session id (see
+/// `ProviderSnapshot::model_for_session`); that fallback must not be written
+/// here as if it were per-session evidence. `session_ids` is accepted so
+/// callers cannot "forget" the sessions they asked about; they are never
+/// written here.
 fn apply_configured_model(
     snapshot: &mut ProviderSnapshot,
     configured_model: Option<&str>,

--- a/src/providers/devin.rs
+++ b/src/providers/devin.rs
@@ -14,6 +14,20 @@
 //! or included in error messages or pane metadata. Cache identity is
 //! `sha256("devin\0" || key)` so a credential swap cannot keep the previous
 //! account's last-good snapshot.
+//!
+//! Model fields are scoped, not interchangeable:
+//!
+//! - `snapshot.model` is the CLI **configured/default** model from
+//!   `~/.config/devin/config.json` `agent.model` (officially "Default AI
+//!   model"). A session can still switch with `/model`, so this is never
+//!   copied into `session_models`.
+//! - `session_models` stays empty until a Devin session file exposes
+//!   per-session evidence. There is no official read-only session-model
+//!   contract today, so we do not guess.
+//! - `planInfo.planName` is the subscription plan (`Pro`), not a model.
+//! - `devin-models.json` is display metadata only: raw id → `variant.label`.
+//!   A missing, oversized, or malformed catalog leaves the raw id in place
+//!   and never fails the quota fetch.
 
 use crate::cache::CacheStore;
 use crate::model::{Provider, ProviderSnapshot, ResetAt, UsageWindow, WindowKind};
@@ -28,6 +42,9 @@ use std::time::Duration;
 
 const DEFAULT_API_SERVER_URL: &str = "https://server.codeium.com";
 const GET_USER_STATUS_PATH: &str = "/exa.seat_management_pb.SeatManagementService/GetUserStatus";
+/// Same bound OpenCode uses for its local models catalog. A huge file is
+/// treated as absent so a corrupt dump cannot stall a quota refresh.
+const MAX_MODELS_BYTES: u64 = 8 * 1024 * 1024;
 
 /// Build the full GetUserStatus URL from an optional `api_server_url`
 /// override. Falls back to `DEFAULT_API_SERVER_URL` when the override is
@@ -62,13 +79,13 @@ impl std::fmt::Debug for DevinCredentials {
     }
 }
 
-/// Fetch Devin CLI's quota. The CLI config's active model is process-global,
+/// Fetch Devin CLI's quota. The CLI configured/default model is provider-level,
 /// so it is published as `snapshot.model`, not as per-session evidence.
 pub fn fetch_for_sessions(session_ids: &[String]) -> Result<ProviderSnapshot> {
     let path = auth_path().context("resolve Devin credentials path")?;
     let credentials = read_credentials(&path).map_err(anyhow::Error::from)?;
     let account_id = account_pin(&credentials.windsurf_api_key);
-    let active_model = active_model_from_config();
+    let configured_model = configured_model_from_config();
     let url = build_url(credentials.api_server_url.as_deref())?;
     let body = serde_json::json!({
         "metadata": {
@@ -93,23 +110,32 @@ pub fn fetch_for_sessions(session_ids: &[String]) -> Result<ProviderSnapshot> {
     let value: Value = response
         .into_json()
         .context("decode Devin GetUserStatus response")?;
-    let mut snapshot = parse_user_status(&value, active_model.as_deref(), CacheStore::now_unix())
-        .map_err(anyhow::Error::from)?;
-    apply_configured_model(&mut snapshot, active_model, session_ids);
+    let mut snapshot =
+        parse_user_status(&value, CacheStore::now_unix()).map_err(anyhow::Error::from)?;
+    apply_configured_model(
+        &mut snapshot,
+        configured_model.as_deref(),
+        session_ids,
+        load_models_catalog().as_ref(),
+    );
     Ok(snapshot.with_account_id(Some(account_id)))
 }
 
-/// `config.json` names the CLI's current default model, not each session's
-/// model. Until a Devin session file exposes per-session evidence, keep that
-/// name on `snapshot.model` and leave `session_models` empty.
+/// `config.json` names the CLI's configured/default model, not each session's
+/// `/model` selection. Until a Devin session file exposes per-session
+/// evidence, keep that name on `snapshot.model` and leave `session_models`
+/// empty. `session_ids` is accepted so callers cannot "forget" the sessions
+/// they asked about; they are never written here.
 fn apply_configured_model(
     snapshot: &mut ProviderSnapshot,
-    active_model: Option<String>,
+    configured_model: Option<&str>,
     _session_ids: &[String],
+    catalog: Option<&Value>,
 ) {
-    if let Some(model) = active_model {
-        snapshot.model = Some(model);
-    }
+    let Some(model_id) = configured_model.map(str::trim).filter(|id| !id.is_empty()) else {
+        return;
+    };
+    snapshot.model = Some(display_name_for_model(model_id, catalog));
 }
 
 /// Resolve the credentials file path.
@@ -167,30 +193,254 @@ fn devin_config_dir() -> Result<PathBuf> {
     Ok(PathBuf::from(home).join(".config/devin"))
 }
 
-/// Devin CLI's `config.json`.
-#[derive(Debug, Clone, Deserialize)]
-struct DevinConfig {
-    agent: AgentConfig,
+/// Read the configured/default model from `~/.config/devin/config.json` (or
+/// `$XDG_CONFIG_HOME/devin/config.json`). Official docs call `agent.model`
+/// the user-wide **Default AI model**; `/model` can still change a running
+/// session. Returns `None` if the file is missing, commented JSON cannot be
+/// parsed, `agent.model` is absent, or the string is empty. Never falls back
+/// to the quota API's `planName`.
+fn configured_model_from_config() -> Option<String> {
+    configured_model_from_path(&devin_config_dir().ok()?.join("config.json"))
 }
 
-#[derive(Debug, Clone, Deserialize)]
-struct AgentConfig {
-    model: String,
+fn configured_model_from_path(path: &Path) -> Option<String> {
+    let text = fs::read_to_string(path).ok()?;
+    configured_model_from_text(&text)
 }
 
-/// Read the active model from `~/.config/devin/config.json` (or
-/// `$XDG_CONFIG_HOME/devin/config.json`). Returns `None` if the file is
-/// missing or malformed so that the quota API's `planName` is used as a
-/// fallback.
-fn active_model_from_config() -> Option<String> {
-    let path = devin_config_dir().ok()?.join("config.json");
-    let text = fs::read_to_string(&path).ok()?;
-    let config: DevinConfig = serde_json::from_str(&text).ok()?;
-    let model = config.agent.model.trim();
-    if model.is_empty() {
+fn configured_model_from_text(text: &str) -> Option<String> {
+    let value = parse_jsonc_value(text)?;
+    let model = value
+        .get("agent")
+        .and_then(|agent| agent.get("model"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|model| !model.is_empty())?;
+    Some(model.to_string())
+}
+
+/// Local Devin model catalog. Official CLI data, not a hardcoded table.
+///
+/// Search order, first readable file wins:
+/// 1. `DEVIN_MODELS_FILE`
+/// 2. `$XDG_CONFIG_HOME/devin/devin-models.json` or `~/.config/devin/devin-models.json`
+/// 3. `$XDG_DATA_HOME/devin/devin-models.json` or `~/.local/share/devin/devin-models.json`
+/// 4. `$XDG_DATA_HOME/devin/cli/devin-models.json` or `~/.local/share/devin/cli/devin-models.json`
+///
+/// (4) sits beside the CLI session database path used by third-party
+/// inspectors; it is still only opened if a file with this exact name exists.
+/// Missing, oversized, or malformed files are skipped. Quota fetch never
+/// depends on this catalog.
+fn load_models_catalog() -> Option<Value> {
+    for path in models_catalog_candidates() {
+        if let Some(catalog) = load_models_catalog_from_path(&path) {
+            return Some(catalog);
+        }
+    }
+    None
+}
+
+fn models_catalog_candidates() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(path) = std::env::var_os("DEVIN_MODELS_FILE") {
+        let path = PathBuf::from(path);
+        if !path.as_os_str().is_empty() {
+            paths.push(path);
+        }
+    }
+    if let Ok(dir) = devin_config_dir() {
+        paths.push(dir.join("devin-models.json"));
+    }
+    if let Ok(dir) = devin_data_dir() {
+        paths.push(dir.join("devin-models.json"));
+        paths.push(dir.join("cli").join("devin-models.json"));
+    }
+    paths
+}
+
+fn load_models_catalog_from_path(path: &Path) -> Option<Value> {
+    let metadata = fs::metadata(path).ok()?;
+    if !metadata.is_file() || metadata.len() > MAX_MODELS_BYTES {
         return None;
     }
-    Some(model.to_string())
+    let text = fs::read_to_string(path).ok()?;
+    let value = parse_jsonc_value(&text)?;
+    value.get("families")?.as_array()?;
+    Some(value)
+}
+
+/// Map a raw Devin model id onto the catalog's friendly label.
+///
+/// Lookup is exact, then case-insensitive, against `variant.model_uid`,
+/// `variant.label`, family `aliases`, `slug`, and `family_uid`. A family-level
+/// hit returns `family_label` rather than picking a "latest" variant. No match
+/// returns the raw id. Catalog failure is indistinguishable from no match.
+fn display_name_for_model(model_id: &str, catalog: Option<&Value>) -> String {
+    let trimmed = model_id.trim();
+    catalog
+        .and_then(|catalog| lookup_model_label(catalog, trimmed))
+        .unwrap_or_else(|| trimmed.to_string())
+}
+
+fn lookup_model_label(catalog: &Value, model_id: &str) -> Option<String> {
+    if model_id.is_empty() {
+        return None;
+    }
+    let families = catalog.get("families")?.as_array()?;
+    lookup_variant_uid(families, model_id, true)
+        .or_else(|| lookup_variant_uid(families, model_id, false))
+        .or_else(|| lookup_variant_label(families, model_id, true))
+        .or_else(|| lookup_variant_label(families, model_id, false))
+        .or_else(|| lookup_family_label(families, model_id, true))
+        .or_else(|| lookup_family_label(families, model_id, false))
+}
+
+fn lookup_variant_uid(families: &[Value], model_id: &str, exact: bool) -> Option<String> {
+    for family in families {
+        let Some(variants) = family.get("variants").and_then(Value::as_array) else {
+            continue;
+        };
+        for variant in variants {
+            if !eq_model_key(
+                variant.get("model_uid").and_then(Value::as_str),
+                model_id,
+                exact,
+            ) {
+                continue;
+            }
+            if let Some(label) = variant
+                .get("label")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|label| !label.is_empty())
+            {
+                return Some(label.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn lookup_variant_label(families: &[Value], model_id: &str, exact: bool) -> Option<String> {
+    for family in families {
+        let Some(variants) = family.get("variants").and_then(Value::as_array) else {
+            continue;
+        };
+        for variant in variants {
+            let Some(label) = variant
+                .get("label")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|label| !label.is_empty())
+            else {
+                continue;
+            };
+            if eq_model_key(Some(label), model_id, exact) {
+                return Some(label.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn lookup_family_label(families: &[Value], model_id: &str, exact: bool) -> Option<String> {
+    for family in families {
+        let slug = family.get("slug").and_then(Value::as_str);
+        let family_uid = family.get("family_uid").and_then(Value::as_str);
+        let aliases = family
+            .get("aliases")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str);
+        let hit = eq_model_key(slug, model_id, exact)
+            || eq_model_key(family_uid, model_id, exact)
+            || aliases.any(|alias| eq_model_key(Some(alias), model_id, exact));
+        if !hit {
+            continue;
+        }
+        if let Some(label) = family
+            .get("family_label")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|label| !label.is_empty())
+        {
+            return Some(label.to_string());
+        }
+    }
+    None
+}
+
+fn eq_model_key(candidate: Option<&str>, model_id: &str, exact: bool) -> bool {
+    let Some(candidate) = candidate.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    if exact {
+        candidate == model_id
+    } else {
+        candidate.eq_ignore_ascii_case(model_id)
+    }
+}
+
+/// Devin config files are JSON with `//` and `/* */` comments. Try strict
+/// JSON first; strip comments only when that fails. Strings are left intact.
+fn parse_jsonc_value(text: &str) -> Option<Value> {
+    if let Ok(value) = serde_json::from_str(text) {
+        return Some(value);
+    }
+    serde_json::from_str(&strip_json_comments(text)).ok()
+}
+
+fn strip_json_comments(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+    while let Some(c) = chars.next() {
+        if in_string {
+            out.push(c);
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if c == '"' {
+            in_string = true;
+            out.push(c);
+            continue;
+        }
+        if c == '/' {
+            match chars.peek() {
+                Some('/') => {
+                    chars.next();
+                    for next in chars.by_ref() {
+                        if next == '\n' {
+                            out.push('\n');
+                            break;
+                        }
+                    }
+                }
+                Some('*') => {
+                    chars.next();
+                    let mut prev = '\0';
+                    for next in chars.by_ref() {
+                        if prev == '*' && next == '/' {
+                            break;
+                        }
+                        prev = next;
+                    }
+                }
+                _ => out.push(c),
+            }
+            continue;
+        }
+        out.push(c);
+    }
+    out
 }
 
 fn read_credentials(path: &Path) -> std::result::Result<DevinCredentials, ProviderError> {
@@ -223,11 +473,10 @@ fn map_request_error(error: &ureq::Error) -> ProviderError {
 /// The response carries remaining percentages for daily and weekly windows.
 /// Those are flipped to used: `used = 100 - remaining`. Reset timestamps are
 /// strings of Unix seconds. Missing or malformed fields yield no window
-/// rather than a guessed number. `active_model` is preferred for the model
-/// field; if it is `None`, the API's `planInfo.planName` is used instead.
+/// rather than a guessed number. `planInfo.planName` is the subscription
+/// plan, not a model, and is ignored here.
 pub fn parse_user_status(
     value: &Value,
-    active_model: Option<&str>,
     now: u64,
 ) -> std::result::Result<ProviderSnapshot, ProviderError> {
     let plan_status = value
@@ -252,15 +501,7 @@ pub fn parse_user_status(
         ));
     }
 
-    let mut snapshot = ProviderSnapshot::new(Provider::Devin, windows, now);
-    snapshot.model = active_model.map(str::to_string).or_else(|| {
-        plan_status
-            .get("planInfo")
-            .and_then(|info| info.get("planName"))
-            .and_then(Value::as_str)
-            .map(str::to_string)
-    });
-    Ok(snapshot)
+    Ok(ProviderSnapshot::new(Provider::Devin, windows, now))
 }
 
 /// Daily window: remaining percent → used, string timestamp → Unix seconds.
@@ -331,11 +572,16 @@ mod tests {
         .expect("fixture is valid JSON")
     }
 
+    fn catalog_fixture() -> Value {
+        serde_json::from_str(include_str!("../../tests/fixtures/devin/devin-models.json"))
+            .expect("catalog fixture is valid JSON")
+    }
+
     #[test]
     fn pro_fixture_flips_remaining_to_used() {
-        let snapshot = parse_user_status(&pro_fixture(), None, 1).expect("snapshot");
+        let snapshot = parse_user_status(&pro_fixture(), 1).expect("snapshot");
         assert_eq!(snapshot.provider, Provider::Devin);
-        assert_eq!(snapshot.model.as_deref(), Some("Pro"));
+        assert_eq!(snapshot.model, None);
 
         let daily = snapshot.window(WindowKind::FiveHour).expect("daily window");
         // 99 remaining → 1 used
@@ -368,47 +614,202 @@ mod tests {
                 }
             }
         });
-        let snapshot = parse_user_status(&value, None, 1).expect("snapshot");
+        let snapshot = parse_user_status(&value, 1).expect("snapshot");
         assert!(snapshot.window(WindowKind::FiveHour).is_none());
         let weekly = snapshot.window(WindowKind::Weekly).expect("weekly");
         assert_eq!(weekly.used_percent, 50.0);
     }
 
     #[test]
-    fn active_model_overrides_plan_name() {
-        let snapshot =
-            parse_user_status(&pro_fixture(), Some("swe-1-7-medium"), 1).expect("snapshot");
-        assert_eq!(snapshot.model.as_deref(), Some("swe-1-7-medium"));
+    fn plan_name_is_not_used_as_model() {
+        let snapshot = parse_user_status(&pro_fixture(), 1).expect("snapshot");
+        assert_eq!(snapshot.model, None);
+        assert_ne!(snapshot.model.as_deref(), Some("Pro"));
     }
 
     #[test]
-    fn devin_global_model_is_not_written_as_session_model() {
-        let mut snapshot = parse_user_status(&pro_fixture(), None, 1).expect("snapshot");
+    fn valid_config_model_is_the_configured_default() {
+        assert_eq!(
+            configured_model_from_text(r#"{"agent":{"model":"swe-1-7-medium"}}"#).as_deref(),
+            Some("swe-1-7-medium")
+        );
+    }
+
+    #[test]
+    fn missing_config_file_yields_no_model() {
+        let dir = tempdir().unwrap();
+        assert_eq!(
+            configured_model_from_path(&dir.path().join("config.json")),
+            None
+        );
+    }
+
+    #[test]
+    fn malformed_config_yields_no_model() {
+        assert_eq!(configured_model_from_text("{not json"), None);
+        assert_eq!(configured_model_from_text("[]"), None);
+        assert_eq!(configured_model_from_text(r#"{"agent":"nope"}"#), None);
+        assert_eq!(configured_model_from_text(r#"{"agent":{"model":1}}"#), None);
+    }
+
+    #[test]
+    fn empty_config_model_yields_no_model() {
+        assert_eq!(
+            configured_model_from_text(r#"{"agent":{"model":""}}"#),
+            None
+        );
+        assert_eq!(
+            configured_model_from_text(r#"{"agent":{"model":"   "}}"#),
+            None
+        );
+        assert_eq!(configured_model_from_text(r#"{"agent":{}}"#), None);
+        assert_eq!(configured_model_from_text("{}"), None);
+    }
+
+    #[test]
+    fn commented_config_json_still_reads_the_default_model() {
+        let text = r#"
+        {
+          // user-wide default, not the session /model
+          "agent": {
+            "model": "swe-1-7-medium" // Default AI model
+          }
+        }
+        "#;
+        assert_eq!(
+            configured_model_from_text(text).as_deref(),
+            Some("swe-1-7-medium")
+        );
+    }
+
+    #[test]
+    fn catalog_maps_model_uid_to_variant_label() {
+        let catalog = catalog_fixture();
+        assert_eq!(
+            display_name_for_model("swe-1-7-medium", Some(&catalog)),
+            "SWE-1.7 Medium"
+        );
+    }
+
+    #[test]
+    fn catalog_maps_family_slug_to_family_label_not_a_variant() {
+        let catalog = catalog_fixture();
+        assert_eq!(display_name_for_model("swe", Some(&catalog)), "SWE-1.7");
+        assert_eq!(
+            display_name_for_model("opus", Some(&catalog)),
+            "Claude Opus"
+        );
+    }
+
+    #[test]
+    fn missing_catalog_keeps_the_raw_id() {
+        assert_eq!(
+            display_name_for_model("swe-1-7-medium", None),
+            "swe-1-7-medium"
+        );
+    }
+
+    #[test]
+    fn malformed_catalog_file_is_skipped() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("devin-models.json");
+        fs::write(&path, "{not json").unwrap();
+        assert!(load_models_catalog_from_path(&path).is_none());
+        fs::write(&path, r#"{"not":"families"}"#).unwrap();
+        assert!(load_models_catalog_from_path(&path).is_none());
+    }
+
+    #[test]
+    fn unknown_model_id_falls_back_to_raw_id() {
+        let catalog = catalog_fixture();
+        assert_eq!(
+            display_name_for_model("not-a-real-model", Some(&catalog)),
+            "not-a-real-model"
+        );
+    }
+
+    #[test]
+    fn configured_model_is_not_written_as_session_model() {
+        let mut snapshot = parse_user_status(&pro_fixture(), 1).expect("snapshot");
         apply_configured_model(
             &mut snapshot,
-            Some("swe-1-7-medium".to_string()),
+            Some("swe-1-7-medium"),
             &["session-a".to_string(), "session-b".to_string()],
+            Some(&catalog_fixture()),
+        );
+        assert_eq!(snapshot.model.as_deref(), Some("SWE-1.7 Medium"));
+        assert!(snapshot.session_models.is_empty());
+        assert!(!snapshot.session_models.contains_key("session-a"));
+        assert!(!snapshot.session_models.contains_key("session-b"));
+    }
+
+    #[test]
+    fn configured_model_without_catalog_stays_raw_and_off_sessions() {
+        let mut snapshot = parse_user_status(&pro_fixture(), 1).expect("snapshot");
+        apply_configured_model(
+            &mut snapshot,
+            Some("swe-1-7-medium"),
+            &["session-a".to_string()],
+            None,
         );
         assert_eq!(snapshot.model.as_deref(), Some("swe-1-7-medium"));
         assert!(snapshot.session_models.is_empty());
     }
 
     #[test]
-    fn plan_name_is_used_when_active_model_is_absent() {
-        let snapshot = parse_user_status(&pro_fixture(), None, 1).expect("snapshot");
-        assert_eq!(snapshot.model.as_deref(), Some("Pro"));
+    fn applying_no_configured_model_leaves_plan_name_out() {
+        let mut snapshot = parse_user_status(&pro_fixture(), 1).expect("snapshot");
+        apply_configured_model(&mut snapshot, None, &["session-a".to_string()], None);
+        assert_eq!(snapshot.model, None);
+        assert!(snapshot.session_models.is_empty());
+    }
+
+    #[test]
+    fn comment_markers_inside_strings_are_kept() {
+        assert_eq!(
+            configured_model_from_text(r#"{"agent":{"model":"foo//bar"}}"#).as_deref(),
+            Some("foo//bar")
+        );
+    }
+
+    #[test]
+    fn oversized_catalog_file_is_skipped() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("devin-models.json");
+        let mut bytes = br#"{"families":[]}"#.to_vec();
+        bytes.resize(MAX_MODELS_BYTES as usize + 1, b' ');
+        fs::write(&path, bytes).unwrap();
+        assert!(load_models_catalog_from_path(&path).is_none());
+    }
+
+    #[test]
+    fn catalog_file_override_loads_from_devin_models_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("devin-models.json");
+        fs::copy(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/devin/devin-models.json"),
+            &path,
+        )
+        .unwrap();
+        std::env::set_var("DEVIN_MODELS_FILE", &path);
+        let catalog = load_models_catalog();
+        std::env::remove_var("DEVIN_MODELS_FILE");
+        assert_eq!(
+            display_name_for_model("swe-1-7-medium", catalog.as_ref()),
+            "SWE-1.7 Medium"
+        );
     }
 
     #[test]
     fn missing_all_windows_is_an_error() {
         let value = json!({"userStatus": {"planStatus": {}}});
-        assert!(parse_user_status(&value, None, 1).is_err());
+        assert!(parse_user_status(&value, 1).is_err());
     }
 
     #[test]
     fn missing_plan_status_is_an_error() {
         let value = json!({"userStatus": {}});
-        assert!(parse_user_status(&value, None, 1).is_err());
+        assert!(parse_user_status(&value, 1).is_err());
     }
 
     #[test]
@@ -421,7 +822,7 @@ mod tests {
                 }
             }
         });
-        assert!(parse_user_status(&value, None, 1).is_err());
+        assert!(parse_user_status(&value, 1).is_err());
     }
 
     #[test]
@@ -510,7 +911,7 @@ mod tests {
                 }
             }
         });
-        assert!(parse_user_status(&value, None, 1).is_err());
+        assert!(parse_user_status(&value, 1).is_err());
     }
 
     #[test]

--- a/src/providers/devin.rs
+++ b/src/providers/devin.rs
@@ -15,22 +15,15 @@
 //! `sha256("devin\0" || key)` so a credential swap cannot keep the previous
 //! account's last-good snapshot.
 //!
-//! Model fields are scoped, not interchangeable:
+//! Model comes from Devin's own files, not from the quota API:
 //!
-//! - Herdr's official Devin integration reports a native session id (used for
-//!   `devin --resume`). That id is real. It is **not** a model name.
-//! - `snapshot.model` is the CLI **configured/default** model from
-//!   `~/.config/devin/config.json` `agent.model` (officially "Default AI
-//!   model"). Issue #53's live `config.json` is the same file. A session can
-//!   still switch with `/model`; we have not live-tested whether that write
-//!   goes back to `config.json`, so this is a display fallback, not per-session
-//!   evidence, and it is never copied into `session_models`.
-//! - `session_models` stays empty until a Devin session file exposes
-//!   per-session evidence that we can match to Herdr's session id.
-//! - `planInfo.planName` is the subscription plan (`Pro`), not a model.
-//! - `devin-models.json` is display metadata only: raw id → `variant.label`.
-//!   A missing, oversized, or malformed catalog leaves the raw id in place
-//!   and never fails the quota fetch.
+//! - `~/.config/devin/config.json` `agent.model` is the CLI default / current
+//!   configured model (Issue #53). New sessions that never run `/model` use
+//!   this value. It is published as `snapshot.model` and shown on every Devin
+//!   pane.
+//! - `devin-models.json` maps that id to a display label. Missing or malformed
+//!   catalog leaves the raw id; quota fetch is unaffected.
+//! - `planInfo.planName` is the subscription plan, not a model.
 
 use crate::cache::CacheStore;
 use crate::model::{Provider, ProviderSnapshot, ResetAt, UsageWindow, WindowKind};
@@ -82,9 +75,9 @@ impl std::fmt::Debug for DevinCredentials {
     }
 }
 
-/// Fetch Devin CLI's quota. The CLI configured/default model is provider-level,
-/// so it is published as `snapshot.model`, not as per-session evidence.
-pub fn fetch_for_sessions(session_ids: &[String]) -> Result<ProviderSnapshot> {
+/// Fetch Devin CLI's quota. The model is the CLI `config.json` default, shared
+/// across panes, so it is published as `snapshot.model`.
+pub fn fetch_for_sessions(_session_ids: &[String]) -> Result<ProviderSnapshot> {
     let path = auth_path().context("resolve Devin credentials path")?;
     let credentials = read_credentials(&path).map_err(anyhow::Error::from)?;
     let account_id = account_pin(&credentials.windsurf_api_key);
@@ -118,23 +111,16 @@ pub fn fetch_for_sessions(session_ids: &[String]) -> Result<ProviderSnapshot> {
     apply_configured_model(
         &mut snapshot,
         configured_model.as_deref(),
-        session_ids,
         load_models_catalog().as_ref(),
     );
     Ok(snapshot.with_account_id(Some(account_id)))
 }
 
-/// `config.json` names the CLI's configured/default model, not each session's
-/// `/model` selection. Keep it on `snapshot.model` and leave `session_models`
-/// empty. Display may fall back to this value for a Herdr session id (see
-/// `ProviderSnapshot::model_for_session`); that fallback must not be written
-/// here as if it were per-session evidence. `session_ids` is accepted so
-/// callers cannot "forget" the sessions they asked about; they are never
-/// written here.
+/// Issue #53: `config.json` `agent.model` is Devin's model. Map it through the
+/// local catalog when possible, then store it on `snapshot.model`.
 fn apply_configured_model(
     snapshot: &mut ProviderSnapshot,
     configured_model: Option<&str>,
-    _session_ids: &[String],
     catalog: Option<&Value>,
 ) {
     let Some(model_id) = configured_model.map(str::trim).filter(|id| !id.is_empty()) else {
@@ -198,12 +184,8 @@ fn devin_config_dir() -> Result<PathBuf> {
     Ok(PathBuf::from(home).join(".config/devin"))
 }
 
-/// Read the configured/default model from `~/.config/devin/config.json` (or
-/// `$XDG_CONFIG_HOME/devin/config.json`). Official docs call `agent.model`
-/// the user-wide **Default AI model**; `/model` can still change a running
-/// session. Returns `None` if the file is missing, commented JSON cannot be
-/// parsed, `agent.model` is absent, or the string is empty. Never falls back
-/// to the quota API's `planName`.
+/// Read `agent.model` from `~/.config/devin/config.json` (or `$XDG_CONFIG_HOME`).
+/// Missing, commented-unparseable, or empty values yield `None`.
 fn configured_model_from_config() -> Option<String> {
     configured_model_from_path(&devin_config_dir().ok()?.join("config.json"))
 }
@@ -224,18 +206,8 @@ fn configured_model_from_text(text: &str) -> Option<String> {
     Some(model.to_string())
 }
 
-/// Local Devin model catalog. Official CLI data, not a hardcoded table.
-///
-/// Search order, first readable file wins:
-/// 1. `DEVIN_MODELS_FILE`
-/// 2. `$XDG_CONFIG_HOME/devin/devin-models.json` or `~/.config/devin/devin-models.json`
-/// 3. `$XDG_DATA_HOME/devin/devin-models.json` or `~/.local/share/devin/devin-models.json`
-/// 4. `$XDG_DATA_HOME/devin/cli/devin-models.json` or `~/.local/share/devin/cli/devin-models.json`
-///
-/// (4) sits beside the CLI session database path used by third-party
-/// inspectors; it is still only opened if a file with this exact name exists.
-/// Missing, oversized, or malformed files are skipped. Quota fetch never
-/// depends on this catalog.
+/// Local `devin-models.json` catalog from Issue #53. First readable file wins:
+/// `DEVIN_MODELS_FILE`, then the Devin config dir, data dir, and `data/cli`.
 fn load_models_catalog() -> Option<Value> {
     for path in models_catalog_candidates() {
         if let Some(catalog) = load_models_catalog_from_path(&path) {
@@ -274,12 +246,6 @@ fn load_models_catalog_from_path(path: &Path) -> Option<Value> {
     Some(value)
 }
 
-/// Map a raw Devin model id onto the catalog's friendly label.
-///
-/// Lookup is exact, then case-insensitive, against `variant.model_uid`,
-/// `variant.label`, family `aliases`, `slug`, and `family_uid`. A family-level
-/// hit returns `family_label` rather than picking a "latest" variant. No match
-/// returns the raw id. Catalog failure is indistinguishable from no match.
 fn display_name_for_model(model_id: &str, catalog: Option<&Value>) -> String {
     let trimmed = model_id.trim();
     catalog
@@ -288,36 +254,31 @@ fn display_name_for_model(model_id: &str, catalog: Option<&Value>) -> String {
 }
 
 fn lookup_model_label(catalog: &Value, model_id: &str) -> Option<String> {
-    if model_id.is_empty() {
-        return None;
-    }
     let families = catalog.get("families")?.as_array()?;
-    lookup_variant_uid(families, model_id, true)
-        .or_else(|| lookup_variant_uid(families, model_id, false))
-        .or_else(|| lookup_variant_label(families, model_id, true))
-        .or_else(|| lookup_variant_label(families, model_id, false))
-        .or_else(|| lookup_family_label(families, model_id, true))
-        .or_else(|| lookup_family_label(families, model_id, false))
+    variant_label(families, model_id, true)
+        .or_else(|| variant_label(families, model_id, false))
+        .or_else(|| family_label(families, model_id, true))
+        .or_else(|| family_label(families, model_id, false))
 }
 
-fn lookup_variant_uid(families: &[Value], model_id: &str, exact: bool) -> Option<String> {
+fn json_str(value: Option<&Value>) -> Option<&str> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+}
+
+fn variant_label(families: &[Value], model_id: &str, exact: bool) -> Option<String> {
     for family in families {
         let Some(variants) = family.get("variants").and_then(Value::as_array) else {
             continue;
         };
         for variant in variants {
-            if !eq_model_key(
-                variant.get("model_uid").and_then(Value::as_str),
-                model_id,
-                exact,
-            ) {
+            let Some(label) = json_str(variant.get("label")) else {
                 continue;
-            }
-            if let Some(label) = variant
-                .get("label")
-                .and_then(Value::as_str)
-                .map(str::trim)
-                .filter(|label| !label.is_empty())
+            };
+            if eq_model_key(json_str(variant.get("model_uid")), model_id, exact)
+                || eq_model_key(Some(label), model_id, exact)
             {
                 return Some(label.to_string());
             }
@@ -326,51 +287,21 @@ fn lookup_variant_uid(families: &[Value], model_id: &str, exact: bool) -> Option
     None
 }
 
-fn lookup_variant_label(families: &[Value], model_id: &str, exact: bool) -> Option<String> {
+fn family_label(families: &[Value], model_id: &str, exact: bool) -> Option<String> {
     for family in families {
-        let Some(variants) = family.get("variants").and_then(Value::as_array) else {
-            continue;
-        };
-        for variant in variants {
-            let Some(label) = variant
-                .get("label")
-                .and_then(Value::as_str)
-                .map(str::trim)
-                .filter(|label| !label.is_empty())
-            else {
-                continue;
-            };
-            if eq_model_key(Some(label), model_id, exact) {
-                return Some(label.to_string());
-            }
-        }
-    }
-    None
-}
-
-fn lookup_family_label(families: &[Value], model_id: &str, exact: bool) -> Option<String> {
-    for family in families {
-        let slug = family.get("slug").and_then(Value::as_str);
-        let family_uid = family.get("family_uid").and_then(Value::as_str);
         let mut aliases = family
             .get("aliases")
             .and_then(Value::as_array)
             .into_iter()
             .flatten()
-            .filter_map(Value::as_str);
-        let hit = eq_model_key(slug, model_id, exact)
-            || eq_model_key(family_uid, model_id, exact)
+            .filter_map(|value| json_str(Some(value)));
+        let hit = eq_model_key(json_str(family.get("slug")), model_id, exact)
+            || eq_model_key(json_str(family.get("family_uid")), model_id, exact)
             || aliases.any(|alias| eq_model_key(Some(alias), model_id, exact));
-        if !hit {
-            continue;
-        }
-        if let Some(label) = family
-            .get("family_label")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|label| !label.is_empty())
-        {
-            return Some(label.to_string());
+        if hit {
+            if let Some(label) = json_str(family.get("family_label")) {
+                return Some(label.to_string());
+            }
         }
     }
     None
@@ -739,24 +670,16 @@ mod tests {
         apply_configured_model(
             &mut snapshot,
             Some("swe-1-7-medium"),
-            &["session-a".to_string(), "session-b".to_string()],
             Some(&catalog_fixture()),
         );
         assert_eq!(snapshot.model.as_deref(), Some("SWE-1.7 Medium"));
         assert!(snapshot.session_models.is_empty());
-        assert!(!snapshot.session_models.contains_key("session-a"));
-        assert!(!snapshot.session_models.contains_key("session-b"));
     }
 
     #[test]
-    fn configured_model_without_catalog_stays_raw_and_off_sessions() {
+    fn configured_model_without_catalog_stays_raw() {
         let mut snapshot = parse_user_status(&pro_fixture(), 1).expect("snapshot");
-        apply_configured_model(
-            &mut snapshot,
-            Some("swe-1-7-medium"),
-            &["session-a".to_string()],
-            None,
-        );
+        apply_configured_model(&mut snapshot, Some("swe-1-7-medium"), None);
         assert_eq!(snapshot.model.as_deref(), Some("swe-1-7-medium"));
         assert!(snapshot.session_models.is_empty());
     }
@@ -764,7 +687,7 @@ mod tests {
     #[test]
     fn applying_no_configured_model_leaves_plan_name_out() {
         let mut snapshot = parse_user_status(&pro_fixture(), 1).expect("snapshot");
-        apply_configured_model(&mut snapshot, None, &["session-a".to_string()], None);
+        apply_configured_model(&mut snapshot, None, None);
         assert_eq!(snapshot.model, None);
         assert!(snapshot.session_models.is_empty());
     }

--- a/src/providers/devin.rs
+++ b/src/providers/devin.rs
@@ -347,7 +347,7 @@ fn lookup_family_label(families: &[Value], model_id: &str, exact: bool) -> Optio
     for family in families {
         let slug = family.get("slug").and_then(Value::as_str);
         let family_uid = family.get("family_uid").and_then(Value::as_str);
-        let aliases = family
+        let mut aliases = family
             .get("aliases")
             .and_then(Value::as_array)
             .into_iter()

--- a/tests/fixtures/devin/devin-models.json
+++ b/tests/fixtures/devin/devin-models.json
@@ -1,0 +1,34 @@
+{
+  "families": [
+    {
+      "family_label": "SWE-1.7",
+      "family_uid": "swe-1-7",
+      "slug": "swe",
+      "aliases": ["swe-1.7", "swe-1-7"],
+      "variants": [
+        {
+          "model_uid": "swe-1-7-medium",
+          "label": "SWE-1.7 Medium",
+          "is_new": false,
+          "is_beta": false,
+          "cost_tier": "standard",
+          "description": "Balanced SWE-1.7 variant"
+        }
+      ]
+    },
+    {
+      "family_label": "Claude Opus",
+      "family_uid": "claude-opus",
+      "slug": "opus",
+      "aliases": ["claude-opus"],
+      "variants": [
+        {
+          "model_uid": "claude-opus-4-6",
+          "label": "Opus 4.6",
+          "is_new": true,
+          "is_beta": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/provider_contracts.rs
+++ b/tests/provider_contracts.rs
@@ -177,8 +177,9 @@ fn omp_reports_nothing_for_an_absent_provider() {
 #[test]
 fn devin_fixture_flips_remaining_to_used_for_daily_and_weekly() {
     let value = fixture(include_str!("fixtures/devin/getuserstatus-pro.json"));
-    let snapshot = devin::parse_user_status(&value, None, 1).expect("snapshot");
+    let snapshot = devin::parse_user_status(&value, 1).expect("snapshot");
     assert_eq!(snapshot.windows.len(), 2);
+    assert_eq!(snapshot.model, None);
 
     let daily = snapshot.window(WindowKind::FiveHour).expect("daily window");
     // 99 remaining → 1 used


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this changes

Fixes #53 by following the issue author's route, not a guessed per-session model file.

- `~/.config/devin/config.json` `agent.model` is Devin's model. Official docs call it the **Default AI model**. A new session that never runs `/model` still uses this value.
- Local `devin-models.json` maps that id to a display label. Missing or malformed catalog leaves the raw id; quota fetch is unaffected.
- The value is stored on `snapshot.model` and shown on every Devin pane. It is **not** copied into `session_models` (that was #52).
- `planInfo.planName` (`Pro`) is the subscription plan, not a model.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features --locked`
- [x] A parser change comes with a fixture in `tests/fixtures/` and a test
- [x] No new network call, background process, or credential write

## Provider impact

Devin only. Claude / Codex / Grok / Agy / OpenCode / Pi / OMP are unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61c97793-f45e-4f08-b5c7-dc96b2a0ad16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61c97793-f45e-4f08-b5c7-dc96b2a0ad16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

