### PR TITLE
fix: preserve native Herdr 0.9 layout and release v1.5.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,10 @@ enable`, invoke it with a marker variable set, and read the file.
 ## Event payload shapes
 
 `HERDR_PLUGIN_EVENT_JSON` is nested and not uniform across events. `pane.focused`
-carries no `agent` at all, which is why `focus` has to call `herdr pane current`:
+carries no `agent`: `focus` uses its pane ID and resolves the harness from one
+agent inventory read. Only a direct `focus` invocation without event JSON uses
+`herdr pane current`. This keeps delayed events and Herdr 0.9's independent
+clients from redirecting a refresh to another pane:
 
 ```json
 {"event":"pane_focused","data":{"type":"pane_focused","pane_id":"w1:p9","workspace_id":"w1"}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-09-08
+
+### Changed
+
+- Require Herdr 0.9.0 or later. Native machine/workspace/tab and agent
+  identity rows stay above plugin fields in both sidebar layouts.
+- Keep Herdr's native token styling, Space Git rows, and worktree grouping.
+  Quota ordering remains opt-in.
+
+### Fixed
+
+- Focus events refresh the pane named in the event instead of the current
+  global focus, including delayed events and independent Herdr clients.
+- Reconfiguring managed shared Agent rows preserves added custom fields and
+  styles while still migrating recognized older plugin layouts.
+
 ## [1.4.0] - 2026-09-06
 
 ### Added
@@ -572,7 +588,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - A popup dashboard pane, event-driven refresh, and a local snapshot cache that
   survives provider failures.
 
-[Unreleased]: https://github.com/levi-qiao/herdr-agent-quota/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/levi-qiao/herdr-agent-quota/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/levi-qiao/herdr-agent-quota/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/levi-qiao/herdr-agent-quota/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/levi-qiao/herdr-agent-quota/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/levi-qiao/herdr-agent-quota/compare/v1.1.0...v1.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ contract.
 ## Setup
 
 Requires Rust `1.95+` (pinned by `rust-toolchain.toml`, so `rustup` installs it
-for you) and Herdr `0.8.0+`.
+for you) and Herdr `0.9.0+`.
 
 ```sh
 git clone https://github.com/levi-qiao/herdr-agent-quota

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-agent-quota"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-agent-quota"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 rust-version = "1.95"
 description = "Credential-scoped AI quota and context in Herdr for Claude, Codex, Grok, Agy, OpenCode, Pi, omp, and Devin"

--- a/README.md
+++ b/README.md
@@ -8,20 +8,18 @@ Credential-scoped model, context, cache, and quota data in Herdr's Agent sidebar
 
 中文文档：[README.zh-CN.md](README.zh-CN.md)
 
-<table>
-<tr><th>packed (default)</th><th>stacked</th></tr>
-<tr>
-<td valign="top"><img src="docs/screenshots/sidebar-packed.png" alt="Packed sidebar" width="284"></td>
-<td valign="top"><img src="docs/screenshots/sidebar-stacked.png" alt="Stacked sidebar" width="177"></td>
-</tr>
-</table>
+Herdr's native machine/workspace/tab row and agent identity row stay at the top.
+Quota fields follow below: `packed` joins related fields; `stacked` separates them.
+Herdr owns Space rows (Git branch/status), worktree grouping, and Agent ordering.
+The plugin leaves those settings intact; quota ordering is opt-in. Custom fields
+and styles added to shared Agent rows also survive reconfiguration.
 
 Empty values collapse. Failed refreshes keep the last good value for the same
 account; confirmed PAYG sessions clear stale subscription quota.
 
 ## Install
 
-Requires Herdr 0.8.0+, Rust 1.95+, macOS or Linux, and at least one supported agent CLI.
+Requires Herdr 0.9.0+, Rust 1.95+, macOS or Linux, and at least one supported agent CLI.
 
 ```sh
 git clone https://github.com/levi-qiao/herdr-agent-quota.git
