### PR TITLE
fix: share newest Claude quota across same-profile panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Idle Claude panes on the same `CLAUDE_CONFIG_DIR` profile now share that
+  profile's newest 5h/7d reading instead of freezing the last statusLine tick
+  for each conversation. Separate work/personal config directories stay
+  isolated, including when their reset times happen to match. A window whose
+  `resets_at` has already passed is shown as unknown rather than as a live
+  percentage. Based on the report in #57.
 - `configure` no longer runs `normalize_official_row` when generating
   `rows_by_agent` from user-owned shared rows, so tokens such as `pane` and
   `terminal_title_stripped` stay intact. With brand colors off, those custom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Idle Claude panes on the same `CLAUDE_CONFIG_DIR` profile now share that
   profile's newest 5h/7d reading instead of freezing the last statusLine tick
-  for each conversation. Separate work/personal config directories stay
-  isolated, including when their reset times happen to match. A window whose
-  `resets_at` has already passed is shown as unknown rather than as a live
-  percentage. Based on the report in #57.
+  for each conversation. A later idle tick that repeats an older percentage
+  for the same reset does not roll the shared figure back. Separate
+  work/personal config directories stay isolated, including when their reset
+  times happen to match. A window whose `resets_at` has already passed is
+  shown as unknown rather than as a live percentage. Based on the report in
+  #57.
 - `configure` no longer runs `normalize_official_row` when generating
   `rows_by_agent` from user-owned shared rows, so tokens such as `pane` and
   `terminal_title_stripped` stay intact. With brand colors off, those custom

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,7 +2,7 @@ use crate::cli::{
     AgentOrder, BrandColors, FieldSet, LowQuotaAlert, PercentStyle, SidebarLayout, SidebarRowGap,
 };
 use crate::model::{
-    merge_omitted_window_list, BillingTarget, ContextUsage, Provider, ProviderSnapshot,
+    merge_omitted_window_list, BillingTarget, ContextUsage, Provider, ProviderSnapshot, UsageWindow,
 };
 use anyhow::{Context, Result};
 use directories::ProjectDirs;
@@ -203,8 +203,20 @@ impl CacheStore {
     pub fn save_statusline_observation(
         &self,
         provider: Provider,
+        snapshot: ProviderSnapshot,
+        observation: &Value,
+    ) -> Result<()> {
+        self.save_statusline_observation_with_quota_scope(provider, snapshot, observation, None)
+    }
+
+    /// Claude statusLine observations also stamp an opaque profile scope so
+    /// idle panes on the same `CLAUDE_CONFIG_DIR` share the newest quota.
+    pub fn save_statusline_observation_with_quota_scope(
+        &self,
+        provider: Provider,
         mut snapshot: ProviderSnapshot,
         observation: &Value,
+        quota_scope: Option<&str>,
     ) -> Result<()> {
         self.ensure()?;
         let session_id = statusline_session_id(observation);
@@ -249,7 +261,7 @@ impl CacheStore {
                     .insert(session_id.to_string(), context);
             }
         }
-        merge_session_windows(&mut snapshot, previous_snapshot, session_id);
+        merge_session_windows(&mut snapshot, previous_snapshot, session_id, quota_scope);
         let current_session_ids = session_id
             .map(|session_id| vec![session_id.to_string()])
             .unwrap_or_default();
@@ -344,7 +356,7 @@ impl CacheStore {
                     .insert(session_id.to_string(), context);
             }
         }
-        merge_session_windows(&mut snapshot, previous.as_ref(), session_id);
+        merge_session_windows(&mut snapshot, previous.as_ref(), session_id, None);
         let current_session_ids = session_id
             .map(|session_id| vec![session_id.to_string()])
             .unwrap_or_default();
