### PR TITLE
fix: isolate Devin sessions.db lookups from process env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,14 @@ upstream, every pin is orphaned and multi-account panes silently fall back to
 "no quota". The pinned-digest test exists to make that a test failure rather
 than a wrong number.
 
+## Devin's per-session model is local SQLite, not the quota API
+
+`~/.local/share/devin/cli/sessions.db` is CLI session state. Open it
+read-only and select only `id, model` — the same discipline as omp
+`models.db`, not `agent.db`. A missing, locked, or unexpected schema skips
+per-session attribution. `config.json` `agent.model` stays on
+`snapshot.model` as the fallback and is never copied into `session_models`.
+
 ## Herdr state this plugin owns outside a pane
 
 Two things reach past the pane metadata, and both are global to the Herdr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   default model comes from `~/.config/devin/config.json` `agent.model` when
   present, then mapped through local `devin-models.json` for a display name.
   New sessions that never run `/model` use this same value. It is published
-  as `snapshot.model` and shown on every Devin pane. The API
-  `planInfo.planName` is the subscription plan and is not used as a model.
-  A missing or malformed models catalog leaves the raw id and does not fail
-  the quota fetch.
-  Per-session active models are read from
-  `~/.local/share/devin/cli/sessions.db` (SQLite, read-only), so two panes
-  running different `/model` selections each show their own model. A session
-  not found in the DB falls back to the `config.json` default. The DB is
-  opened read-only and only `id, model` are selected, matching the omp
-  `agent.db` discipline.
+  as `snapshot.model` and used as the fallback when a session is not in
+  `sessions.db`. The API `planInfo.planName` is the subscription plan and is
+  not used as a model. A missing or malformed models catalog leaves the raw
+  id and does not fail the quota fetch. Per-session active models are read
+  from `~/.local/share/devin/cli/sessions.db` (SQLite, read-only, selecting
+  only `id` and `model` — the omp `models.db` discipline, not `agent.db`),
+  so two panes running different `/model` selections each show their own
+  model.
   Snapshots are stamped with `sha256("devin\0" || key)`
   so a credential swap cannot keep the previous account's last-good value.
   The API key is never logged, stored, or included in error messages.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ toml = "0.8"
 toml_edit = "0.22"
 ureq = { version = "2.12", features = ["json"] }
 # Bundled SQLite so macOS/Linux CI does not need libsqlite3 or a sqlite3 binary.
-# Used only for exact session-id lookups in OpenCode's local opencode.db.
+# Used for exact session-id lookups in OpenCode's local opencode.db, omp's
+# models.db, and Devin CLI's sessions.db.
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 
 # Only used to put the Codex app-server in its own process group.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 
 | Dimension | Source and behavior |
 | --- | --- |
-| Provider / model | Exact route and active model for the pane's session. Devin uses `config.json` `agent.model` for every pane, including a new session that never ran `/model`. |
+| Provider / model | Exact route and active model for the pane's session. Devin uses `sessions.db` when that pane's session id is present, otherwise `config.json` `agent.model`. |
 | Topic | Current visible user prompt; the previous topic survives when it scrolls away. |
 | Context | Used percentage of the active model's context window. |
 | Cache | Session cache hit rate when the agent exposes trustworthy counters. |
@@ -115,7 +115,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 | OpenCode | OpenCode Go 5h + 7d; 30d in dashboard | exact local session model/context |
 | Pi | Canonical Codex quota on an exact account match | model, context, cache, supported TTL data |
 | omp (oh-my-pi) | OMP-normalized windows such as `5h`, `1d`, `7d`, `Monthly` | model, context, cache, supported TTL data |