@@ -36,10 +34,10 @@ Restart already-running agent panes once. To install only a subset:
 ```
 
 `install.sh` only rewrites the shared `ui.sidebar.agents.rows` array when it is
-empty, contains only rows already managed by the plugin, or matches Herdr's
-default `["state_icon", "agent"]` row. Existing rows from another plugin or the
-user are preserved, while `rows_by_agent` for the selected agents is still
-added or updated.
+empty, managed by the plugin, or matches a supported default layout. These rows
+use Herdr 0.9's `[["state_icon", "machine", "workspace", "tab"], ["agent"]]`
+before the quota fields. Existing custom rows and styles are preserved, while
+`rows_by_agent` for the selected agents is still added or updated.
 
 Supported values: `all`, `claude`, `codex`, `grok`, `agy`, `opencode`, `pi`, `omp`, `devin`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,19 +8,16 @@
 
 English: [README.md](README.md)
 
-<table>
-<tr><th>packed（默认）</th><th>stacked</th></tr>
-<tr>
-<td valign="top"><img src="docs/screenshots/sidebar-packed.png" alt="拼接布局" width="284"></td>
-<td valign="top"><img src="docs/screenshots/sidebar-stacked.png" alt="分行布局" width="177"></td>
-</tr>
-</table>
+顶部保留 Herdr 原生的机器／工作区／标签页行和 agent 身份行，插件信息追加在下面。
+`packed`（默认）合并相关字段，`stacked` 将字段分行显示。
+Space 区域的 Git 分支／状态、worktree 分组和 Agent 排序由 Herdr 管理，插件保留这些设置；
+按额度排序需主动开启。在共享 Agent 行中追加的自定义字段和样式，重新配置时也会保留。
 
 空字段自动折叠。刷新失败时保留同一账户最后一次成功结果；确认是 PAYG 的 session 会清掉旧订阅额度。
 
 ## 安装
 
-要求：Herdr 0.8.0+、Rust 1.95+、macOS 或 Linux，以及至少一个受支持的 agent CLI。
+要求：Herdr 0.9.0+、Rust 1.95+、macOS 或 Linux，以及至少一个受支持的 agent CLI。
 
 ```sh
 git clone https://github.com/levi-qiao/herdr-agent-quota.git