@@ -812,6 +824,7 @@ fn merge_session_windows(
     snapshot: &mut ProviderSnapshot,
     previous: Option<&ProviderSnapshot>,
     session_id: Option<&str>,
+    quota_scope: Option<&str>,
 ) {
     if let Some(previous) = previous {
         for (session_id, windows) in &previous.session_windows {
@@ -820,19 +833,42 @@ fn merge_session_windows(
                 .entry(session_id.clone())
                 .or_insert_with(|| windows.clone());
         }
-        match session_id {
-            Some(session_id) => {
-                let previous_windows = previous
-                    .session_windows
-                    .get(session_id)
-                    .map(Vec::as_slice)
-                    .or_else(|| {
-                        previous
-                            .session_windows
-                            .is_empty()
-                            .then_some(previous.windows.as_slice())
-                    });
-                if let Some(previous_windows) = previous_windows {
+        for (session_id, scope) in &previous.session_quota_scopes {
+            snapshot
+                .session_quota_scopes
+                .entry(session_id.clone())
+                .or_insert_with(|| scope.clone());
+        }
+        for (scope, windows) in &previous.quota_scope_windows {
+            snapshot
+                .quota_scope_windows
+                .entry(scope.clone())
+                .or_insert_with(|| windows.clone());
+        }
+    }
+    let resolved_scope = session_id.and_then(|session_id| {
+        quota_scope.map(str::to_string).or_else(|| {
+            snapshot
+                .session_quota_scopes
+                .get(session_id)
+                .cloned()
+                .or_else(|| {
+                    previous
+                        .and_then(|previous| previous.session_quota_scopes.get(session_id).cloned())
+                })
+        })
+    });
+    if let (Some(session_id), Some(scope)) = (session_id, resolved_scope.as_deref()) {
+        snapshot
+            .session_quota_scopes
+            .insert(session_id.to_string(), scope.to_string());
+    }
+    if let Some(previous) = previous {
+        match (session_id, resolved_scope.as_deref()) {
+            (Some(session_id), scope) => {
+                let previous_windows = previous_windows_for_merge(previous, session_id, scope)
+                    .map(|windows| windows.to_vec());
+                if let Some(previous_windows) = previous_windows.as_deref() {
                     merge_omitted_window_list(
                         &mut snapshot.windows,
                         previous_windows,
@@ -840,7 +876,7 @@ fn merge_session_windows(
                     );
                 }
             }
-            None => snapshot.merge_omitted_windows(previous),
+            (None, _) => snapshot.merge_omitted_windows(previous),
         }
     }
     if let Some(session_id) = session_id {
@@ -848,12 +884,49 @@ fn merge_session_windows(
             .session_windows
             .insert(session_id.to_string(), snapshot.windows.clone());
     }
+    if let Some(scope) = resolved_scope.as_deref() {
+        if !snapshot.windows.is_empty() {
+            snapshot
+                .quota_scope_windows
+                .insert(scope.to_string(), snapshot.windows.clone());
+        }
+    }
+}
+
+fn previous_windows_for_merge<'a>(
+    previous: &'a ProviderSnapshot,
+    session_id: &str,
+    quota_scope: Option<&str>,
+) -> Option<&'a [UsageWindow]> {
+    if let Some(scope) = quota_scope {
+        if let Some(windows) = previous.quota_scope_windows.get(scope) {
+            return Some(windows.as_slice());
+        }
+        return previous.session_windows.get(session_id).map(Vec::as_slice);
+    }
+    previous
+        .session_windows
+        .get(session_id)
+        .map(Vec::as_slice)
+        .or_else(|| {
+            previous
+                .session_windows
+                .is_empty()
+                .then_some(previous.windows.as_slice())
+        })
 }
 
 fn prune_session_diagnostics(snapshot: &mut ProviderSnapshot, current_session_ids: &[String]) {
     prune_session_map(&mut snapshot.session_models, current_session_ids);
     prune_session_map(&mut snapshot.session_contexts, current_session_ids);
     prune_session_map(&mut snapshot.session_windows, current_session_ids);
+    prune_session_map(&mut snapshot.session_quota_scopes, current_session_ids);
+    snapshot.quota_scope_windows.retain(|scope, _| {
+        snapshot
+            .session_quota_scopes
+            .values()
+            .any(|mapped| mapped == scope)
+    });
 }
 
 fn prune_session_map<T>(map: &mut BTreeMap<String, T>, current_session_ids: &[String]) {
@@ -1130,6 +1203,233 @@ mod tests {
             90.0
         );
         assert!(saved.windows_for_session(Some("unknown")).is_empty());
+    }
+
+    #[test]
+    fn statusline_observations_share_quota_windows_for_the_same_profile_scope() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![UsageWindow::new(
+                        WindowKind::FiveHour,
+                        5.0,
+                        Some(ResetAt::from_unix_seconds(16_000)),
+                    )
+                    .unwrap()],
+                    1,
+                ),
+                &json!({"session_id": "session-c"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![UsageWindow::new(
+                        WindowKind::FiveHour,
+                        92.0,
+                        Some(ResetAt::from_unix_seconds(16_000)),
+                    )
+                    .unwrap()],
+                    2,
+                ),
+                &json!({"session_id": "session-a"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        assert_eq!(
+            saved.windows_for_session(Some("session-c"))[0].used_percent,
+            92.0
+        );
+        assert_eq!(
+            saved.windows_for_session(Some("session-a"))[0].used_percent,
+            92.0
+        );
+        assert_eq!(saved.session_quota_scopes["session-c"], "scope-w");
+        assert_eq!(saved.session_quota_scopes["session-a"], "scope-w");
+    }
+
+    #[test]
+    fn statusline_observations_keep_quota_isolated_across_profile_scopes() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![UsageWindow::new(
+                        WindowKind::FiveHour,
+                        18.0,
+                        Some(ResetAt::from_unix_seconds(16_000)),
+                    )
+                    .unwrap()],
+                    1,
+                ),
+                &json!({"session_id": "work"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![UsageWindow::new(
+                        WindowKind::FiveHour,
+                        82.0,
+                        Some(ResetAt::from_unix_seconds(16_000)),
+                    )
+                    .unwrap()],
+                    2,
+                ),
+                &json!({"session_id": "personal"}),
+                Some("scope-p"),
+            )
+            .unwrap();
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        assert_eq!(
+            saved.windows_for_session(Some("work"))[0].used_percent,
+            18.0
+        );
+        assert_eq!(
+            saved.windows_for_session(Some("personal"))[0].used_percent,
+            82.0
+        );
+    }
+
+    #[test]
+    fn empty_rate_limits_on_a_new_session_do_not_clear_profile_quota() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![UsageWindow::new(
+                        WindowKind::FiveHour,
+                        18.0,
+                        Some(ResetAt::from_unix_seconds(16_000)),
+                    )
+                    .unwrap()],
+                    1,
+                ),
+                &json!({"session_id": "session-a"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(Provider::Claude, vec![], 2),
+                &json!({"session_id": "session-b"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        assert_eq!(
+            saved.windows_for_session(Some("session-a"))[0].used_percent,
+            18.0
+        );
+        assert_eq!(
+            saved.windows_for_session(Some("session-b"))[0].used_percent,
+            18.0
+        );
+    }
+
+    #[test]
+    fn omitted_five_hour_window_is_restored_from_the_same_profile_scope() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![
+                        UsageWindow::new(
+                            WindowKind::FiveHour,
+                            22.0,
+                            Some(ResetAt::from_unix_seconds(2_000)),
+                        )
+                        .unwrap(),
+                        UsageWindow::new(
+                            WindowKind::Weekly,
+                            65.0,
+                            Some(ResetAt::from_unix_seconds(10_000)),
+                        )
+                        .unwrap(),
+                    ],
+                    1_000,
+                ),
+                &json!({"session_id": "session-a"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![UsageWindow::new(
+                        WindowKind::Weekly,
+                        66.0,
+                        Some(ResetAt::from_unix_seconds(10_000)),
+                    )
+                    .unwrap()],
+                    1_200,
+                ),
+                &json!({"session_id": "session-b"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        assert_eq!(
+            saved
+                .windows_for_session(Some("session-a"))
+                .iter()
+                .find(|window| window.kind == WindowKind::FiveHour)
+                .unwrap()
+                .used_percent,
+            22.0
+        );
+        assert_eq!(
+            saved
+                .windows_for_session(Some("session-b"))
+                .iter()
+                .find(|window| window.kind == WindowKind::FiveHour)
+                .unwrap()
+                .used_percent,
+            22.0
+        );
     }
 
     #[test]
@@ -1610,6 +1910,42 @@ mod tests {
         assert!(saved
             .session_models
             .contains_key(&format!("session-{}", MAX_STATUSLINE_SESSIONS + 7)));
+    }
+
+    #[test]
+    fn unreferenced_quota_scope_windows_are_pruned_with_sessions() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        for index in 0..(MAX_STATUSLINE_SESSIONS + 8) {
+            let session_id = format!("session-{index}");
+            let scope = format!("scope-{index}");
+            cache
+                .save_statusline_observation_with_quota_scope(
+                    Provider::Claude,
+                    ProviderSnapshot::new(
+                        Provider::Claude,
+                        vec![UsageWindow::new(WindowKind::Weekly, 1.0, None).unwrap()],
+                        index as u64,
+                    )
+                    .with_model(Some(format!("model-{index}")))
+                    .with_context(Some(ContextUsage::new(0.0).unwrap())),
+                    &json!({"session_id": session_id}),
+                    Some(&scope),
+                )
+                .unwrap();
+        }
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        assert_eq!(saved.session_quota_scopes.len(), MAX_STATUSLINE_SESSIONS);
+        assert_eq!(saved.quota_scope_windows.len(), MAX_STATUSLINE_SESSIONS);
+        assert!(saved
+            .session_quota_scopes
+            .values()
+            .all(|scope| saved.quota_scope_windows.contains_key(scope)));
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,7 +2,8 @@ use crate::cli::{
     AgentOrder, BrandColors, FieldSet, LowQuotaAlert, PercentStyle, SidebarLayout, SidebarRowGap,
 };
 use crate::model::{
-    merge_omitted_window_list, BillingTarget, ContextUsage, Provider, ProviderSnapshot, UsageWindow,
+    merge_omitted_window_list, window_in, BillingTarget, ContextUsage, Provider, ProviderSnapshot,
+    UsageWindow, WindowKind,
 };
 use anyhow::{Context, Result};
 use directories::ProjectDirs;
@@ -886,9 +887,75 @@ fn merge_session_windows(
     }
     if let Some(scope) = resolved_scope.as_deref() {
         if !snapshot.windows.is_empty() {
+            let stored = snapshot
+                .quota_scope_windows
+                .get(scope)
+                .cloned()
+                .unwrap_or_default();
+            let merged = merge_profile_quota_windows(&stored, &snapshot.windows);
             snapshot
                 .quota_scope_windows
-                .insert(scope.to_string(), snapshot.windows.clone());
+                .insert(scope.to_string(), merged);
+        }
+    }
+}
+
+/// Merge one Claude profile's canonical windows.
+///
+/// StatusLine arrival order is not freshness: an idle pane can keep emitting
+/// an old `used_percent` for the current reset. Same-reset percentages are
+/// therefore monotonic; only a newer `resets_at` may lower the figure. When
+/// neither side has a reset, used percent is still monotonic so an undated
+/// idle tick cannot roll the canonical value back.
+fn merge_profile_quota_windows(
+    stored: &[UsageWindow],
+    current: &[UsageWindow],
+) -> Vec<UsageWindow> {
+    [
+        WindowKind::FiveHour,
+        WindowKind::Weekly,
+        WindowKind::Monthly,
+    ]
+    .into_iter()
+    .filter_map(|kind| {
+        merge_profile_quota_window(window_in(stored, kind), window_in(current, kind))
+    })
+    .collect()
+}
+
+fn merge_profile_quota_window(
+    stored: Option<&UsageWindow>,
+    current: Option<&UsageWindow>,
+) -> Option<UsageWindow> {
+    match (stored, current) {
+        (None, None) => None,
+        (Some(stored), None) => Some(stored.clone()),
+        (None, Some(current)) => Some(current.clone()),
+        (Some(stored), Some(current)) => Some(prefer_fresher_profile_window(stored, current)),
+    }
+}
+
+fn prefer_fresher_profile_window(stored: &UsageWindow, current: &UsageWindow) -> UsageWindow {
+    match (stored.resets_at, current.resets_at) {
+        (Some(stored_reset), Some(current_reset)) => {
+            if current_reset.unix_seconds() > stored_reset.unix_seconds() {
+                current.clone()
+            } else if current_reset.unix_seconds() < stored_reset.unix_seconds() {
+                stored.clone()
+            } else if current.used_percent > stored.used_percent {
+                current.clone()
+            } else {
+                stored.clone()
+            }
+        }
+        (Some(_), None) => stored.clone(),
+        (None, Some(_)) => current.clone(),
+        (None, None) => {
+            if current.used_percent > stored.used_percent {
+                current.clone()
+            } else {
+                stored.clone()
+            }
         }
     }
 }
@@ -1012,9 +1079,10 @@ fn sessions_match(previous_session_id: Option<&str>, session_id: Option<&str>) -
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{merge_profile_quota_windows, *};
     use crate::model::{
-        BillingTarget, CacheUsage, ContextUsage, Provider, ResetAt, UsageWindow, WindowKind,
+        window_in, BillingTarget, CacheUsage, ContextUsage, Provider, ResetAt, UsageWindow,
+        WindowKind,
     };
     use serde_json::json;
     use tempfile::tempdir;
@@ -1259,6 +1327,220 @@ mod tests {
         );
         assert_eq!(saved.session_quota_scopes["session-c"], "scope-w");
         assert_eq!(saved.session_quota_scopes["session-a"], "scope-w");
+    }
+
+    fn five_hour(used: f64, reset: u64) -> UsageWindow {
+        UsageWindow::new(
+            WindowKind::FiveHour,
+            used,
+            Some(ResetAt::from_unix_seconds(reset)),
+        )
+        .unwrap()
+    }
+
+    fn weekly(used: f64, reset: u64) -> UsageWindow {
+        UsageWindow::new(
+            WindowKind::Weekly,
+            used,
+            Some(ResetAt::from_unix_seconds(reset)),
+        )
+        .unwrap()
+    }
+
+    fn used_percent(windows: &[UsageWindow], kind: WindowKind) -> f64 {
+        windows
+            .iter()
+            .find(|window| window.kind == kind)
+            .unwrap()
+            .used_percent
+    }
+
+    #[test]
+    fn idle_statusline_tick_does_not_regress_profile_quota() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(Provider::Claude, vec![five_hour(5.0, 16_000)], 1),
+                &json!({"session_id": "session-c"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(Provider::Claude, vec![five_hour(92.0, 16_000)], 2),
+                &json!({"session_id": "session-a"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(Provider::Claude, vec![five_hour(5.0, 16_000)], 3),
+                &json!({"session_id": "session-c"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        assert_eq!(
+            used_percent(
+                saved.windows_for_session(Some("session-c")),
+                WindowKind::FiveHour
+            ),
+            92.0
+        );
+        assert_eq!(
+            used_percent(
+                saved.windows_for_session(Some("session-a")),
+                WindowKind::FiveHour
+            ),
+            92.0
+        );
+        assert_eq!(
+            used_percent(&saved.quota_scope_windows["scope-w"], WindowKind::FiveHour),
+            92.0
+        );
+        assert_eq!(
+            saved.quota_scope_windows["scope-w"][0].remaining_percent,
+            8.0
+        );
+    }
+
+    #[test]
+    fn a_newer_reset_window_replaces_profile_quota_even_when_used_percent_drops() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(Provider::Claude, vec![five_hour(92.0, 16_000)], 1),
+                &json!({"session_id": "session-a"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(Provider::Claude, vec![five_hour(5.0, 34_000)], 2),
+                &json!({"session_id": "session-a"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        let window = saved.windows_for_session(Some("session-a"))[0].clone();
+        assert_eq!(window.used_percent, 5.0);
+        assert_eq!(window.resets_at, Some(ResetAt::from_unix_seconds(34_000)));
+    }
+
+    #[test]
+    fn an_older_reset_window_does_not_replace_profile_quota() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(Provider::Claude, vec![five_hour(20.0, 34_000)], 1),
+                &json!({"session_id": "session-a"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+        cache
+            .save_statusline_observation_with_quota_scope(
+                Provider::Claude,
+                ProviderSnapshot::new(Provider::Claude, vec![five_hour(95.0, 16_000)], 2),
+                &json!({"session_id": "session-c"}),
+                Some("scope-w"),
+            )
+            .unwrap();
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        let window = saved.quota_scope_windows["scope-w"][0].clone();
+        assert_eq!(window.used_percent, 20.0);
+        assert_eq!(window.resets_at, Some(ResetAt::from_unix_seconds(34_000)));
+    }
+
+    #[test]
+    fn merge_profile_quota_windows_is_per_kind_and_preserves_metadata() {
+        let stored = vec![
+            five_hour(92.0, 16_000).with_source_window("5h", Some(18_000)),
+            weekly(40.0, 80_000),
+        ];
+        let current = vec![
+            five_hour(5.0, 16_000),
+            weekly(55.0, 80_000).with_source_window("7d", Some(604_800)),
+        ];
+        let merged = merge_profile_quota_windows(&stored, &current);
+        assert_eq!(used_percent(&merged, WindowKind::FiveHour), 92.0);
+        assert_eq!(
+            window_in(&merged, WindowKind::FiveHour)
+                .unwrap()
+                .source_label
+                .as_deref(),
+            Some("5h")
+        );
+        assert_eq!(used_percent(&merged, WindowKind::Weekly), 55.0);
+        assert_eq!(
+            window_in(&merged, WindowKind::Weekly)
+                .unwrap()
+                .duration_seconds,
+            Some(604_800)
+        );
+    }
+
+    #[test]
+    fn merge_profile_quota_windows_accepts_a_newer_reset_and_rejects_an_older_one() {
+        let newer =
+            merge_profile_quota_windows(&[five_hour(92.0, 16_000)], &[five_hour(5.0, 34_000)]);
+        assert_eq!(newer[0].used_percent, 5.0);
+        assert_eq!(newer[0].resets_at, Some(ResetAt::from_unix_seconds(34_000)));
+
+        let older =
+            merge_profile_quota_windows(&[five_hour(20.0, 34_000)], &[five_hour(95.0, 16_000)]);
+        assert_eq!(older[0].used_percent, 20.0);
+        assert_eq!(older[0].resets_at, Some(ResetAt::from_unix_seconds(34_000)));
+    }
+
+    #[test]
+    fn merge_profile_quota_windows_keeps_a_dated_canonical_when_reset_is_missing() {
+        let stored = five_hour(92.0, 16_000);
+        let undated = UsageWindow::new(WindowKind::FiveHour, 5.0, None).unwrap();
+        let merged = merge_profile_quota_windows(&[stored], &[undated]);
+        assert_eq!(merged[0].used_percent, 92.0);
+        assert_eq!(
+            merged[0].resets_at,
+            Some(ResetAt::from_unix_seconds(16_000))
+        );
+    }
+
+    #[test]
+    fn merge_profile_quota_windows_does_not_regress_when_both_resets_are_missing() {
+        let first = UsageWindow::new(WindowKind::Weekly, 27.0, None).unwrap();
+        let higher = UsageWindow::new(WindowKind::Weekly, 28.0, None).unwrap();
+        let stale = UsageWindow::new(WindowKind::Weekly, 5.0, None).unwrap();
+        assert_eq!(
+            merge_profile_quota_windows(std::slice::from_ref(&first), &[higher])[0].used_percent,
+            28.0
+        );
+        assert_eq!(
+            merge_profile_quota_windows(&[first], &[stale])[0].used_percent,
+            27.0
+        );
     }
 
     #[test]

--- a/src/configure/claude.rs
+++ b/src/configure/claude.rs
@@ -1,7 +1,7 @@
 use super::statusline::{settings_path, Adapter};
 use crate::cache::{CacheStore, DEFAULT_WATCH_INTERVAL_SECONDS};
 use crate::model::Provider;
-use crate::providers::claude::parse_statusline;
+use crate::providers::claude::{parse_statusline, quota_scope_id};
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::io::{Read, Write};
@@ -73,7 +73,17 @@ pub fn run_statusline_hook() -> Result<()> {
     if let Ok(value) = serde_json::from_slice::<Value>(&input) {
         if let Ok(snapshot) = parse_statusline(&value, CacheStore::now_unix()) {
             if let Ok(cache) = CacheStore::from_env() {
-                let _ = cache.save_statusline_observation(Provider::Claude, snapshot, &value);
+                let quota_scope = quota_scope_id(
+                    std::env::var_os("CLAUDE_CONFIG_DIR").as_deref(),
+                    std::env::var_os("HOME").as_deref(),
+                    std::env::current_dir().ok().as_deref(),
+                );
+                let _ = cache.save_statusline_observation_with_quota_scope(
+                    Provider::Claude,
+                    snapshot,
+                    &value,
+                    quota_scope.as_deref(),
+                );
             }
         }
     }

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -142,6 +142,29 @@ mod tests {
         );
     }
 
+    #[test]
+    fn expired_windows_are_not_rendered_as_live_dashboard_quota() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![UsageWindow::new(
+                WindowKind::FiveHour,
+                20.0,
+                Some(ResetAt::from_unix_seconds(1_000)),
+            )
+            .unwrap()],
+            0,
+        );
+        let rendered = render_provider(
+            Provider::Claude,
+            Some(&snapshot),
+            1_001,
+            PercentStyle::default(),
+        );
+        assert!(rendered.contains("Claude N/A"), "{rendered}");
+        assert!(!rendered.contains("80%"), "{rendered}");
+        assert!(!rendered.contains("20%"), "{rendered}");
+    }
+
     /// The sidebar has no monthly token, so the dashboard is where a Go plan's
     /// 30d bucket has to surface. It appears only once something is cached.
     #[test]
@@ -157,13 +180,13 @@ mod tests {
                     UsageWindow::new(
                         WindowKind::FiveHour,
                         10.0,
-                        Some(ResetAt::from_unix_seconds(3_600)),
+                        Some(ResetAt::from_unix_seconds(2_000_000_000)),
                     )
                     .unwrap(),
                     UsageWindow::new(
                         WindowKind::Monthly,
                         30.0,
-                        Some(ResetAt::from_unix_seconds(1_500_000)),
+                        Some(ResetAt::from_unix_seconds(2_000_000_000)),
                     )
                     .unwrap(),
                 ],

--- a/src/model.rs
+++ b/src/model.rs
@@ -382,6 +382,15 @@ impl UsageWindow {
             .as_deref()
             .unwrap_or_else(|| self.kind.label())
     }
+
+    /// Whether this window can still be shown as a live reading.
+    ///
+    /// A known `resets_at` in the past or present is expired. Missing reset
+    /// times cannot be proven stale, so they stay visible.
+    pub fn is_current(&self, now_unix: u64) -> bool {
+        self.resets_at
+            .is_none_or(|reset| reset.unix_seconds() > now_unix)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -575,8 +584,22 @@ pub struct ProviderSnapshot {
     /// (Claude, Agy) can run two signed-in accounts into one cache file, and
     /// the top-level `windows` field only holds whichever account ticked last;
     /// those ticks are stored here so a pane can read its own account.
+    ///
+    /// Claude also records an opaque profile scope per session. When that
+    /// mapping exists, [`Self::windows_for_session`] prefers the profile's
+    /// latest windows over this legacy per-session copy. Agy has no equivalent
+    /// profile identity and keeps using this map.
     #[serde(default)]
     pub session_windows: BTreeMap<String, Vec<UsageWindow>>,
+    /// Opaque Claude profile identity for a session. The value is a SHA-256
+    /// hex digest of the normalized config directory; the raw path is never
+    /// stored.
+    #[serde(default)]
+    pub session_quota_scopes: BTreeMap<String, String>,
+    /// Latest quota windows for a Claude profile scope. Sessions that map to
+    /// the same scope share this canonical reading.
+    #[serde(default)]
+    pub quota_scope_windows: BTreeMap<String, Vec<UsageWindow>>,
     /// Login identity the snapshot was fetched for (Grok `user_id`, Codex
     /// `tokens.account_id`). Used to drop another account's cached quota after
     /// `grok login` / Codex account switch. Absent on snapshots written before
@@ -598,6 +621,8 @@ impl ProviderSnapshot {
             session_models: BTreeMap::new(),
             session_contexts: BTreeMap::new(),
             session_windows: BTreeMap::new(),
+            session_quota_scopes: BTreeMap::new(),
+            quota_scope_windows: BTreeMap::new(),
             account_id: None,
         }
     }
@@ -642,19 +667,33 @@ impl ProviderSnapshot {
     ///
     /// Context and model are session-local, so a known session never falls
     /// back to the provider-level value. Quota is account-level: Grok, Codex,
-    /// and Devin share one login's windows across every pane, and this map
-    /// stays empty for them. StatusLine providers fill the map; a known
-    /// session missing from a non-empty map must not borrow another account's
-    /// numbers. The top-level `windows` field is used when Herdr has no
-    /// session id, or when no session has reported windows yet (legacy cache).
+    /// and Devin share one login's windows across every pane, and the keyed
+    /// maps stay empty for them.
+    ///
+    /// Lookup order:
+    /// 1. No session id → top-level `windows`.
+    /// 2. Session has a Claude profile scope with canonical windows → those.
+    /// 3. Session has legacy `session_windows` → those (Agy, old cache).
+    /// 4. Every keyed map is empty → top-level `windows` (Grok/Codex/Devin
+    ///    and a StatusLine cache written before session maps existed).
+    /// 5. Keyed maps exist but this session is unknown → empty. A missing
+    ///    session must not borrow another account's numbers.
     pub fn windows_for_session(&self, session_id: Option<&str>) -> &[UsageWindow] {
         let Some(session_id) = session_id else {
             return &self.windows;
         };
+        if let Some(scope) = self.session_quota_scopes.get(session_id) {
+            if let Some(windows) = self.quota_scope_windows.get(scope) {
+                return windows;
+            }
+        }
         if let Some(windows) = self.session_windows.get(session_id) {
             return windows;
         }
-        if self.session_windows.is_empty() {
+        if self.session_windows.is_empty()
+            && self.session_quota_scopes.is_empty()
+            && self.quota_scope_windows.is_empty()
+        {
             return &self.windows;
         }
         &[]
@@ -718,15 +757,16 @@ impl ProviderSnapshot {
         windows: &[UsageWindow],
         now_unix: u64,
     ) -> Severity {
+        let live = live_windows(windows, now_unix);
         let relevant = match provider {
-            Provider::Grok => long_window(windows),
+            Provider::Grok => long_window(&live),
             Provider::Codex
             | Provider::Claude
             | Provider::Agy
             | Provider::OpenCodeGo
             | Provider::Omp
             | Provider::Devin => {
-                window_in(windows, WindowKind::FiveHour).or_else(|| long_window(windows))
+                window_in(&live, WindowKind::FiveHour).or_else(|| long_window(&live))
             }
         };
         relevant
@@ -748,6 +788,15 @@ pub(crate) fn window_in(windows: &[UsageWindow], kind: WindowKind) -> Option<&Us
 /// wins, because it is the limit that binds first.
 pub(crate) fn long_window(windows: &[UsageWindow]) -> Option<&UsageWindow> {
     window_in(windows, WindowKind::Weekly).or_else(|| window_in(windows, WindowKind::Monthly))
+}
+
+/// Windows that can still be treated as a live provider reading.
+pub(crate) fn live_windows(windows: &[UsageWindow], now_unix: u64) -> Vec<UsageWindow> {
+    windows
+        .iter()
+        .filter(|window| window.is_current(now_unix))
+        .cloned()
+        .collect()
 }
 
 /// Restore an omitted 5h/weekly window from a previous observation of the
@@ -1357,5 +1406,129 @@ mod tests {
                 .used_percent,
             90.0
         );
+    }
+
+    #[test]
+    fn claude_profile_scope_shares_the_latest_quota_across_sessions() {
+        let mut snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![quota_window(WindowKind::FiveHour, 92.0, 16_000)],
+            1,
+        );
+        snapshot
+            .session_quota_scopes
+            .insert("session-a".to_string(), "scope-w".to_string());
+        snapshot
+            .session_quota_scopes
+            .insert("session-b".to_string(), "scope-w".to_string());
+        snapshot.session_windows.insert(
+            "session-a".to_string(),
+            vec![quota_window(WindowKind::FiveHour, 5.0, 16_000)],
+        );
+        snapshot.session_windows.insert(
+            "session-b".to_string(),
+            vec![quota_window(WindowKind::FiveHour, 92.0, 16_000)],
+        );
+        snapshot.quota_scope_windows.insert(
+            "scope-w".to_string(),
+            vec![quota_window(WindowKind::FiveHour, 92.0, 16_000)],
+        );
+
+        assert_eq!(
+            snapshot
+                .windows_for_session(Some("session-a"))
+                .first()
+                .unwrap()
+                .used_percent,
+            92.0
+        );
+        assert_eq!(
+            snapshot
+                .windows_for_session(Some("session-b"))
+                .first()
+                .unwrap()
+                .used_percent,
+            92.0
+        );
+    }
+
+    #[test]
+    fn claude_profile_scopes_stay_isolated_when_reset_times_match() {
+        let mut snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![quota_window(WindowKind::FiveHour, 82.0, 16_000)],
+            1,
+        );
+        snapshot
+            .session_quota_scopes
+            .insert("work".to_string(), "scope-w".to_string());
+        snapshot
+            .session_quota_scopes
+            .insert("personal".to_string(), "scope-p".to_string());
+        snapshot.quota_scope_windows.insert(
+            "scope-w".to_string(),
+            vec![quota_window(WindowKind::FiveHour, 18.0, 16_000)],
+        );
+        snapshot.quota_scope_windows.insert(
+            "scope-p".to_string(),
+            vec![quota_window(WindowKind::FiveHour, 82.0, 16_000)],
+        );
+
+        assert_eq!(
+            snapshot
+                .windows_for_session(Some("work"))
+                .first()
+                .unwrap()
+                .used_percent,
+            18.0
+        );
+        assert_eq!(
+            snapshot
+                .windows_for_session(Some("personal"))
+                .first()
+                .unwrap()
+                .used_percent,
+            82.0
+        );
+        assert!(snapshot.windows_for_session(Some("unknown")).is_empty());
+    }
+
+    #[test]
+    fn legacy_snapshots_deserialize_without_quota_scope_maps() {
+        let snapshot: ProviderSnapshot = serde_json::from_str(
+            r#"{
+                "provider":"claude",
+                "source":"claude-statusline",
+                "fetched_at_unix":1,
+                "windows":[{"kind":"five_hour","used_percent":90.0,"remaining_percent":10.0}],
+                "session_windows":{
+                    "old":[{"kind":"five_hour","used_percent":20.0,"remaining_percent":80.0}]
+                }
+            }"#,
+        )
+        .unwrap();
+        assert!(snapshot.session_quota_scopes.is_empty());
+        assert!(snapshot.quota_scope_windows.is_empty());
+        assert_eq!(
+            snapshot
+                .windows_for_session(Some("old"))
+                .first()
+                .unwrap()
+                .used_percent,
+            20.0
+        );
+        assert!(snapshot.windows_for_session(Some("unknown")).is_empty());
+    }
+
+    #[test]
+    fn an_expired_window_is_not_current() {
+        let live = quota_window(WindowKind::FiveHour, 20.0, 1_001);
+        let expired = quota_window(WindowKind::FiveHour, 20.0, 1_000);
+        assert!(live.is_current(1_000));
+        assert!(!expired.is_current(1_000));
+        assert!(!expired.is_current(1_001));
+        assert!(UsageWindow::new(WindowKind::FiveHour, 20.0, None)
+            .unwrap()
+            .is_current(1_001));
     }
 }

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1,7 +1,7 @@
 use crate::cli::PercentStyle;
 use crate::model::{
-    format_percent, long_window, window_in, Provider, ProviderSnapshot, ResetAt, Severity,
-    UsageWindow, WindowKind,
+    format_percent, live_windows, long_window, window_in, Provider, ProviderSnapshot, ResetAt,
+    Severity, UsageWindow, WindowKind,
 };
 
 /// Exactly the values a pane can be given.
@@ -89,6 +89,8 @@ impl MetadataTokens {
         windows: &[UsageWindow],
         style: PercentStyle,
     ) -> Self {
+        let live = live_windows(windows, now_unix);
+        let windows = live.as_slice();
         let quota_provider = snapshot.provider.display_name().to_string();
         let quota_model = model.unwrap_or_default().to_string();
         let omp_windows = snapshot.source.starts_with("omp.");
@@ -193,8 +195,9 @@ pub fn dashboard_summary(
     now_unix: u64,
     style: PercentStyle,
 ) -> String {
+    let live = live_windows(&snapshot.windows, now_unix);
     windows_summary(
-        &snapshot.windows,
+        &live,
         &[
             WindowKind::FiveHour,
             WindowKind::Weekly,
@@ -897,6 +900,90 @@ mod tests {
         );
         assert_eq!(unknown.quota_5h, "5h N/A");
         assert_eq!(unknown.quota_week, "");
+    }
+
+    #[test]
+    fn claude_panes_on_the_same_profile_share_the_newest_quota() {
+        let mut snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![window(WindowKind::FiveHour, 92.0, 14_820)],
+            0,
+        );
+        snapshot
+            .session_quota_scopes
+            .insert("session-c".to_string(), "scope-w".to_string());
+        snapshot
+            .session_quota_scopes
+            .insert("session-a".to_string(), "scope-w".to_string());
+        snapshot.session_windows.insert(
+            "session-c".to_string(),
+            vec![window(WindowKind::FiveHour, 5.0, 14_820)],
+        );
+        snapshot.session_windows.insert(
+            "session-a".to_string(),
+            vec![window(WindowKind::FiveHour, 92.0, 14_820)],
+        );
+        snapshot.quota_scope_windows.insert(
+            "scope-w".to_string(),
+            vec![window(WindowKind::FiveHour, 92.0, 14_820)],
+        );
+
+        let idle = MetadataTokens::from_snapshot_for_pane(
+            &snapshot,
+            0,
+            Some("session-c"),
+            PercentStyle::default(),
+        );
+        let live = MetadataTokens::from_snapshot_for_pane(
+            &snapshot,
+            0,
+            Some("session-a"),
+            PercentStyle::default(),
+        );
+        assert_eq!(idle.quota_5h, "5h 8% 4h07m");
+        assert_eq!(live.quota_5h, "5h 8% 4h07m");
+        assert_eq!(idle.quota_headroom, Some(8));
+        assert_eq!(live.quota_headroom, Some(8));
+    }
+
+    #[test]
+    fn an_expired_window_is_not_shown_as_live_quota() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![window(WindowKind::FiveHour, 20.0, 1_000)],
+            0,
+        );
+        let tokens = MetadataTokens::from_snapshot(&snapshot, 1_001);
+        assert_eq!(tokens.quota_5h, "5h N/A");
+        assert_eq!(tokens.quota_5h_severity, Some(Severity::Unknown));
+        assert_eq!(tokens.quota_headroom, None);
+        assert!(!tokens.quota_5h.contains("80%"), "{tokens:?}");
+        assert_eq!(
+            dashboard_summary(&snapshot, 1_001, PercentStyle::default()),
+            ""
+        );
+        assert_eq!(
+            ProviderSnapshot::severity_for_windows(Provider::Claude, &snapshot.windows, 1_001),
+            Severity::Unknown
+        );
+    }
+
+    #[test]
+    fn an_expired_five_hour_window_does_not_drive_headroom_or_severity() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![
+                window(WindowKind::FiveHour, 95.0, 1_000),
+                window(WindowKind::Weekly, 10.0, 10_000),
+            ],
+            0,
+        );
+        let tokens = MetadataTokens::from_snapshot(&snapshot, 1_001);
+        assert_eq!(tokens.quota_5h, "5h N/A");
+        assert_eq!(tokens.quota_5h_severity, Some(Severity::Unknown));
+        assert!(tokens.quota_week.starts_with("7d 90%"), "{tokens:?}");
+        assert_eq!(tokens.quota_headroom, Some(90));
+        assert_eq!(tokens.quota_week_severity, Some(Severity::Normal));
     }
 
     #[test]

--- a/src/providers/claude.rs
+++ b/src/providers/claude.rs
@@ -3,6 +3,88 @@ use crate::model::{ContextUsage, Provider, ProviderSnapshot, ResetAt, UsageWindo
 use crate::providers::statusline::{parse_context, parse_model};
 use crate::providers::ProviderError;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
+
+/// Opaque Claude profile identity used to share quota across sessions.
+///
+/// Claude Code's `CLAUDE_CONFIG_DIR` is the profile root for credentials and
+/// session history. The cache stores only a SHA-256 hex digest of the
+/// normalized path, never the path itself.
+pub fn quota_scope_id(
+    claude_config_dir: Option<&OsStr>,
+    home: Option<&OsStr>,
+    current_dir: Option<&Path>,
+) -> Option<String> {
+    let config_dir = claude_config_dir.filter(|value| !value.is_empty());
+    let home_path = home.filter(|value| !value.is_empty()).map(PathBuf::from);
+    let raw = match config_dir {
+        Some(dir) => PathBuf::from(dir),
+        None => home_path.as_ref()?.join(".claude"),
+    };
+    let normalized = normalize_profile_root(&raw, home_path.as_deref(), current_dir);
+    Some(hash_profile_root(&normalized))
+}
+
+fn normalize_profile_root(path: &Path, home: Option<&Path>, current_dir: Option<&Path>) -> PathBuf {
+    let expanded = expand_tilde(path, home);
+    let absolute = if expanded.is_absolute() {
+        expanded
+    } else if let Some(cwd) = current_dir {
+        cwd.join(expanded)
+    } else {
+        expanded
+    };
+    normalize_components(&absolute)
+}
+
+fn expand_tilde(path: &Path, home: Option<&Path>) -> PathBuf {
+    let mut components = path.components();
+    match (components.next(), home) {
+        (Some(Component::Normal(first)), Some(home)) if first == "~" => {
+            let rest = components.as_path();
+            if rest.as_os_str().is_empty() {
+                home.to_path_buf()
+            } else {
+                home.join(rest)
+            }
+        }
+        _ => path.to_path_buf(),
+    }
+}
+
+fn normalize_components(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => out.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !out.pop() {
+                    out.push("..");
+                }
+            }
+            Component::Normal(name) => out.push(name),
+        }
+    }
+    if out.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        out
+    }
+}
+
+fn hash_profile_root(path: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"claude-quota-scope\0");
+    hasher.update(path.as_os_str().as_encoded_bytes());
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
 
 pub fn parse_statusline(
     value: &Value,
@@ -147,6 +229,8 @@ pub fn run_statusline(input: &[u8]) -> std::result::Result<ProviderSnapshot, Pro
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::ffi::OsStr;
+    use std::path::Path;
 
     #[test]
     fn parses_claude_five_hour_and_weekly_limits() {
@@ -325,5 +409,62 @@ mod tests {
     #[test]
     fn rejects_non_json_statusline_input() {
         assert!(run_statusline(b"not-json").is_err());
+    }
+
+    #[test]
+    fn quota_scope_is_stable_for_the_same_profile_root() {
+        let home = OsStr::new("/Users/me");
+        let unset = quota_scope_id(None, Some(home), None).unwrap();
+        let explicit =
+            quota_scope_id(Some(OsStr::new("/Users/me/.claude")), Some(home), None).unwrap();
+        let trailing =
+            quota_scope_id(Some(OsStr::new("/Users/me/.claude/")), Some(home), None).unwrap();
+        assert_eq!(unset, explicit);
+        assert_eq!(unset, trailing);
+        assert_eq!(unset.len(), 64);
+        assert!(unset.chars().all(|ch| ch.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn quota_scope_differs_across_config_dirs() {
+        let work = quota_scope_id(Some(OsStr::new("/tmp/.claude-work")), None, None).unwrap();
+        let personal =
+            quota_scope_id(Some(OsStr::new("/tmp/.claude-personal")), None, None).unwrap();
+        assert_ne!(work, personal);
+    }
+
+    #[test]
+    fn quota_scope_normalizes_tilde_and_relative_paths() {
+        let home = Path::new("/Users/me");
+        let cwd = Path::new("/Users/me/proj");
+        let tilde = quota_scope_id(
+            Some(OsStr::new("~/.claude-work")),
+            Some(home.as_os_str()),
+            Some(cwd),
+        )
+        .unwrap();
+        let absolute = quota_scope_id(
+            Some(OsStr::new("/Users/me/.claude-work")),
+            Some(home.as_os_str()),
+            Some(cwd),
+        )
+        .unwrap();
+        let relative = quota_scope_id(
+            Some(OsStr::new("../.claude-work")),
+            Some(home.as_os_str()),
+            Some(cwd),
+        )
+        .unwrap();
+        assert_eq!(tilde, absolute);
+        assert_eq!(relative, absolute);
+    }
+
+    #[test]
+    fn quota_scope_never_embeds_the_config_path() {
+        let path = "/Users/secret/.claude-work";
+        let scope = quota_scope_id(Some(OsStr::new(path)), None, None).unwrap();
+        assert!(!scope.contains("secret"));
+        assert!(!scope.contains("claude"));
+        assert!(!scope.contains('/'));
     }
 }

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -763,6 +763,72 @@ fn claude_panes_on_the_same_profile_share_the_newest_quota() {
 }
 
 #[test]
+fn idle_claude_statusline_tick_does_not_regress_shared_profile_quota() {
+    let state = tempdir().unwrap();
+    let profile = state.path().join("claude-profile");
+    fs::create_dir_all(&profile).unwrap();
+    let (herdr_stub, herdr_log) = install_herdr_stub(
+        state.path(),
+        r#"{"result":{"agents":[
+            {"agent":"claude","pane_id":"w1:p1","agent_session":{"value":"session-c"}},
+            {"agent":"claude","pane_id":"w2:p1","agent_session":{"value":"session-a"}}
+        ]}}"#,
+    );
+    run_claude_collector_with_config_dir(
+        state.path(),
+        &herdr_stub,
+        br#"{
+            "session_id": "session-c",
+            "rate_limits": {
+                "five_hour": {"used_percentage": 5.0, "resets_at": 2000000000}
+            }
+        }"#,
+        Some(&profile),
+    );
+    run_claude_collector_with_config_dir(
+        state.path(),
+        &herdr_stub,
+        br#"{
+            "session_id": "session-a",
+            "rate_limits": {
+                "five_hour": {"used_percentage": 92.0, "resets_at": 2000000000}
+            }
+        }"#,
+        Some(&profile),
+    );
+    run_claude_collector_with_config_dir(
+        state.path(),
+        &herdr_stub,
+        br#"{
+            "session_id": "session-c",
+            "rate_limits": {
+                "five_hour": {"used_percentage": 5.0, "resets_at": 2000000000}
+            }
+        }"#,
+        Some(&profile),
+    );
+
+    run_claude_refresh(state.path(), &herdr_stub);
+    let report = fs::read_to_string(herdr_log).unwrap();
+    let idle_report = report
+        .lines()
+        .find(|line| line.contains("w1:p1"))
+        .expect("idle pane reported");
+    let live_report = report
+        .lines()
+        .find(|line| line.contains("w2:p1"))
+        .expect("live pane reported");
+    assert!(
+        idle_report.contains("quota_5h_danger=5h 8%"),
+        "{idle_report}"
+    );
+    assert!(
+        live_report.contains("quota_5h_danger=5h 8%"),
+        "{live_report}"
+    );
+}
+
+#[test]
 fn claude_new_session_without_rate_limits_keeps_profile_quota() {
     let state = tempdir().unwrap();
     let profile = state.path().join("claude-profile");

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -31,14 +31,26 @@ fn install_herdr_stub(state: &Path, agent_list: &str) -> (PathBuf, PathBuf) {
 }
 
 fn run_claude_collector(state: &Path, herdr: &Path, input: &[u8]) {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_herdr-agent-quota"))
+    run_claude_collector_with_config_dir(state, herdr, input, None);
+}
+
+fn run_claude_collector_with_config_dir(
+    state: &Path,
+    herdr: &Path,
+    input: &[u8],
+    config_dir: Option<&Path>,
+) {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_herdr-agent-quota"));
+    command
         .arg("claude-statusline")
         .env("HERDR_PLUGIN_STATE_DIR", state)
         .env("HERDR_BIN_PATH", herdr)
         .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .unwrap();
+        .stdout(Stdio::piped());
+    if let Some(config_dir) = config_dir {
+        command.env("CLAUDE_CONFIG_DIR", config_dir);
+    }
+    let mut child = command.spawn().unwrap();
     child.stdin.take().unwrap().write_all(input).unwrap();
     assert!(child.wait_with_output().unwrap().status.success());
 }
@@ -555,6 +567,9 @@ fn claude_cache_is_published_by_refresh_event() {
 
 #[test]
 fn claude_statusline_without_rate_limits_clears_stale_quota_windows() {
+    // A payload with no session id still clears the top-level `windows`
+    // snapshot. Profile-scoped canonical quota is a different path: an empty
+    // rate_limits payload on a *new* session must not wipe the account.
     let state = tempdir().unwrap();
     let (herdr_stub, _herdr_log) = install_herdr_stub(
         state.path(),
@@ -610,11 +625,17 @@ fn statusline_without_context_keeps_the_last_context_snapshot() {
 
 #[test]
 fn concurrent_claude_accounts_keep_their_own_quota_windows() {
-    // Two Claude panes signed in to different accounts (for example a work
-    // and a personal login in separate CLAUDE_CONFIG_DIR checkouts) each send
-    // their own statusLine ticks. Sidebar percentages are remaining, not used:
-    // work 18%/10% used → 82%/90% remaining; personal 82%/90% used → 18%/10%.
+    // Two Claude panes signed in to different accounts (a work and a personal
+    // login in separate CLAUDE_CONFIG_DIR profiles) each send their own
+    // statusLine ticks. Matching reset boundaries are not an identity: both
+    // windows reset at the same unix second and must still stay isolated.
+    // Sidebar percentages are remaining, not used: work 18%/10% used →
+    // 82%/90% remaining; personal 82%/90% used → 18%/10%.
     let state = tempdir().unwrap();
+    let work_config = state.path().join("claude-work");
+    let personal_config = state.path().join("claude-personal");
+    fs::create_dir_all(&work_config).unwrap();
+    fs::create_dir_all(&personal_config).unwrap();
     let (herdr_stub, herdr_log) = install_herdr_stub(
         state.path(),
         r#"{"result":{"agents":[
@@ -622,31 +643,33 @@ fn concurrent_claude_accounts_keep_their_own_quota_windows() {
             {"agent":"claude","pane_id":"w2:p1","agent_session":{"value":"personal-session"}}
         ]}}"#,
     );
-    run_claude_collector(
+    run_claude_collector_with_config_dir(
         state.path(),
         &herdr_stub,
         br#"{
             "session_id": "work-session",
             "rate_limits": {
-                "five_hour": {"used_percentage": 18.0},
-                "seven_day": {"used_percentage": 10.0}
+                "five_hour": {"used_percentage": 18.0, "resets_at": 2000000000},
+                "seven_day": {"used_percentage": 10.0, "resets_at": 2000000000}
             }
         }"#,
+        Some(&work_config),
     );
-    run_claude_collector(
+    run_claude_collector_with_config_dir(
         state.path(),
         &herdr_stub,
         br#"{
             "session_id": "personal-session",
             "rate_limits": {
-                "five_hour": {"used_percentage": 82.0},
-                "seven_day": {"used_percentage": 90.0}
+                "five_hour": {"used_percentage": 82.0, "resets_at": 2000000000},
+                "seven_day": {"used_percentage": 90.0, "resets_at": 2000000000}
             }
         }"#,
+        Some(&personal_config),
     );
 
     run_claude_refresh(state.path(), &herdr_stub);
-    let report = fs::read_to_string(herdr_log).unwrap();
+    let report = fs::read_to_string(&herdr_log).unwrap();
     let work_report = report
         .lines()
         .find(|line| line.contains("w1:p1"))
@@ -671,6 +694,116 @@ fn concurrent_claude_accounts_keep_their_own_quota_windows() {
         personal_report.contains("quota_week_danger=7d 10%"),
         "{personal_report}"
     );
+
+    let observation =
+        fs::read_to_string(state.path().join("claude-statusline.observation.json")).unwrap();
+    assert!(
+        !observation.contains(work_config.to_str().unwrap()),
+        "cache must not store the raw Claude config path"
+    );
+    assert!(
+        !observation.contains(personal_config.to_str().unwrap()),
+        "cache must not store the raw Claude config path"
+    );
+}
+
+#[test]
+fn claude_panes_on_the_same_profile_share_the_newest_quota() {
+    let state = tempdir().unwrap();
+    let profile = state.path().join("claude-profile");
+    fs::create_dir_all(&profile).unwrap();
+    let (herdr_stub, herdr_log) = install_herdr_stub(
+        state.path(),
+        r#"{"result":{"agents":[
+            {"agent":"claude","pane_id":"w1:p1","agent_session":{"value":"session-c"}},
+            {"agent":"claude","pane_id":"w2:p1","agent_session":{"value":"session-a"}}
+        ]}}"#,
+    );
+    run_claude_collector_with_config_dir(
+        state.path(),
+        &herdr_stub,
+        br#"{
+            "session_id": "session-c",
+            "rate_limits": {
+                "five_hour": {"used_percentage": 5.0, "resets_at": 2000000000}
+            }
+        }"#,
+        Some(&profile),
+    );
+    run_claude_collector_with_config_dir(
+        state.path(),
+        &herdr_stub,
+        br#"{
+            "session_id": "session-a",
+            "rate_limits": {
+                "five_hour": {"used_percentage": 92.0, "resets_at": 2000000000}
+            }
+        }"#,
+        Some(&profile),
+    );
+
+    run_claude_refresh(state.path(), &herdr_stub);
+    let report = fs::read_to_string(herdr_log).unwrap();
+    let idle_report = report
+        .lines()
+        .find(|line| line.contains("w1:p1"))
+        .expect("idle pane reported");
+    let live_report = report
+        .lines()
+        .find(|line| line.contains("w2:p1"))
+        .expect("live pane reported");
+    assert!(
+        idle_report.contains("quota_5h_danger=5h 8%"),
+        "{idle_report}"
+    );
+    assert!(
+        live_report.contains("quota_5h_danger=5h 8%"),
+        "{live_report}"
+    );
+}
+
+#[test]
+fn claude_new_session_without_rate_limits_keeps_profile_quota() {
+    let state = tempdir().unwrap();
+    let profile = state.path().join("claude-profile");
+    fs::create_dir_all(&profile).unwrap();
+    let (herdr_stub, herdr_log) = install_herdr_stub(
+        state.path(),
+        r#"{"result":{"agents":[
+            {"agent":"claude","pane_id":"w1:p1","agent_session":{"value":"session-a"}},
+            {"agent":"claude","pane_id":"w2:p1","agent_session":{"value":"session-b"}}
+        ]}}"#,
+    );
+    run_claude_collector_with_config_dir(
+        state.path(),
+        &herdr_stub,
+        br#"{
+            "session_id": "session-a",
+            "rate_limits": {
+                "five_hour": {"used_percentage": 18.0, "resets_at": 2000000000}
+            }
+        }"#,
+        Some(&profile),
+    );
+    run_claude_collector_with_config_dir(
+        state.path(),
+        &herdr_stub,
+        br#"{"session_id":"session-b"}"#,
+        Some(&profile),
+    );
+
+    run_claude_refresh(state.path(), &herdr_stub);
+    let report = fs::read_to_string(herdr_log).unwrap();
+    let session_a = report
+        .lines()
+        .find(|line| line.contains("w1:p1"))
+        .expect("session A reported");
+    let session_b = report
+        .lines()
+        .find(|line| line.contains("w2:p1"))
+        .expect("session B reported");
+    assert!(session_a.contains("quota_5h_normal=5h 82%"), "{session_a}");
+    assert!(session_b.contains("quota_5h_normal=5h 82%"), "{session_b}");
 }
 
 #[test]

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -7,7 +7,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tempfile::tempdir;
 
 fn install_herdr_stub(state: &Path, agent_list: &str) -> (PathBuf, PathBuf) {
@@ -28,6 +28,30 @@ fn install_herdr_stub(state: &Path, agent_list: &str) -> (PathBuf, PathBuf) {
     permissions.set_mode(0o755);
     fs::set_permissions(&executable, permissions).unwrap();
     (executable, log)
+}
+
+fn future_reset_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is after unix epoch")
+        .as_secs()
+        + 3_600
+}
+
+fn claude_statusline_windows(
+    session_id: &str,
+    five_hour_used: f64,
+    seven_day_used: Option<f64>,
+    reset: u64,
+) -> String {
+    match seven_day_used {
+        Some(week_used) => format!(
+            r#"{{"session_id":"{session_id}","rate_limits":{{"five_hour":{{"used_percentage":{five_hour_used},"resets_at":{reset}}},"seven_day":{{"used_percentage":{week_used},"resets_at":{reset}}}}}}}"#
+        ),
+        None => format!(
+            r#"{{"session_id":"{session_id}","rate_limits":{{"five_hour":{{"used_percentage":{five_hour_used},"resets_at":{reset}}}}}}}"#
+        ),
+    }
 }
 
 fn run_claude_collector(state: &Path, herdr: &Path, input: &[u8]) {
@@ -549,10 +573,14 @@ fn claude_cache_is_published_by_refresh_event() {
         state.path(),
         r#"{"result":{"agents":[{"agent":"claude","pane_id":"w1:p1"}]}}"#,
     );
+    let reset = future_reset_unix();
     run_claude_collector(
         state.path(),
         &herdr_stub,
-        include_bytes!("fixtures/claude/statusline-both.json"),
+        format!(
+            r#"{{"rate_limits":{{"five_hour":{{"used_percentage":58.0,"resets_at":{reset}}},"seven_day":{{"used_percentage":27.0,"resets_at":{reset}}}}}}}"#
+        )
+        .as_bytes(),
     );
     assert!(!herdr_log.exists());
 
@@ -643,28 +671,17 @@ fn concurrent_claude_accounts_keep_their_own_quota_windows() {
             {"agent":"claude","pane_id":"w2:p1","agent_session":{"value":"personal-session"}}
         ]}}"#,
     );
