### PR TITLE
fix: refresh expired quota windows without waiting for a new turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Idle Codex (and other API-backed) panes no longer keep a frozen 5h remaining
+  count after the window resets. A cached window whose reset is in the past
+  bypasses the 60-second fetch debounce, and a watcher already running for
+  another agent includes those expired targets so the sidebar is rewritten
+  without waiting for that pane to start a turn. Codex `/status` is still a
+  session-local cache and is not scraped.
+
 ## [1.5.2] - 2026-09-08
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,9 @@ Timing-sensitive tests can be diagnosed with `-- --test-threads=1`.
 - Read only the named pane's visible screen on an event. Watch, refresh, and
   startup must not read terminal output. Publish once and suppress unchanged
   metadata; include new tokens in the metadata comparison set.
-- Keep one bounded watcher for all supported harnesses. Fetch only active or
-  settling billing targets, retain upstream cache limits, and test completion
-  inside a debounce window.
+- Keep one bounded watcher for all supported harnesses. Fetch active or
+  settling billing targets, and any target whose cached windows have expired,
+  retain upstream cache limits, and test completion inside a debounce window.
 - Preserve user configuration and existing preferences during upgrades.
   Installation, repair, and uninstall must be repeatable and reversible.
   Test migration from older caches and a watcher using an old Herdr client.

--- a/src/model.rs
+++ b/src/model.rs
@@ -756,6 +756,25 @@ impl ProviderSnapshot {
         window_in(&self.windows, kind)
     }
 
+    /// True when a stored quota window's reset is now in the past.
+    ///
+    /// Missing reset times cannot be proved expired, so they do not qualify.
+    /// An empty window list is "no quota", not a lapsed window.
+    pub fn has_expired_quota(&self, now_unix: u64) -> bool {
+        fn expired(windows: &[UsageWindow], now_unix: u64) -> bool {
+            windows.iter().any(|window| !window.is_current(now_unix))
+        }
+        expired(&self.windows, now_unix)
+            || self
+                .session_windows
+                .values()
+                .any(|windows| expired(windows, now_unix))
+            || self
+                .quota_scope_windows
+                .values()
+                .any(|windows| expired(windows, now_unix))
+    }
+
     /// Keep a previously observed quota window when the latest payload omits
     /// it. Upstream often drops the short window for a tick (Claude statusLine
     /// without `five_hour`, Codex `secondary: null` after a reset credit).