@@ -34,9 +31,10 @@ cd herdr-agent-quota
 ./install.sh --agent claude,codex,omp
 ```
 
-`install.sh` 只会在共享的 `ui.sidebar.agents.rows` 为空、已由本插件管理、或等于
-Herdr 默认的 `["state_icon", "agent"]` 时改写它。其他插件或用户自己的行会保留，
-仍会为所选 agent 添加或更新 `rows_by_agent`。
+`install.sh` 只会在共享的 `ui.sidebar.agents.rows` 为空、已由本插件管理、或匹配
+受支持的默认布局时改写它。以 Herdr 0.9 的
+`[["state_icon", "machine", "workspace", "tab"], ["agent"]]` 为基础追加插件字段。
+用户自己的行和样式会保留，仍会为所选 agent 添加或更新 `rows_by_agent`。
 
 可选值：`all`、`claude`、`codex`、`grok`、`agy`、`opencode`、`pi`、`omp`、`devin`。
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,7 +1,7 @@
 id = "herdr-agent-quota"
 name = "Herdr Agent Quota"
-version = "1.4.0"
-min_herdr_version = "0.8.0"
+version = "1.5.0"
+min_herdr_version = "0.9.0"
 description = "Credential-scoped AI quota and context for Claude, Codex, Grok, Agy, OpenCode, Pi, omp, and Devin."
 platforms = ["macos", "linux"]
 

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -412,27 +412,47 @@ fn build_managed_rows(
     fields: FieldSet,
     rewrite: RowRewrite,
 ) -> Result<Array> {
-    let mut updated_rows = Array::new();
-    if let Some(rows) = original {
-        for row in rows.iter() {
-            let cleaned = match rewrite {
-                RowRewrite::Takeover => normalize_official_row(strip_quota_tokens(row, true)),
-                RowRewrite::Preserve => strip_quota_tokens(row, false),
-            };
-            if !cleaned.is_empty() {
-                updated_rows.push(Value::Array(cleaned));
-            }
+    let mut updated_rows = match rewrite {
+        RowRewrite::Takeover
+            if original.is_none_or(|rows| {
+                rows.iter()
+                    .all(|row| is_safe_to_take(row) || is_legacy_identity_row(row))
+            }) =>
+        {
+            official_agent_rows()
         }
-    }
-
-    // If an older version replaced every row with quota-only rows, restore
-    // Herdr's official state/tab row before adding provider, usage, and topic.
-    if updated_rows.is_empty() && matches!(rewrite, RowRewrite::Takeover) {
-        updated_rows.push(Value::Array(default_state_row()));
-    }
-    append_quota_rows(&mut updated_rows, layout, rewrite);
+        _ => {
+            let mut rows = Array::new();
+            if let Some(original) = original {
+                for row in original {
+                    let cleaned = strip_quota_tokens(row);
+                    if !cleaned.is_empty() {
+                        rows.push(Value::Array(cleaned));
+                    }
+                }
+            }
+            rows
+        }
+    };
+    append_quota_rows(&mut updated_rows, layout);
     retain_selected_fields(&mut updated_rows, fields);
     Ok(updated_rows)
+}
+
+// Recognize only the tab styling written by older plugin versions. A managed
+// marker does not make later user-added Git, directory, or styled rows ours.
+fn is_legacy_identity_row(row: &Value) -> bool {
+    let cleaned = strip_quota_tokens(row);
+    if cleaned.len() != 2 || cleaned.get(0).and_then(Value::as_str) != Some("state_icon") {
+        return false;
+    }
+    let Some(tab) = cleaned.get(1).and_then(Value::as_inline_table) else {
+        return false;
+    };
+    tab.get("token").and_then(Value::as_str) == Some("tab")
+        && tab.get("bold").and_then(Value::as_bool) == Some(true)
+        && (tab.len() == 2
+            || (tab.len() == 3 && tab.get("dim").and_then(Value::as_bool) == Some(false)))
 }
 
 fn has_rows_marker(value: &Value) -> bool {
@@ -448,7 +468,7 @@ fn is_safe_to_take_over(rows: &Array) -> bool {
 }
 
 fn is_safe_to_take(row: &Value) -> bool {
-    let cleaned = strip_quota_tokens(row, false);
+    let cleaned = strip_quota_tokens(row);
     if cleaned.is_empty() {
         return true;
     }
@@ -458,13 +478,13 @@ fn is_safe_to_take(row: &Value) -> bool {
 fn is_default_state_equivalent(row: &Array) -> bool {
     let mut has_state_icon = false;
     for item in row.iter() {
-        match configured_token_name(item) {
+        match item.as_str() {
             Some("state_icon") => has_state_icon = true,
-            Some("agent" | "tab") => {}
+            Some("agent" | "tab" | "machine" | "workspace") => {}
             _ => return false,
         }
     }
-    has_state_icon
+    has_state_icon || (row.len() == 1 && row.get(0).and_then(Value::as_str) == Some("agent"))
 }
 
 /// Full-installation form, used by callers that remove every agent.
@@ -518,7 +538,7 @@ pub fn remove_quota_row_for(input: &str, agents: &[Harness], full: bool) -> Resu
     if let Some(rows) = table.get_mut("rows").and_then(Item::as_array_mut) {
         let mut retained = Array::new();
         for row in rows.iter() {
-            let cleaned = strip_quota_tokens(row, false);
+            let cleaned = strip_quota_tokens(row);
             if !cleaned.is_empty() {
                 retained.push(Value::Array(cleaned));
             }
@@ -610,16 +630,13 @@ fn ensure_table<'a>(document: &'a mut DocumentMut, path: &[&str]) -> Result<&'a 
         .context("Herdr config section is not a table")
 }
 
-fn strip_quota_tokens(row: &Value, keep_provider_model: bool) -> Array {
+fn strip_quota_tokens(row: &Value) -> Array {
     let mut cleaned = Array::new();
     if let Some(items) = row.as_array() {
         for item in items {
             let is_quota_token =
                 configured_token_name(item).is_some_and(|value| QUOTA_ROW_MARKERS.contains(&value));
-            if !is_quota_token
-                || (keep_provider_model
-                    && configured_token_name(item) == Some("$quota_provider_model"))
-            {
+            if !is_quota_token {
                 cleaned.push(item.clone());
             }
         }
@@ -729,219 +746,53 @@ fn has_provider_style_marker(value: &Value) -> bool {
         .is_some_and(|suffix| suffix.contains(PROVIDER_STYLE_MARKER))
 }
 
-fn default_state_row() -> Array {
-    let mut row = Array::new();
-    row.push("state_icon");
-    row.push(styled_tab());
-    row
+/// Herdr 0.9's native navigation and agent identity rows. Plugin fields are
+/// appended below them so empty metadata never removes the native identity.
+fn official_agent_rows() -> Array {
+    let mut rows = Array::new();
+    rows.push(Value::Array(
+        ["state_icon", "machine", "workspace", "tab"]
+            .into_iter()
+            .collect(),
+    ));
+    rows.push(Value::Array(["agent"].into_iter().collect()));
+    rows
 }
 
-fn is_tab_token(value: &Value) -> bool {
-    value.as_str() == Some("tab") || configured_token_name(value) == Some("tab")
-}
-
-fn styled_tab() -> Value {
-    styled_token("tab", None, Some(true), Some(false))
-}
-
-fn normalize_official_row(row: Array) -> Array {
-    let has_state_icon = row.iter().any(|item| item.as_str() == Some("state_icon"));
-    if !has_state_icon
-        || row.iter().any(|item| {
-            item.as_str() == Some("agent")
-                || configured_token_name(item) == Some("$quota_provider_model")
-        })
-    {
-        return row;
-    }
-    let mut normalized = Array::new();
-    let mut has_tab = false;
-    for item in row {
-        if is_tab_token(&item) {
-            if !has_tab {
-                has_tab = true;
-                normalized.push(styled_tab());
-            }
-            continue;
-        }
-        match item.as_str() {
-            Some("workspace") | Some("pane") => {
-                if !has_tab {
-                    normalized.push(styled_tab());
-                    has_tab = true;
-                }
-            }
-            Some("terminal_title_stripped") => {}
-            _ => normalized.push(item),
+fn append_quota_rows(rows: &mut Array, layout: SidebarLayout) {
+    match layout {
+        SidebarLayout::Packed => rows.push(Value::Array(styled_row(
+            "$quota_provider_model",
+            None,
+            Some(true),
+            Some(false),
+        ))),
+        SidebarLayout::Stacked => {
+            rows.push(Value::Array(styled_row(
+                "$quota_provider",
+                None,
+                Some(true),
+                Some(false),
+            )));
+            rows.push(Value::Array(styled_row(
+                "$quota_model",
+                None,
+                Some(false),
+                Some(false),
+            )));
         }
     }
-    if !has_tab {
-        let insert_at = normalized
-            .iter()
-            .position(|item| item.as_str() == Some("terminal_title_stripped"))
-            .unwrap_or(normalized.len());
-        normalized.insert(insert_at, styled_tab());
-    }
-    normalized
-}
-
-fn append_quota_rows(rows: &mut Array, layout: SidebarLayout, rewrite: RowRewrite) {
-    // Context can carry the weekly token when 5h is empty. Limits stay on the
-    // next row so a present 5h window never shares a line with context. Herdr
-    // drops empty tokens and empty rows. Stacked keeps that publish rule and
-    // only changes which tokens share a visual line.
-    for row in rows.iter_mut() {
-        let Some(items) = row.as_array_mut() else {
-            continue;
-        };
-        let has_state_icon = items.iter().any(|item| item.as_str() == Some("state_icon"));
-        let mut cleaned = Array::new();
-        for item in items.iter() {
-            let token_name = configured_token_name(item);
-            if token_name.is_some_and(|token| {
-                QUOTA_ROW_MARKERS.contains(&token)
-                    && !(layout == SidebarLayout::Packed
-                        && has_state_icon
-                        && token == "$quota_provider_model")
-            }) {
-                continue;
-            }
-            match item.as_str() {
-                Some("terminal_title_stripped") if matches!(rewrite, RowRewrite::Takeover) => {}
-                Some("$quota_topic") => {}
-                Some("agent") if !has_state_icon && matches!(rewrite, RowRewrite::Takeover) => {}
-                _ => cleaned.push(item.clone()),
-            }
-        }
-        *items = cleaned;
-    }
-
-    let mut compacted_rows = Array::new();
-    for row in rows.iter() {
-        if row.as_array().is_some_and(|items| !items.is_empty()) {
-            compacted_rows.push(row.clone());
-        }
-    }
-    *rows = compacted_rows;
-
-    let official_index = rows.iter().position(|row| {
-        row.as_array()
-            .is_some_and(|items| items.iter().any(|item| item.as_str() == Some("state_icon")))
-    });
-
-    if let Some(index) = official_index {
-        if let Some(row) = rows.get_mut(index).and_then(Value::as_array_mut) {
-            *row = match (rewrite, layout) {
-                (RowRewrite::Preserve, SidebarLayout::Packed) => preserve_identity_row(row),
-                (RowRewrite::Preserve, SidebarLayout::Stacked) => row.clone(),
-                (RowRewrite::Takeover, SidebarLayout::Packed) => packed_identity_row(row),
-                (RowRewrite::Takeover, SidebarLayout::Stacked) => stacked_identity_row(row),
-            };
-        }
-    }
-
-    if layout == SidebarLayout::Stacked {
-        let insert_at = official_index.map(|index| index + 1).unwrap_or(0);
-        rows.insert(
-            insert_at,
-            Value::Array(styled_row("$quota_provider", None, Some(true), Some(false))),
-        );
-        rows.insert(
-            insert_at + 1,
-            Value::Array(styled_row("$quota_model", None, Some(false), Some(false))),
-        );
-    }
-
     rows.push(Value::Array(styled_row(
         "$quota_topic",
         None,
         Some(false),
         Some(false),
     )));
-
+    // Context folds the weekly quota when 5h is absent; empty rows collapse.
     match layout {
         SidebarLayout::Packed => append_packed_quota_rows(rows),
         SidebarLayout::Stacked => append_stacked_quota_rows(rows),
     }
-}
-
-fn preserve_identity_row(row: &Array) -> Array {
-    let mut kept = Array::new();
-    let mut has_provider_model = false;
-    for item in row.iter() {
-        if configured_token_name(item) == Some("$quota_provider_model") {
-            if !has_provider_model {
-                kept.push(item.clone());
-                has_provider_model = true;
-            }
-        } else {
-            kept.push(item.clone());
-        }
-    }
-    if !has_provider_model {
-        kept.push(styled_token(
-            "$quota_provider_model",
-            None,
-            Some(true),
-            Some(false),
-        ));
-    }
-    kept
-}
-
-fn packed_identity_row(row: &Array) -> Array {
-    let mut compacted = Array::new();
-    let mut has_provider_model = false;
-    for item in row.iter() {
-        if item.as_str() == Some("agent") {
-            if !has_provider_model {
-                compacted.push(styled_token(
-                    "$quota_provider_model",
-                    None,
-                    Some(true),
-                    Some(false),
-                ));
-                has_provider_model = true;
-            }
-        } else if configured_token_name(item) == Some("$quota_provider_model") {
-            if !has_provider_model {
-                compacted.push(item.clone());
-                has_provider_model = true;
-            }
-        } else if is_tab_token(item) {
-            compacted.push(styled_tab());
-        } else {
-            compacted.push(item.clone());
-        }
-    }
-    if !has_provider_model {
-        compacted.push(styled_token(
-            "$quota_provider_model",
-            None,
-            Some(true),
-            Some(false),
-        ));
-    }
-    compacted
-}
-
-fn stacked_identity_row(row: &Array) -> Array {
-    let mut compacted = Array::new();
-    for item in row.iter() {
-        if item.as_str() == Some("agent")
-            || matches!(
-                configured_token_name(item),
-                Some("$quota_provider_model" | "$quota_provider" | "$quota_model")
-            )
-        {
-            continue;
-        }
-        compacted.push(item.clone());
-    }
-    // Dropping `agent` would otherwise skip normalize_official_row's tab
-    // restore, so a first stacked apply from `["state_icon", "agent"]`
-    // would not match the second.
-    normalize_official_row(compacted)
 }
 
 fn append_packed_quota_rows(rows: &mut Array) {
@@ -1180,7 +1031,7 @@ fn skipped_provider_label(provider: &str) -> &str {
 }
 
 fn print_diff_hint(layout: SidebarLayout, fields: FieldSet, brand: BrandColors) {
-    println!("  keep Herdr's official state icon and plane tab");
+    println!("  keep Herdr's official machine, workspace, tab, and agent rows");
     match layout {
         SidebarLayout::Packed => {
             println!("  show the user prompt, context, and one compact severity-colored 5h/7d row");
@@ -1207,6 +1058,123 @@ fn print_diff_hint(layout: SidebarLayout, fields: FieldSet, brand: BrandColors) 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn repair_preserves_native_rows_added_after_installation() {
+        let installed = add_quota_row(concat!(
+            "[ui]\nagent_panel_sort = \"spaces\"\n",
+            "[ui.sidebar.spaces]\n",
+            "rows = [[\"state_icon\", \"workspace\"], [\"branch\", \"git_status\"]]\n",
+        ))
+        .unwrap();
+        let mut document = installed.parse::<DocumentMut>().unwrap();
+        let rows = document["ui"]["sidebar"]["agents"]["rows"]
+            .as_array_mut()
+            .unwrap();
+        let mut custom = Array::new();
+        custom.push("pane");
+        custom.push(styled_token("workspace", Some("#123456"), None, None));
+        custom.push("$git_branch");
+        rows.insert(1, Value::Array(custom.clone()));
+        let customized = document.to_string();
+
+        for layout in [SidebarLayout::Packed, SidebarLayout::Stacked] {
+            for brand in [BrandColors::On, BrandColors::Off] {
+                let apply = |input: &str| {
+                    add_quota_row_with(
+                        input,
+                        &AgentSelection::SUPPORTED,
+                        layout,
+                        SidebarRowGap::default(),
+                        FieldSet::all(),
+                        brand,
+                    )
+                    .unwrap()
+                };
+                let repaired = apply(&customized);
+                let parsed = repaired.parse::<DocumentMut>().unwrap();
+                assert_eq!(parsed["ui"]["agent_panel_sort"].as_str(), Some("spaces"));
+                assert_eq!(
+                    parsed["ui"]["sidebar"]["spaces"].to_string(),
+                    document["ui"]["sidebar"]["spaces"].to_string()
+                );
+                let agents = &parsed["ui"]["sidebar"]["agents"];
+                let shared = agents["rows"].as_array().unwrap();
+                assert_eq!(
+                    shared.get(1).unwrap().to_string().trim(),
+                    custom.to_string()
+                );
+                if brand.is_on() {
+                    let provider = agents["rows_by_agent"]["claude"].as_array().unwrap();
+                    assert_eq!(
+                        provider.get(1).unwrap().to_string().trim(),
+                        custom.to_string()
+                    );
+                }
+                assert_eq!(apply(&repaired), repaired);
+                let removed = remove_quota_row(&repaired).unwrap();
+                assert!(removed.contains("pane"));
+                assert!(removed.contains("$git_branch"));
+                assert!(removed.contains("#123456"));
+                assert!(!removed.contains("$quota_"));
+            }
+        }
+    }
+
+    #[test]
+    fn official_09_rows_stay_above_plugin_fields_on_install_and_migration() {
+        for original in [
+            "",
+            "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"machine\", \"workspace\", \"tab\"], [\"agent\"]]\n",
+            "[ui.sidebar.agents]\nrows = [[\"state_icon\", { token = \"tab\", bold = true }, \"$quota_provider_model\"], [\"$quota_topic\"]] # herdr-agent-quota-row\n",
+        ] {
+            for layout in [SidebarLayout::Packed, SidebarLayout::Stacked] {
+                let updated = add_quota_row_for(original, &[Harness::Claude], layout).unwrap();
+                let document = updated.parse::<DocumentMut>().unwrap();
+                for rows in [
+                    document["ui"]["sidebar"]["agents"]["rows"].as_array().unwrap(),
+                    document["ui"]["sidebar"]["agents"]["rows_by_agent"]["claude"].as_array().unwrap(),
+                ] {
+                    let names = |index| rows.get(index).unwrap().as_array().unwrap()
+                        .iter().map(|item| item.as_str().unwrap()).collect::<Vec<_>>();
+                    assert_eq!(names(0), ["state_icon", "machine", "workspace", "tab"]);
+                    assert_eq!(names(1), ["agent"]);
+                    assert!(rows.iter().skip(2).any(|row| row_contains_token(row, "$quota_topic")));
+                }
+                assert_eq!(add_quota_row_for(&updated, &[Harness::Claude], layout).unwrap(), updated);
+            }
+        }
+    }
+
+    #[test]
+    fn custom_styles_on_native_tokens_survive_repair() {
+        let original = "[ui.sidebar.agents]\nrows = [[\"state_icon\", { token = \"workspace\", fg = \"#123456\" }, \"tab\"], [\"agent\"]]\n";
+        let updated = add_quota_row(original).unwrap();
+        let document = updated.parse::<DocumentMut>().unwrap();
+        for rows in [
+            document["ui"]["sidebar"]["agents"]["rows"]
+                .as_array()
+                .unwrap(),
+            document["ui"]["sidebar"]["agents"]["rows_by_agent"]["claude"]
+                .as_array()
+                .unwrap(),
+        ] {
+            let first = rows.get(0).unwrap().as_array().unwrap();
+            assert_eq!(first.len(), 3);
+            assert_eq!(
+                first
+                    .get(1)
+                    .unwrap()
+                    .as_inline_table()
+                    .unwrap()
+                    .get("fg")
+                    .and_then(Value::as_str),
+                Some("#123456")
+            );
+            assert_eq!(token_names(rows.get(1).unwrap()), ["agent"]);
+        }
+        assert_eq!(add_quota_row(&updated).unwrap(), updated);
+    }
 
     #[test]
     fn adds_quota_rows_without_replacing_official_rows() {
@@ -1336,7 +1304,7 @@ rows = [["state_icon", "agent"]]
             .iter()
             .position(|row| row_contains_token(row, "$quota_topic"))
             .unwrap();
-        assert_eq!(identity_index + 1, provider_index);
+        assert_eq!(identity_index + 2, provider_index);
         assert_eq!(provider_index + 1, model_index);
         assert_eq!(model_index + 1, topic_index);
         assert!(!rows
@@ -1410,7 +1378,7 @@ rows = [["state_icon", "agent"]]
     }
 
     #[test]
-    fn tab_labels_inherit_herdr_theme_and_remain_bold() {
+    fn tab_labels_keep_herdr_default_styling() {
         let updated =
             add_quota_row("[ui.sidebar.agents]\nrows = [[\"state_icon\", \"tab\", \"agent\"]]\n")
                 .unwrap();
@@ -1430,11 +1398,8 @@ rows = [["state_icon", "agent"]]
         let tab = identity
             .iter()
             .find(|item| configured_token_name(item) == Some("tab"))
-            .and_then(Value::as_inline_table)
             .unwrap();
-        assert!(!tab.contains_key("fg"));
-        assert_eq!(tab.get("bold").and_then(Value::as_bool), Some(true));
-        assert_eq!(tab.get("dim").and_then(Value::as_bool), Some(false));
+        assert_eq!(tab.as_str(), Some("tab"));
     }
 
     #[test]

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -413,12 +413,7 @@ fn build_managed_rows(
     rewrite: RowRewrite,
 ) -> Result<Array> {
     let mut updated_rows = match rewrite {
-        RowRewrite::Takeover
-            if original.is_none_or(|rows| {
-                rows.iter()
-                    .all(|row| is_safe_to_take(row) || is_legacy_identity_row(row))
-            }) =>
-        {
+        RowRewrite::Takeover if original.is_none_or(|rows| is_default_layout(rows, true)) => {
             official_agent_rows()
         }
         _ => {
@@ -441,12 +436,11 @@ fn build_managed_rows(
 
 // Recognize only the tab styling written by older plugin versions. A managed
 // marker does not make later user-added Git, directory, or styled rows ours.
-fn is_legacy_identity_row(row: &Value) -> bool {
-    let cleaned = strip_quota_tokens(row);
-    if cleaned.len() != 2 || cleaned.get(0).and_then(Value::as_str) != Some("state_icon") {
+fn is_legacy_identity_row(row: &Array) -> bool {
+    if row.len() != 2 || row.get(0).and_then(Value::as_str) != Some("state_icon") {
         return false;
     }
-    let Some(tab) = cleaned.get(1).and_then(Value::as_inline_table) else {
+    let Some(tab) = row.get(1).and_then(Value::as_inline_table) else {
         return false;
     };
     tab.get("token").and_then(Value::as_str) == Some("tab")
@@ -464,15 +458,29 @@ fn has_rows_marker(value: &Value) -> bool {
 }
 
 fn is_safe_to_take_over(rows: &Array) -> bool {
-    rows.iter().all(is_safe_to_take)
+    is_default_layout(rows, false)
 }
 
-fn is_safe_to_take(row: &Value) -> bool {
-    let cleaned = strip_quota_tokens(row);
-    if cleaned.is_empty() {
-        return true;
+fn is_default_layout(rows: &Array, allow_legacy: bool) -> bool {
+    let native: Vec<_> = rows
+        .iter()
+        .map(strip_quota_tokens)
+        .filter(|row| !row.is_empty())
+        .collect();
+    match native.as_slice() {
+        [] => true,
+        [identity] => {
+            is_default_state_equivalent(identity)
+                || (allow_legacy && is_legacy_identity_row(identity))
+        }
+        [identity, agent] => {
+            is_default_state_equivalent(identity)
+                && !identity.iter().any(|item| item.as_str() == Some("agent"))
+                && agent.len() == 1
+                && agent.get(0).and_then(Value::as_str) == Some("agent")
+        }
+        _ => false,
     }
-    is_default_state_equivalent(&cleaned)
 }
 
 fn is_default_state_equivalent(row: &Array) -> bool {
@@ -484,7 +492,7 @@ fn is_default_state_equivalent(row: &Array) -> bool {
             _ => return false,
         }
     }
-    has_state_icon || (row.len() == 1 && row.get(0).and_then(Value::as_str) == Some("agent"))
+    has_state_icon
 }
 
 /// Full-installation form, used by callers that remove every agent.
@@ -1058,6 +1066,25 @@ fn print_diff_hint(layout: SidebarLayout, fields: FieldSet, brand: BrandColors) 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extra_native_identity_rows_and_unmarked_legacy_styles_are_preserved() {
+        for original in [
+            "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"machine\", \"workspace\", \"tab\"], [\"agent\"], [\"agent\"]] # herdr-agent-quota-row\n",
+            "[ui.sidebar.agents]\nrows = [[\"state_icon\", { token = \"tab\", bold = true, dim = false }]]\n",
+        ] {
+            let expected = original.parse::<DocumentMut>().unwrap();
+            let expected = expected["ui"]["sidebar"]["agents"]["rows"].as_array().unwrap();
+            let applied = add_quota_row(original).unwrap();
+            let parsed = applied.parse::<DocumentMut>().unwrap();
+            let rows = parsed["ui"]["sidebar"]["agents"]["rows"].as_array().unwrap();
+            for (actual, expected) in rows.iter().zip(expected.iter()) {
+                assert_eq!(actual.to_string().trim(), expected.to_string().trim());
+            }
+            assert!(rows.len() >= expected.len());
+            assert_eq!(add_quota_row(&applied).unwrap(), applied);
+        }
+    }
 
     #[test]
     fn repair_preserves_native_rows_added_after_installation() {

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -204,13 +204,26 @@ pub fn event() -> Result<()> {
 }
 
 pub fn focus() -> Result<()> {
-    let Some((pane_id, harness)) = current_focused_pane()? else {
+    let pane = if let Some(event) = event_json() {
+        let Some(pane_id) = find_pane_id(&event) else {
+            return Ok(());
+        };
+        // Focus may have moved again, or belong to another client. The event
+        // names our target; the inventory supplies its current harness.
+        list_agent_state()?
+            .panes
+            .into_iter()
+            .find(|pane| pane.pane_id == pane_id)
+    } else {
+        let Some((pane_id, harness)) = current_focused_pane()? else {
+            return Ok(());
+        };
+        named_pane(&pane_id, harness)?
+    };
+    let Some(pane) = pane else {
         return Ok(());
     };
     let cache = CacheStore::from_env()?;
-    let Some(pane) = named_pane(&pane_id, harness)? else {
-        return Ok(());
-    };
     handle_named_pane(&cache, pane, None)
 }
 

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -141,7 +141,7 @@ fn run_claude_refresh(state: &Path, herdr: &Path) {
 #[test]
 fn sidebar_configuration_is_idempotent_and_removes_plugin_rows() {
     let original = "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n";
-    let canonical_without_plugin = "[ui.sidebar.agents]\nrows = [[\"state_icon\"]]\n";
+    let canonical_without_plugin = "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"machine\", \"workspace\", \"tab\"], [\"agent\"]]\n";
     let applied = add_quota_row(original).unwrap();
     assert!(applied.contains("key = \"prefix+shift+r\""));
     assert!(applied.contains("type = \"plugin_action\""));
@@ -172,7 +172,7 @@ fn sidebar_configuration_preserves_a_conflicting_refresh_key() {
     assert!(!applied.contains("command = \"herdr-agent-quota.refresh\""));
     assert_eq!(
         remove_quota_row(&applied).unwrap(),
-        "[[keys.command]]\nkey = \"prefix+shift+r\"\ntype = \"shell\"\ncommand = \"echo user-owned\"\ndescription = \"user refresh\"\n\n[ui.sidebar.agents]\nrows = [[\"state_icon\"]]\n"
+        "[[keys.command]]\nkey = \"prefix+shift+r\"\ntype = \"shell\"\ncommand = \"echo user-owned\"\ndescription = \"user refresh\"\n\n[ui.sidebar.agents]\nrows = [[\"state_icon\", \"machine\", \"workspace\", \"tab\"], [\"agent\"]]\n"
     );
 }
 
@@ -257,7 +257,6 @@ fn non_semantic_text_inherits_the_active_herdr_theme() {
         .as_array()
         .unwrap();
     let inherited = [
-        "tab",
         "$quota_topic",
         "$quota_cache",
         "$quota_cache_ttl",
@@ -338,8 +337,7 @@ fn context_is_the_penultimate_row_and_model_shares_provider_style() {
             );
         } else {
             assert!(
-                rendered
-                    .starts_with(" [[\"state_icon\", { token = \"$quota_provider_model\", bold"),
+                rendered.contains("{ token = \"$quota_provider_model\", bold"),
                 "{provider} should use the neutral identity style: {rendered}"
             );
         }
@@ -472,7 +470,7 @@ fn sidebar_configuration_preserves_an_explicit_row_gap() {
     assert!(!applied.contains("row_gap = 1"));
     assert_eq!(
         remove_quota_row(&applied).unwrap(),
-        "[ui.sidebar.agents]\nrow_gap = 2\nrows = [[\"state_icon\"]]\n"
+        "[ui.sidebar.agents]\nrow_gap = 2\nrows = [[\"state_icon\", \"machine\", \"workspace\", \"tab\"], [\"agent\"]]\n"
     );
 }
 
@@ -1234,6 +1232,40 @@ fn unknown_agent_working_event_does_not_refresh_any_collector() {
 }
 
 #[test]
+fn focus_event_uses_its_pane_even_when_the_current_focus_differs() {
+    for pane_id in ["w1:p9", "w1:p99"] {
+        let state = tempdir().unwrap();
+        let (herdr, herdr_log, codex, codex_log) = install_logged_herdr_and_codex(
+            state.path(),
+            original_four_inventory_with_working_codex(),
+            Some(r#"{"result":{"pane":{"agent":"codex","pane_id":"w1:p2"}}}"#),
+        );
+        let output = Command::new(env!("CARGO_BIN_EXE_herdr-agent-quota"))
+            .arg("focus")
+            .env("HERDR_PLUGIN_STATE_DIR", state.path())
+            .env("HERDR_BIN_PATH", &herdr)
+            .env("CODEX_BIN_PATH", &codex)
+            .env("XDG_DATA_HOME", state.path().join("xdg-data"))
+            .env_remove("OPENCODE_API_KEY")
+            .env("HERDR_PLUGIN_EVENT_JSON", format!(
+                r#"{{"event":"pane_focused","data":{{"type":"pane_focused","pane_id":"{pane_id}","workspace_id":"w1"}}}}"#
+            ))
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let calls = fs::read_to_string(&herdr_log).unwrap_or_default();
+        assert!(!calls.contains("pane current"), "{calls}");
+        assert_eq!(calls.matches("agent list").count(), 1, "{calls}");
+        assert!(!calls.contains("pane read"), "{calls}");
+        assert_no_original_four_collection(state.path(), &herdr_log, &codex_log);
+    }
+}
+
+#[test]
 fn focus_on_an_opencode_pane_does_not_refresh_collectors() {
     let state = tempdir().unwrap();
     let (herdr, herdr_log, codex, codex_log) = install_logged_herdr_and_codex(
@@ -1873,7 +1905,8 @@ fn an_installer_can_select_flush_gap_through_the_plugin_config_dir() {
 fn sidebar_is_packed(sidebar: &str) -> bool {
     quota_tokens_share_a_row(sidebar, "$quota_cache", "$quota_cache_ttl")
         && quota_tokens_share_a_row(sidebar, "$quota_5h_normal", "$quota_week_normal")
-        && tab_shares_row_with_provider_model(sidebar)
+        && sidebar_has_token(sidebar, "$quota_provider_model")
+        && !tab_shares_row_with_provider_model(sidebar)
 }
 
 fn sidebar_is_stacked(sidebar: &str) -> bool {


### PR DESCRIPTION
## What this changes

Herdr 0.9 native navigation and agent identity rows now stay above quota fields instead of being replaced by plugin identity styling. Reconfiguring shared managed rows preserves added custom fields and styles, while recognized older plugin layouts migrate to the native baseline. Space Git rows and worktree grouping remain under Herdr's control.

Focus events resolve the pane named in their payload using one agent inventory read, so delayed events and independent clients cannot redirect refreshes to the current global focus. Release v1.5.0 requires Herdr 0.9.0+.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features --locked` (501 tests)
- [x] Event targeting and sidebar migration/preservation have regression tests; no provider parser changed
- [x] No new network call, background process, or credential write
- [x] Release build with the locked dependencies

## Provider impact

All supported agents retain native Herdr identity rows. Quota collection contracts are unchanged. Verified with Herdr client/server 0.9.0 (protocol 22); live config check succeeds. No claim about visual repaint behavior is based on scroll offsets or content hashes.