+    let reset = future_reset_unix();
     run_claude_collector_with_config_dir(
         state.path(),
         &herdr_stub,
-        br#"{
-            "session_id": "work-session",
-            "rate_limits": {
-                "five_hour": {"used_percentage": 18.0, "resets_at": 2000000000},
-                "seven_day": {"used_percentage": 10.0, "resets_at": 2000000000}
-            }
-        }"#,
+        claude_statusline_windows("work-session", 18.0, Some(10.0), reset).as_bytes(),
         Some(&work_config),
     );
     run_claude_collector_with_config_dir(
         state.path(),
         &herdr_stub,
-        br#"{
-            "session_id": "personal-session",
-            "rate_limits": {
-                "five_hour": {"used_percentage": 82.0, "resets_at": 2000000000},
-                "seven_day": {"used_percentage": 90.0, "resets_at": 2000000000}
-            }
-        }"#,
+        claude_statusline_windows("personal-session", 82.0, Some(90.0), reset).as_bytes(),
         Some(&personal_config),
     );
 
@@ -719,26 +736,17 @@ fn claude_panes_on_the_same_profile_share_the_newest_quota() {
             {"agent":"claude","pane_id":"w2:p1","agent_session":{"value":"session-a"}}
         ]}}"#,
     );
+    let reset = future_reset_unix();
     run_claude_collector_with_config_dir(
         state.path(),
         &herdr_stub,
-        br#"{
-            "session_id": "session-c",
-            "rate_limits": {
-                "five_hour": {"used_percentage": 5.0, "resets_at": 2000000000}
-            }
-        }"#,
+        claude_statusline_windows("session-c", 5.0, None, reset).as_bytes(),
         Some(&profile),
     );
     run_claude_collector_with_config_dir(
         state.path(),
         &herdr_stub,
-        br#"{
-            "session_id": "session-a",
-            "rate_limits": {
-                "five_hour": {"used_percentage": 92.0, "resets_at": 2000000000}
-            }
-        }"#,
+        claude_statusline_windows("session-a", 92.0, None, reset).as_bytes(),
         Some(&profile),
     );
 