-| Devin CLI | 1d + 7d | Model from `~/.config/devin/config.json` `agent.model` (Issue #53), mapped through local `devin-models.json` when present. New sessions that never run `/model` use this default. Not the API `planName`. |
+| Devin CLI | 1d + 7d | Per-session model from `~/.local/share/devin/cli/sessions.db` (`id`, `model`), mapped through local `devin-models.json`. A session not in the DB uses `config.json` `agent.model`. Not the API `planName`. |
 
 OMP is a generic adapter, not a second set of provider adapters. The plugin runs
 `omp usage --json --provider <id>`, retains OMP's window labels, and attributes

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,7 +94,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 
 | 维度 | 来源与行为 |
 | --- | --- |
-| 供应商 / 模型 | 当前 pane 精确 session 的路由和模型。Devin 每个 pane 都用 `config.json` 的 `agent.model`，包括从未执行 `/model` 的新 session。 |
+| 供应商 / 模型 | 当前 pane 精确 session 的路由和模型。Devin 能在 `sessions.db` 里对上 session id 时用该 session 的模型，否则回退到 `config.json` 的 `agent.model`。 |
 | Topic | 当前可见的用户问题；滚出屏幕后保留已发布主题。 |
 | Context | 当前模型上下文窗口的已用比例。 |
 | Cache | 上游提供可信计数时显示 session 缓存命中率。 |
@@ -111,7 +111,7 @@ herdr plugin action invoke refresh --plugin herdr-agent-quota
 | OpenCode | OpenCode Go 5h + 7d；dashboard 含 30d | 精确本地 session 的 model/context |
 | Pi | 只有账户精确匹配时复用规范 Codex 额度 | model、context、cache、可支持的 TTL |
 | omp（oh-my-pi） | 原样展示 `omp usage` 归一化窗口，如 `5h`、`1d`、`7d`、`Monthly` | model、context、cache、可支持的 TTL |
-| Devin CLI | 1d + 7d | 模型来自 `~/.config/devin/config.json` 的 `agent.model`（Issue #53），有 `devin-models.json` 时映射为显示名。新 session 不切 `/model` 也用这个默认值。不使用 API 的 `planName`。 |
+| Devin CLI | 1d + 7d | 有 session id 时从 `~/.local/share/devin/cli/sessions.db` 读该 session 的 `model`，有 `devin-models.json` 时映射为显示名。DB 里没有这条 session 则用 `config.json` 的 `agent.model`。不使用 API 的 `planName`。 |
 
 OMP 是通用适配，不为内部每个供应商维护第二套规则。插件只调用
 `omp usage --json --provider <id>`，保留 OMP 给出的窗口标签，再用 session 的

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -1013,7 +1013,7 @@ mod tests {
 
     #[test]
     fn id_kind_preserves_every_existing_harness_session() {
-        for agent in ["claude", "codex", "grok", "agy", "opencode"] {
+        for agent in ["claude", "codex", "grok", "agy", "opencode", "devin"] {
             let value = json!({"result": {"agents": [{
                 "pane_id": "w1:p1",
                 "agent": agent,

--- a/src/model.rs
+++ b/src/model.rs
@@ -557,8 +557,9 @@ pub struct ProviderSnapshot {
     ///
     /// StatusLine providers also keep the per-session value below so panes
     /// running the same provider can be distinguished from one another.
-    /// Devin stores the CLI `config.json` model here. Panes read it through
-    /// [`Self::model_for_session`] when they have no per-session entry.
+    /// Devin stores the CLI `config.json` default here. A pane whose session
+    /// is in `sessions.db` reads `session_models` instead; otherwise
+    /// [`Self::model_for_session`] falls back to this value.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default)]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -673,6 +673,37 @@ mod tests {
     }
 
     #[test]
+    fn devin_panes_keep_distinct_session_models() {
+        let mut snapshot = ProviderSnapshot::new(
+            Provider::Devin,
+            vec![window(WindowKind::Weekly, 10.0, 183_600)],
+            0,
+        )
+        .with_model(Some("SWE-1.7 Medium".to_string()));
+        snapshot
+            .session_models
+            .insert("session-a".to_string(), "Opus 4.6".to_string());
+
+        let switched = MetadataTokens::from_snapshot_for_pane(
+            &snapshot,
+            0,
+            Some("session-a"),
+            PercentStyle::default(),
+        );
+        assert_eq!(switched.quota_model, "Opus 4.6");
+        assert_eq!(switched.quota_provider_model, "Devin/Opus 4.6");
+
+        let untouched = MetadataTokens::from_snapshot_for_pane(
+            &snapshot,
+            0,
+            Some("session-b"),
+            PercentStyle::default(),
+        );
+        assert_eq!(untouched.quota_model, "SWE-1.7 Medium");
+        assert_eq!(untouched.quota_provider_model, "Devin/SWE-1.7 Medium");
+    }
+
+    #[test]
     fn metadata_uses_context_and_cache_for_the_pane_session() {
         let mut snapshot = ProviderSnapshot::new(Provider::Codex, vec![], 0);
         snapshot.session_contexts.insert(

--- a/src/providers/devin.rs
+++ b/src/providers/devin.rs
@@ -119,7 +119,12 @@ pub fn fetch_for_sessions(session_ids: &[String]) -> Result<ProviderSnapshot> {
     let mut snapshot =
         parse_user_status(&value, CacheStore::now_unix()).map_err(anyhow::Error::from)?;
     apply_configured_model(&mut snapshot, configured_model.as_deref(), catalog.as_ref());
-    apply_session_models(&mut snapshot, session_ids, catalog.as_ref());
+    apply_session_models(
+        &mut snapshot,
+        session_ids,
+        catalog.as_ref(),
+        sessions_db_path().as_deref(),
+    );
     Ok(snapshot.with_account_id(Some(account_id)))
 }
 
@@ -140,24 +145,29 @@ fn apply_configured_model(
 /// `session_models`. A session not found in the DB, or when the DB is
 /// missing/unreadable, simply gets no entry — `model_for_session` then falls
 /// back to `snapshot.model` (the `config.json` default).
+///
+/// `db_path` is injected so tests do not mutate process-wide `XDG_*` variables.
+/// Production passes [`sessions_db_path`]. The default is never copied into
+/// `session_models`.
 fn apply_session_models(
     snapshot: &mut ProviderSnapshot,
     session_ids: &[String],
     catalog: Option<&Value>,
+    db_path: Option<&Path>,
 ) {
     if session_ids.is_empty() {
         return;
     }
-    let Some(db_path) = sessions_db_path() else {
+    let Some(db_path) = db_path else {
         return;
     };
-    let models = match session_models_from_db(&db_path, session_ids) {
-        Ok(models) => models,
-        Err(_) => return,
+    let Ok(models) = session_models_from_db(db_path, session_ids) else {
+        return;
     };
     for (session_id, model_id) in models {
-        let display = display_name_for_model(&model_id, catalog);
-        snapshot.session_models.insert(session_id, display);
+        snapshot
+            .session_models
+            .insert(session_id, display_name_for_model(&model_id, catalog));
     }
 }
 
@@ -173,7 +183,9 @@ fn sessions_db_path() -> Option<PathBuf> {
 }
 
 /// Query `sessions.db` for the `model` column of each requested session id.
-/// The DB is opened read-only; a missing table, a locked DB, or any other
+///
+/// Opened read-only, selecting only `id`/`model` — the omp `models.db`
+/// discipline, not `agent.db`. A missing table, a locked DB, or any other
 /// error yields `Err` so the caller skips per-session attribution entirely.
 fn session_models_from_db(
     db_path: &Path,
@@ -183,10 +195,11 @@ fn session_models_from_db(
     let mut statement = connection.prepare("SELECT model FROM sessions WHERE id = ?1 LIMIT 1")?;
     let mut results = Vec::new();
     for session_id in session_ids {
-        let model: Option<String> = statement
-            .query_row(rusqlite::params![session_id], |row| row.get(0))
+        let model = statement
+            .query_row(rusqlite::params![session_id], |row| row.get::<_, String>(0))
             .ok()
-            .filter(|model: &String| !model.trim().is_empty());
+            .map(|model| model.trim().to_string())
+            .filter(|model| !model.is_empty());
         if let Some(model) = model {
             results.push((session_id.clone(), model));
         }
@@ -825,13 +838,6 @@ mod tests {
     fn apply_session_models_populates_session_models_with_catalog_labels() {
         let dir = tempdir().unwrap();
         let db = write_sessions_db(dir.path(), &[("dapper-indigo", "claude-opus-4-6")]);
-        // Override sessions_db_path by pointing XDG_DATA_HOME at our temp dir
-        // so sessions_db_path() finds our test DB.
-        std::env::set_var("XDG_DATA_HOME", dir.path());
-        let db_in_cli = dir.path().join("devin").join("cli").join("sessions.db");
-        fs::create_dir_all(db_in_cli.parent().unwrap()).unwrap();
-        fs::copy(&db, &db_in_cli).unwrap();
-
         let mut snapshot = parse_user_status(&pro_fixture(), 1).expect("snapshot");
         apply_configured_model(
             &mut snapshot,
@@ -842,10 +848,9 @@ mod tests {
             &mut snapshot,
             &["dapper-indigo".to_string()],
             Some(&catalog_fixture()),
+            Some(&db),
         );
-        std::env::remove_var("XDG_DATA_HOME");
 
-        // snapshot.model is the config default; session_models has the per-session override
         assert_eq!(snapshot.model.as_deref(), Some("SWE-1.7 Medium"));
         assert_eq!(
             snapshot
@@ -854,23 +859,60 @@ mod tests {
                 .map(String::as_str),
             Some("Opus 4.6")
         );
+        assert_eq!(
+            snapshot.model_for_session(Some("dapper-indigo")),
+            Some("Opus 4.6")
+        );
+        assert_eq!(
+            snapshot.model_for_session(Some("brand-new-session")),
+            Some("SWE-1.7 Medium")
+        );
     }
 
     #[test]
     fn apply_session_models_does_nothing_when_no_session_ids() {
         let mut snapshot = parse_user_status(&pro_fixture(), 1).expect("snapshot");
-        apply_session_models(&mut snapshot, &[], None);
+        apply_session_models(&mut snapshot, &[], None, None);
         assert!(snapshot.session_models.is_empty());
     }
 
     #[test]
     fn apply_session_models_does_nothing_when_db_missing() {
-        let dir = tempdir().unwrap();
-        std::env::set_var("XDG_DATA_HOME", dir.path());
         let mut snapshot = parse_user_status(&pro_fixture(), 1).expect("snapshot");
-        apply_session_models(&mut snapshot, &["nonexistent-session".to_string()], None);
-        std::env::remove_var("XDG_DATA_HOME");
+        apply_session_models(
+            &mut snapshot,
+            &["nonexistent-session".to_string()],
+            None,
+            None,
+        );
         assert!(snapshot.session_models.is_empty());
+        apply_configured_model(&mut snapshot, Some("swe-1-7-medium"), None);
+        assert_eq!(
+            snapshot.model_for_session(Some("nonexistent-session")),
+            Some("swe-1-7-medium")
+        );
+    }
+
+    #[test]
+    fn session_models_from_db_ignores_extra_columns() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("sessions.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (id TEXT, model TEXT, created_at TEXT, workspace TEXT)",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions (id, model, created_at, workspace) VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params!["dapper-indigo", "swe-1-7-medium", "2026-01-01", "/tmp"],
+        )
+        .unwrap();
+        let models =
+            session_models_from_db(&db_path, &["dapper-indigo".to_string()]).expect("db read");
+        assert_eq!(
+            models,
+            vec![("dapper-indigo".to_string(), "swe-1-7-medium".to_string())]
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this changes

Hardens #55 without changing its route. Devin still reads per-session models from `sessions.db` and falls back to `config.json` `agent.model`. Tests inject the DB path instead of mutating `XDG_DATA_HOME` (that raced and failed macOS CI). A DB miss never copies the default into `session_models`. Docs now describe the omp `models.db` discipline, not `agent.db`.

Claude / Codex / Grok / Agy / OpenCode / Pi / OMP are untouched.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features --locked`
- [x] A parser change comes with a fixture in `tests/fixtures/` and a test
- [x] No new network call, background process, or credential write

## Provider impact

Devin only. Other providers' fetch, cache, and `model_for_session` behavior are unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61c97793-f45e-4f08-b5c7-dc96b2a0ad16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61c97793-f45e-4f08-b5c7-dc96b2a0ad16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

