### PR TITLE
docs: restore sidebar layout previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ Model, context, prompt-cache usage, and subscription quota in Herdr's Agent side
 
 [简体中文](README.zh-CN.md)
 
+<table>
+<tr><th>packed (default)</th><th>stacked</th></tr>
+<tr>
+<td valign="top"><img src="docs/screenshots/sidebar-packed.png" alt="Packed sidebar" width="284"></td>
+<td valign="top"><img src="docs/screenshots/sidebar-stacked.png" alt="Stacked sidebar" width="177"></td>
+</tr>
+</table>
+
 The plugin preserves Herdr's native rows, custom styles, and worktree grouping.
 Optional quota ordering and low-quota notifications are disabled by default.
 Empty fields collapse; percentages can show remaining or used quota.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,6 +7,14 @@
 
 [English](README.md)
 
+<table>
+<tr><th>packed（默认）</th><th>stacked</th></tr>
+<tr>
+<td valign="top"><img src="docs/screenshots/sidebar-packed.png" alt="拼接布局" width="284"></td>
+<td valign="top"><img src="docs/screenshots/sidebar-stacked.png" alt="分行布局" width="177"></td>
+</tr>
+</table>
+
 插件保留 Herdr 原生行、自定义样式和 worktree 分组。按额度排序和低额度通知默认关闭。
 空字段自动折叠，百分比可选择显示剩余或已用额度。
 


### PR DESCRIPTION
Restore the original packed/stacked screenshot comparison near the top of both READMEs. The existing images and their original sizing are reused. Documentation links and git diff whitespace checks pass.