@@ -774,37 +782,23 @@ fn idle_claude_statusline_tick_does_not_regress_shared_profile_quota() {
             {"agent":"claude","pane_id":"w2:p1","agent_session":{"value":"session-a"}}
         ]}}"#,
     );
+    let reset = future_reset_unix();
     run_claude_collector_with_config_dir(
         state.path(),
         &herdr_stub,
-        br#"{
-            "session_id": "session-c",
-            "rate_limits": {
-                "five_hour": {"used_percentage": 5.0, "resets_at": 2000000000}
-            }
-        }"#,
+        claude_statusline_windows("session-c", 5.0, None, reset).as_bytes(),
         Some(&profile),
     );
     run_claude_collector_with_config_dir(
         state.path(),
         &herdr_stub,
-        br#"{
-            "session_id": "session-a",
-            "rate_limits": {
-                "five_hour": {"used_percentage": 92.0, "resets_at": 2000000000}
-            }
-        }"#,
+        claude_statusline_windows("session-a", 92.0, None, reset).as_bytes(),
         Some(&profile),
     );
     run_claude_collector_with_config_dir(
         state.path(),
         &herdr_stub,
-        br#"{
-            "session_id": "session-c",
-            "rate_limits": {
-                "five_hour": {"used_percentage": 5.0, "resets_at": 2000000000}
-            }
-        }"#,
+        claude_statusline_windows("session-c", 5.0, None, reset).as_bytes(),
         Some(&profile),
     );
 
