### PR TITLE
fix: preserve omitted five_hour window for session-local Claude statusline observations

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -914,10 +914,25 @@ fn merge_session_windows(
     quota_scope: Option<&str>,
 ) {
     if snapshot.session_quota_only {
-        if let Some(previous) = previous.filter(|previous| previous.session_quota_only) {
+        let previous = previous.filter(|previous| previous.session_quota_only);
+        if let Some(previous) = previous {
             snapshot.session_windows = previous.session_windows.clone();
         }
         if let Some(id) = session_id {
+            // A statusLine tick that omits `five_hour` is not a report that the
+            // window is gone, so restore this session's own last reading before
+            // it becomes the session's stored quota. Without this the sidebar
+            // falls back to `5h N/A` until Claude Code emits the window again.
+            if let Some(previous_windows) =
+                previous.and_then(|previous| previous_windows_for_merge(previous, id, None))
+            {
+                let previous_windows = previous_windows.to_vec();
+                merge_omitted_window_list(
+                    &mut snapshot.windows,
+                    &previous_windows,
+                    snapshot.fetched_at_unix,
+                );
+            }
             snapshot
                 .session_windows
                 .insert(id.to_string(), snapshot.windows.clone());
@@ -2415,6 +2430,106 @@ mod tests {
                 .used_percent,
             22.0
         );
+    }
+
+    /// A session-local (`session_quota_only`) statusLine observation is the
+    /// Claude path: a tick without `five_hour` must not strip the window from
+    /// the session's stored quota, or the sidebar renders `5h N/A`.
+    #[test]
+    fn session_local_statusline_observation_preserves_an_omitted_five_hour_window() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let payload = json!({"session_id": "session-1"});
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![
+                        UsageWindow::new(
+                            WindowKind::FiveHour,
+                            13.0,
+                            Some(ResetAt::from_unix_seconds(2_000)),
+                        )
+                        .unwrap(),
+                        UsageWindow::new(
+                            WindowKind::Weekly,
+                            20.0,
+                            Some(ResetAt::from_unix_seconds(10_000)),
+                        )
+                        .unwrap(),
+                    ],
+                    1_000,
+                )
+                .session_local(),
+                &payload,
+            )
+            .unwrap();
+
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![UsageWindow::new(
+                        WindowKind::Weekly,
+                        20.0,
+                        Some(ResetAt::from_unix_seconds(10_000)),
+                    )
+                    .unwrap()],
+                    1_100,
+                )
+                .session_local(),
+                &payload,
+            )
+            .unwrap();
+
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        assert_eq!(
+            window_in(&saved.windows, WindowKind::FiveHour)
+                .unwrap()
+                .used_percent,
+            13.0
+        );
+        assert_eq!(
+            window_in(
+                saved.windows_for_session(Some("session-1")),
+                WindowKind::FiveHour
+            )
+            .unwrap()
+            .used_percent,
+            13.0
+        );
+
+        // The restore is bounded by the window's own reset: once the 5h period
+        // has elapsed the stale reading is dropped rather than carried forward.
+        cache
+            .save_statusline_observation(
+                Provider::Claude,
+                ProviderSnapshot::new(
+                    Provider::Claude,
+                    vec![UsageWindow::new(
+                        WindowKind::Weekly,
+                        20.0,
+                        Some(ResetAt::from_unix_seconds(10_000)),
+                    )
+                    .unwrap()],
+                    2_500,
+                )
+                .session_local(),
+                &payload,
+            )
+            .unwrap();
+        let saved = cache
+            .load_statusline_observation(Provider::Claude)
+            .unwrap()
+            .unwrap()
+            .snapshot;
+        assert!(window_in(&saved.windows, WindowKind::FiveHour).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #65.

## Problem

Claude Code does not put `rate_limits.five_hour` on every statusLine payload. `providers::claude::parse_statusline` marks every Claude snapshot `session_local()`, so `merge_session_windows` always takes the `session_quota_only` early-return branch, which writes the incoming windows into `session_windows[session_id]` verbatim. A tick that omits `five_hour` therefore erases the stored 5h window, and the sidebar renders `5h N/A` while the weekly window keeps updating.

`merge_omitted_window_list` exists for exactly this case but is only reached on the path Claude never takes.

## Fix

Inside the `session_quota_only` branch, restore omitted windows from the session's own previous list via the existing `previous_windows_for_merge` + `merge_omitted_window_list` before inserting into `session_windows`. All existing guards stay intact: an empty window list still clears stale quota, a window whose `resets_at` has elapsed is not carried forward, and a sibling window that itself reset suppresses the restore.

## Test

New `cache::tests::session_local_statusline_observation_preserves_an_omitted_five_hour_window` drives `save_statusline_observation` with `.session_local()` snapshots and asserts both the restore and the drop after reset. `cargo test`: 417 unit + 93 integration, 0 failures. `cargo build --release` clean.

Reproduced before/after with the real binary against an isolated `HERDR_PLUGIN_STATE_DIR`; steps are in #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UssUQzn3NBV7mDZAVJdfCX