@@ -1597,5 +1616,40 @@ mod tests {
         assert!(UsageWindow::new(WindowKind::FiveHour, 20.0, None)
             .unwrap()
             .is_current(1_001));
+    }
+
+    #[test]
+    fn a_snapshot_has_expired_quota_only_when_a_reset_is_in_the_past() {
+        let live = ProviderSnapshot::new(
+            Provider::Codex,
+            vec![
+                quota_window(WindowKind::FiveHour, 96.0, 2_000),
+                quota_window(WindowKind::Weekly, 48.0, 10_000),
+            ],
+            1_000,
+        );
+        assert!(!live.has_expired_quota(1_999));
+        let expired = ProviderSnapshot::new(
+            Provider::Codex,
+            vec![
+                quota_window(WindowKind::FiveHour, 96.0, 1_000),
+                quota_window(WindowKind::Weekly, 48.0, 10_000),
+            ],
+            900,
+        );
+        assert!(expired.has_expired_quota(1_000));
+        let undated = ProviderSnapshot::new(
+            Provider::Codex,
+            vec![UsageWindow::new(WindowKind::Weekly, 48.0, None).unwrap()],
+            1_000,
+        );
+        assert!(!undated.has_expired_quota(5_000));
+        assert!(!ProviderSnapshot::new(Provider::Codex, vec![], 1_000).has_expired_quota(5_000));
+        let mut session = ProviderSnapshot::new(Provider::Claude, vec![], 1_000);
+        session.session_windows.insert(
+            "s1".to_string(),
+            vec![quota_window(WindowKind::FiveHour, 90.0, 1_000)],
+        );
+        assert!(session.has_expired_quota(1_001));
     }
 }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -106,7 +106,9 @@ pub fn startup(providers: &[Provider]) -> Result<()> {
 /// per poll and refreshes every selected provider that is working. Each
 /// provider has its own non-blocking refresh lease, so slow I/O never stalls a
 /// statusLine hook or another provider. The existing provider-level debounce
-/// remains the lower bound for network requests.
+/// remains the lower bound for network requests, except when a cached window
+/// has already expired — that reading is no longer live, so the next pass
+/// fetches it even if the pane itself is idle.
 pub fn watch(providers: &[Provider], interval_seconds: Option<u64>, defer: bool) -> Result<()> {
     let cache = CacheStore::from_env()?;
     let interval_seconds = interval_seconds
@@ -162,19 +164,23 @@ pub fn watch(providers: &[Provider], interval_seconds: Option<u64>, defer: bool)
             .working_pane_ids
             .iter()
             .filter(|id| {
-                state.panes.iter().any(|pane| {
-                    pane.pane_id == **id
-                        && (covers_every_collector(providers)
-                            || pane
-                                .harness
-                                .billing()
-                                .is_some_and(|p| providers.contains(&p)))
-                })
+                state
+                    .panes
+                    .iter()
+                    .any(|pane| pane.pane_id == **id && pane_in_watch_scope(pane, providers))
             })
             .cloned()
             .collect::<Vec<_>>();
         let now = CacheStore::now_unix();
-        let affected = watch_targets(&active, &previous_active, &mut settling, now);
+        let affected = watch_pass_ids(
+            &cache,
+            &state.panes,
+            providers,
+            &active,
+            &previous_active,
+            &mut settling,
+            now,
+        );
         let _ = refresh_working_panes(&cache, &state.panes, &affected);
         if active.is_empty() && settling.is_empty() {
             break;
@@ -207,6 +213,52 @@ fn watch_targets(
     affected.extend(settling.keys().cloned());
     settling.retain(|_, finished| now.saturating_sub(*finished) < 60);
     affected
+}
+
+fn pane_in_watch_scope(pane: &AgentPane, providers: &[Provider]) -> bool {
+    covers_every_collector(providers)
+        || pane
+            .harness
+            .billing()
+            .is_some_and(|provider| providers.contains(&provider))
+}
+
+/// Working and settling panes, plus idle panes whose cached quota has lapsed.
+///
+/// An expired window is no longer a live reading. Including those pane ids in
+/// an already-running watch pass is what rewrites the sidebar after a 5h
+/// reset without waiting for that pane to start a turn, and without starting
+/// a second watcher while everything is idle.
+fn watch_pass_ids(
+    cache: &CacheStore,
+    panes: &[AgentPane],
+    providers: &[Provider],
+    active: &[String],
+    previous: &[String],
+    settling: &mut BTreeMap<String, u64>,
+    now: u64,
+) -> Vec<String> {
+    let mut affected = watch_targets(active, previous, settling, now);
+    for pane in panes {
+        if !pane_in_watch_scope(pane, providers) || affected.contains(&pane.pane_id) {
+            continue;
+        }
+        if cached_quota_has_expired(cache, pane, now) {
+            affected.push(pane.pane_id.clone());
+        }
+    }
+    affected
+}
+
+fn cached_quota_has_expired(cache: &CacheStore, pane: &AgentPane, now: u64) -> bool {
+    let Resolution::Subscription(target) = route::resolve(pane) else {
+        return false;
+    };
+    cache
+        .load_target(&target)
+        .ok()
+        .flatten()
+        .is_some_and(|snapshot| snapshot.has_expired_quota(now))
 }
 
 fn wait_for_watch_tick(
@@ -561,7 +613,12 @@ fn omp_quota_with_refresh(
     let debounced = cache
         .should_debounce_target(target, now, 60)
         .unwrap_or(false);
-    if debounced && !force {
+    if debounced
+        && !force
+        && !cached
+            .as_ref()
+            .is_some_and(|snapshot| snapshot.has_expired_quota(now))
+    {
         return cached
             .as_ref()
             .and_then(|snapshot| {
@@ -834,6 +891,11 @@ fn should_skip_fetch_for_account(
     mtime: Option<u64>,
 ) -> Result<bool> {
     if force || !cache.should_debounce(provider, now_unix, 60)? {
+        return Ok(false);
+    }
+    if cache.load(provider)?.is_some_and(|snapshot| {
+        snapshot.usable_for_account(account, mtime) && snapshot.has_expired_quota(now_unix)
+    }) {
         return Ok(false);
     }
     if let Some(attempted) = cache.last_refresh_account(provider) {
@@ -1198,8 +1260,23 @@ fn tokens_for_loaded_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{ProviderSnapshot, UsageWindow, WindowKind};
+    use crate::model::{ProviderSnapshot, ResetAt, UsageWindow, WindowKind};
     use tempfile::tempdir;
+
+    fn test_pane(id: &str, harness: Harness) -> AgentPane {
+        AgentPane {
+            pane_id: id.to_string(),
+            harness,
+            session: None,
+            session_summary: String::new(),
+            topic: String::new(),
+            tokens: BTreeMap::new(),
+        }
+    }
+
+    fn window(kind: WindowKind, used: f64, reset: u64) -> UsageWindow {
+        UsageWindow::new(kind, used, Some(ResetAt::from_unix_seconds(reset))).unwrap()
+    }
 
     fn low(pairs: &[(&str, u8)]) -> BTreeMap<String, u8> {
         pairs
@@ -1298,6 +1375,102 @@ mod tests {
             100
         )
         .contains(&a));
+    }
+
+    #[test]
+    fn an_idle_pane_with_an_expired_window_joins_a_running_watch_pass() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save(&ProviderSnapshot::new(
+                Provider::Codex,
+                vec![
+                    window(WindowKind::FiveHour, 96.0, 1_000),
+                    window(WindowKind::Weekly, 48.0, 10_000),
+                ],
+                900,
+            ))
+            .unwrap();
+        let panes = [
+            test_pane("codex-idle", Harness::Codex),
+            test_pane("grok-working", Harness::Grok),
+        ];
+        let grok = "grok-working".to_string();
+        let mut settling = BTreeMap::new();
+        let affected = watch_pass_ids(
+            &cache,
+            &panes,
+            &Provider::ALL,
+            std::slice::from_ref(&grok),
+            std::slice::from_ref(&grok),
+            &mut settling,
+            1_001,
+        );
+        assert!(affected.contains(&"codex-idle".to_string()));
+        assert!(affected.contains(&grok));
+    }
+
+    #[test]
+    fn a_live_idle_pane_does_not_join_another_providers_watch_pass() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save(&ProviderSnapshot::new(
+                Provider::Codex,
+                vec![
+                    window(WindowKind::FiveHour, 20.0, 2_000),
+                    window(WindowKind::Weekly, 48.0, 10_000),
+                ],
+                900,
+            ))
+            .unwrap();
+        let panes = [
+            test_pane("codex-idle", Harness::Codex),
+            test_pane("grok-working", Harness::Grok),
+        ];
+        let grok = "grok-working".to_string();
+        let mut settling = BTreeMap::new();
+        let affected = watch_pass_ids(
+            &cache,
+            &panes,
+            &Provider::ALL,
+            std::slice::from_ref(&grok),
+            std::slice::from_ref(&grok),
+            &mut settling,
+            1_001,
+        );
+        assert!(!affected.contains(&"codex-idle".to_string()));
+        assert_eq!(affected, vec![grok]);
+    }
+
+    #[test]
+    fn an_expired_idle_pane_stays_out_of_a_narrower_watch_selection() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save(&ProviderSnapshot::new(
+                Provider::Codex,
+                vec![window(WindowKind::FiveHour, 96.0, 1_000)],
+                900,
+            ))
+            .unwrap();
+        let panes = [
+            test_pane("codex-idle", Harness::Codex),
+            test_pane("grok-working", Harness::Grok),
+        ];
+        let grok = "grok-working".to_string();
+        let mut settling = BTreeMap::new();
+        let affected = watch_pass_ids(
+            &cache,
+            &panes,
+            &[Provider::Grok],
+            std::slice::from_ref(&grok),
+            std::slice::from_ref(&grok),
+            &mut settling,
+            1_001,
+        );
+        assert!(!affected.contains(&"codex-idle".to_string()));
+        assert_eq!(affected, vec![grok]);
     }
 
     #[test]
@@ -1535,6 +1708,60 @@ mod tests {
     }
 
     #[test]
+    fn an_expired_omp_window_bypasses_the_fetch_debounce() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let target = BillingTarget::omp("anthropic");
+        cache
+            .save_target(
+                &target,
+                &ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![window(WindowKind::FiveHour, 96.0, 1_000)],
+                    900,
+                )
+                .with_account_id(Some("account-pin".to_string())),
+            )
+            .unwrap();
+        cache.mark_refresh_target(&target, 980).unwrap();
+        let evidence = crate::omp::OmpEvidence {
+            paths: crate::omp::OmpPaths {
+                agent_dir: directory.path().join(".omp/agent"),
+                sessions: directory.path().join(".omp/agent/sessions"),
+            },
+            provider_id: "anthropic".to_string(),
+            account_pin: Some("account-pin".to_string()),
+        };
+        let update = omp_quota_with_refresh(
+            &cache,
+            &target,
+            &evidence,
+            1_001,
+            PercentStyle::default(),
+            false,
+            |_, _, _, _| {
+                OmpUsage::Account(Box::new(
+                    ProviderSnapshot::new(
+                        Provider::Claude,
+                        vec![window(WindowKind::FiveHour, 0.0, 2_000)],
+                        1_001,
+                    )
+                    .with_account_id(Some("account-pin".to_string())),
+                ))
+            },
+        )
+        .expect("refreshed update");
+        let PaneQuotaUpdate::Replace(values) = update else {
+            panic!("expected replacement");
+        };
+        assert!(
+            values.quota_5h.starts_with("5h 100%"),
+            "{}",
+            values.quota_5h
+        );
+    }
+
+    #[test]
     fn an_omp_usage_failure_keeps_the_same_accounts_last_good_snapshot() {
         let directory = tempdir().unwrap();
         let cache = CacheStore::new(directory.path());
@@ -1599,6 +1826,76 @@ mod tests {
         );
         // A failure must not masquerade as a lapsed prompt cache.
         assert_eq!(values.quota_cache_state, "");
+    }
+
+    #[test]
+    fn an_expired_cached_window_bypasses_the_fetch_debounce() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        cache
+            .save(
+                &ProviderSnapshot::new(
+                    Provider::Codex,
+                    vec![
+                        window(WindowKind::FiveHour, 96.0, 1_000),
+                        window(WindowKind::Weekly, 48.0, 10_000),
+                    ],
+                    900,
+                )
+                .with_account_id(Some("acc".into())),
+            )
+            .unwrap();
+        cache
+            .mark_refresh_account(Provider::Codex, 980, Some("acc"))
+            .unwrap();
+        assert!(
+            !should_skip_fetch_for_account(
+                &cache,
+                Provider::Codex,
+                false,
+                1_001,
+                Some("acc"),
+                None
+            )
+            .unwrap(),
+            "a 5h window that has already reset must be fetched even inside the debounce window"
+        );
+        cache
+            .save(
+                &ProviderSnapshot::new(
+                    Provider::Codex,
+                    vec![
+                        window(WindowKind::FiveHour, 4.0, 2_000),
+                        window(WindowKind::Weekly, 48.0, 10_000),
+                    ],
+                    1_001,
+                )
+                .with_account_id(Some("acc".into())),
+            )
+            .unwrap();
+        cache
+            .mark_refresh_account(Provider::Codex, 1_001, Some("acc"))
+            .unwrap();
+        assert!(
+            should_skip_fetch_for_account(&cache, Provider::Codex, false, 1_030, Some("acc"), None)
+                .unwrap(),
+            "a still-current window must keep the debounce"
+        );
+        cache
+            .save(
+                &ProviderSnapshot::new(
+                    Provider::Codex,
+                    vec![UsageWindow::new(WindowKind::Weekly, 48.0, None).unwrap()],
+                    1_001,
+                )
+                .with_account_id(Some("acc".into())),
+            )
+            .unwrap();
+        assert!(
+            should_skip_fetch_for_account(&cache, Provider::Codex, false, 1_030, Some("acc"), None)
+                .unwrap(),
+            "a window without a reset time cannot be proved expired"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Codex `/status` can show a fresh 5h window (100% left) while Herdr's sidebar still displays the last published token, including a frozen countdown such as `5h 4% 1h19m`. The plugin does not scrape `/status` (pane reads repaint the TUI). Quota comes from `account/rateLimits/read`, cached for 60s, and the watcher only refreshed **working or settling** targets. After a 5h reset, an idle Codex pane kept yesterday's metadata until that pane started another turn.

## Change

- Treat a cached window whose `resets_at` is in the past as expired. Missing reset times still cannot be proved stale.
- Bypass the 60-second fetch debounce for that account's snapshot so the next collector call is not skipped.
- When a watch pass is already running for another agent, include idle panes whose cached quota has expired and publish to their siblings. Does not start a second watcher while everything is idle, and does not scrape `/status`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets --all-features --locked`
- `cargo clippy --release --all-targets --all-features --locked -- -D warnings`
- `cargo build --release --locked`

New tests cover: expired vs live vs undated windows, debounce bypass, watch inclusion of idle expired Codex while Grok is working, narrower `--provider grok` not picking up Codex, and the same debounce bypass for omp.