@@ -843,12 +837,7 @@ fn claude_new_session_without_rate_limits_keeps_profile_quota() {
     run_claude_collector_with_config_dir(
         state.path(),
         &herdr_stub,
-        br#"{
-            "session_id": "session-a",
-            "rate_limits": {
-                "five_hour": {"used_percentage": 18.0, "resets_at": 2000000000}
-            }
-        }"#,
+        claude_statusline_windows("session-a", 18.0, None, future_reset_unix()).as_bytes(),
         Some(&profile),
     );
     run_claude_collector_with_config_dir(

--- a/tests/fixtures/claude/statusline-both.json
+++ b/tests/fixtures/claude/statusline-both.json
@@ -2,11 +2,11 @@
   "rate_limits": {
     "five_hour": {
       "used_percentage": 58.0,
-      "resets_at": "2026-08-15T12:00:00Z"
+      "resets_at": "2030-08-15T12:00:00Z"
     },
     "seven_day": {
       "used_percentage": 27.0,
-      "resets_at": "2026-08-22T12:00:00Z"
+      "resets_at": "2030-08-22T12:00:00Z"
     }
   }
 }

--- a/tests/provider_contracts.rs
+++ b/tests/provider_contracts.rs
@@ -80,7 +80,7 @@ fn claude_fixture_contains_both_subscription_windows() {
     );
     assert_eq!(
         snapshot.window(WindowKind::Weekly).unwrap().resets_at,
-        Some(ResetAt::from_unix_seconds(1_787_400_000))
+        Some(ResetAt::from_unix_seconds(1_913_630_400))
     );
 }
 


### PR DESCRIPTION
## What this changes

Fixes #57. Idle Claude panes on the same `CLAUDE_CONFIG_DIR` profile now show that profile's newest 5h/7d reading instead of a frozen per-session percentage beside a still-correct countdown. Work/personal profiles stay isolated (the #31 guarantee), including when their reset times happen to match. A window whose `resets_at` has already passed renders as unknown (`5h N/A`) rather than as a live percentage.

Lookup is `session → opaque profile scope → canonical windows`. The cache stores only a SHA-256 of the normalized config dir, never the path. Agy keeps legacy `session_windows`; Grok/Codex/Devin still fall back to top-level windows when the keyed maps are empty. An empty `rate_limits` payload from a new session does not clear the profile's last good quota.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features --locked`
- [x] A parser change comes with a fixture in `tests/fixtures/` and a test
- [x] No new network call, background process, or credential write

## Provider impact

Claude Code statusLine (profile-scoped quota). Agy is unchanged (still per-session). Codex / Grok / Devin keep account-level windows when no session map is filled.

## Test plan

- [ ] Same Claude profile, two panes: after the active pane reports 92% used, the idle pane should also show 8% remaining (default style), not a hours-old 95%.
- [ ] Separate `CLAUDE_CONFIG_DIR` work/personal profiles still show their own remaining percentages and do not clobber each other, even with the same `resets_at`.
- [ ] A new session that has not yet received `rate_limits` does not wipe the profile's live quota.
- [ ] A window with `resets_at` in the past shows `5h N/A` / unknown, not the old remaining percent, and does not drive headroom or the low-quota alert.


Made with [Cursor](https://cursor.com)