### PR TITLE
feat: gauges sidebar layout with a meter beside each quota number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- A third sidebar layout, `gauges`: each quota field gets its own row with a
+  meter beside the number, so remaining headroom reads as a bar length before
+  any digit is read. Every bar fills to the number printed next to it, so the
+  `cx`, `5h` and `7d` rows all print the one quantity `quota-percent` selects
+  (remaining by default), so the column reads as a single scale; `packed` and
+  `stacked` keep printing `context N%` as consumption.
+  The meter sizes itself from the sidebar width Herdr is rendering —
+  four cells at 20 columns, ten at 26, twelve at 30 or wider — and steps aside
+  on a sidebar too narrow to hold it, leaving the row exactly as `stacked`
+  renders it rather than truncating the number the bar labels. The bars live
+  inside the values of the tokens the plugin already publishes. The label
+  column is two characters wide: the built-in periods fit it (`30d` renders as
+  `mo`, so a monthly plan keeps the meter on its only recurring row), while a
+  window an omp workspace names itself is never rewritten and keeps the plain
+  `stacked` shape instead of a truncated label. The one exception is the
+  `cx` row, which under `gauges` takes a severity color of its own on the same
+  green/amber/red scale as the window rows. Color always reads the headroom
+  left, never the number printed — amber below 50% of the context left, red
+  below 20% — and so adds the `quota_context_normal`,
+  `quota_context_warning` and `quota_context_danger` token names. Only one of
+  the three is ever filled, and the report stays inside Herdr's token budget.
+  The `gauges` rows use a muted version of the severity palette (`#98b17d`,
+  `#dec27f`, `#df919b`), because a full-strength hue repeated across a whole
+  row of bar glyphs reads as alarm rather than as a reading.
+  `packed` and `stacked` are unchanged, including their uncolored context row
+  and their original severity colors.
+  Select it with `configure --sidebar-layout gauges`,
+  `./install.sh --sidebar-layout gauges`, or the settings pane's Layout row.
+
 ## [1.5.3] - 2026-09-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ and worktree grouping. The branded provider/model line is the agent identity;
 the native `agent` row is omitted so `grok` does not sit above `Grok/grok-4.6`.
 Optional quota ordering and low-quota notifications are disabled by default.
 Empty fields collapse; percentages can show remaining or used quota.
+`gauges` puts a meter beside each quota number. Every bar fills to the number
+printed next to it, and under `gauges` all three rows — `cx`, `5h` and `7d` —
+print the one quantity `quota-percent` selects, so the column reads as a single
+scale. (`packed` and `stacked` keep printing `context N%` as consumption.) The
+meter is sized from the sidebar width Herdr is rendering — the width it
+auto-scaled to, or `ui.sidebar_width` if it has recorded none — and is dropped,
+never truncated, on a sidebar too narrow to hold it. The label column is two
+characters wide: the built-in periods fit it (`30d` renders as `mo`, so a
+monthly plan keeps the meter on its only recurring row), while a
+provider-named window is never rewritten and keeps the plain `stacked` shape
+rather than a truncated label. Under `gauges` the `cx`
+row takes a severity colour of its own, on the same green/amber/red scale as
+`5h` and `7d`: colour always reads the headroom left, whichever side of the
+ledger the number shows — amber below 50% of the context left, red below 20%.
+The `gauges` rows are drawn in a muted version of that palette, because a
+full-strength hue repeated across a whole row of bar glyphs reads as alarm
+rather than as a reading; `packed` and `stacked` keep the original colours.
 
 ## Install and upgrade
 
@@ -61,7 +78,7 @@ herdr plugin pane open --plugin herdr-agent-quota --entrypoint settings --focus
 | Setting | Options |
 | --- | --- |
 | Percentages | Remaining or used; colors always indicate remaining headroom |
-| Layout | `packed` groups related fields; `stacked` gives each field a row |
+| Layout | `packed` groups related fields; `stacked` gives each field a row; `gauges` adds a meter beside each quota number |
 | Row gap | Zero or one blank line between agents |
 | Watch interval | 30 seconds–1 hour; default 60 seconds |
 | Fields | Topic, model, cache, TTL, context, short/long quota |
@@ -113,6 +130,7 @@ turn failures into zero usage.
 | Devin quota is missing | Check the CLI login and `DEVIN_CREDENTIALS_FILE` if customized |
 | Rows are missing | Run the configure action below to repair managed configuration |
 | Packed rows are truncated | Select `stacked` |
+| The `gauges` meter disappears on a narrow sidebar | Widen the sidebar, or select `stacked` |
 
 ```sh
 herdr plugin action invoke refresh --plugin herdr-agent-quota

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,6 +19,17 @@
 带品牌色的 provider/model 行就是 agent 身份，因此不再保留灰色的原生 `agent` 行，
 避免 `grok` 叠在 `Grok/grok-4.6` 上面。按额度排序和低额度通知默认关闭。
 空字段自动折叠，百分比可选择显示剩余或已用额度。
+`gauges` 在每个额度数字旁加一条进度条。进度条长度始终对应旁边打印的数字；
+`gauges` 下 `cx`、`5h`、`7d` 三行统一采用 `quota-percent` 选定的口径，
+整列读起来是同一把尺子（`packed` 和 `stacked` 的 `context N%` 仍表示已用）。
+进度条按 Herdr 实际渲染的侧栏宽度自动定长（Herdr 自动伸缩后的宽度，没有记录时才回退到 `ui.sidebar_width`）；侧栏太窄时直接不画进度条，不会截断内容。
+标签列固定两个字符宽：内置周期都放得下（`30d` 显示为 `mo`，按月计费的账号因此不会
+在唯一的周期行上丢掉进度条）；服务商自定义的窗口名不会被改写，会退回 `stacked`
+的普通样式，而不是截断标签。
+`gauges` 下 `cx` 行也有自己的严重程度配色，与 `5h`、`7d` 共用同一套绿/黄/红：
+无论数字显示的是剩余还是已用，配色一律按剩余量分档——上下文剩余不足 50% 转黄，
+不足 20% 转红。`gauges` 各行采用这套配色的低饱和版本：整行进度条重复同一个高饱和色调
+读起来像告警而不像读数；`packed` 和 `stacked` 仍沿用原来的颜色。
 
 ## 安装与升级
 
@@ -57,7 +68,7 @@ herdr plugin pane open --plugin herdr-agent-quota --entrypoint settings --focus
 | 设置 | 可选项 |
 | --- | --- |
 | Percentages | 剩余或已用比例；颜色始终表示剩余额度 |
-| Layout | `packed` 合并相关字段，`stacked` 将字段分行显示 |
+| Layout | `packed` 合并相关字段，`stacked` 将字段分行显示，`gauges` 在每个额度数字旁加进度条 |
 | Row gap | Agent 之间保留零行或一行空白 |
 | Watch interval | 30 秒–1 小时，默认 60 秒 |
 | Fields | 主题、模型、缓存、TTL、上下文、短期／长期额度 |
@@ -103,6 +114,7 @@ Claude/Agy 没有可靠的服务账号 ID，因此不跨会话共享观测值。
 | Devin 缺少额度 | 检查 CLI 登录；使用自定义路径时检查 `DEVIN_CREDENTIALS_FILE` |
 | 缺少侧栏行 | 运行下面的 configure action 修复插件配置 |
 | packed 内容被截断 | 选择 `stacked` |
+| 侧栏太窄，`gauges` 不显示进度条 | 调宽侧栏，或选择 `stacked` |
 
 ```sh
 herdr plugin action invoke refresh --plugin herdr-agent-quota

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 #   ./install.sh
 #   ./install.sh --agent claude,codex
 #   ./install.sh --watch-interval-seconds 300
-#   ./install.sh --sidebar-layout stacked
+#   ./install.sh --sidebar-layout gauges
 #   ./install.sh --row-gap 0
 #   ./install.sh --quota-percent used
 #   ./install.sh --fields topic,model,context,5h,7d
@@ -18,7 +18,8 @@
 # statusLine entry and no hook file. The default is every supported agent.
 #
 # --sidebar-layout packed (default) joins cache/TTL and 5h/7d on one row.
-# stacked puts provider, model, cache, TTL, context, 5h, and 7d on their own rows.
+# stacked puts provider, model, cache, TTL, context, 5h, and 7d on their own
+# rows. gauges draws a meter beside each quota number.
 #
 # --row-gap 1 (default) leaves one blank row between agent panes; 0 packs them
 # flush. Herdr only accepts whole rows.
@@ -132,8 +133,8 @@ command -v herdr >/dev/null 2>&1 || die "Herdr is not installed or not on PATH"
 command -v cargo >/dev/null 2>&1 || die "Rust/Cargo is not installed or not on PATH"
 
 case "$SIDEBAR_LAYOUT" in
-  ""|packed|stacked) ;;
-  *) die "sidebar-layout must be packed or stacked" ;;
+  ""|packed|stacked|gauges) ;;
+  *) die "sidebar-layout must be packed, stacked, or gauges" ;;
 esac
 case "$ROW_GAP" in
   ""|0|1) ;;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,7 +87,7 @@ pub enum Command {
         watch_interval_seconds: Option<u64>,
         /// Sidebar row layout: packed joins related tokens on one row;
         /// stacked puts provider, model, cache, TTL, context, 5h, and 7d on
-        /// their own rows.
+        /// their own rows; gauges adds a meter beside each quota number.
         /// Herdr plugin actions run a fixed command line, so install.sh
         /// passes this through $HERDR_AGENT_QUOTA_SIDEBAR_LAYOUT.
         #[arg(long, value_enum)]
@@ -175,7 +175,8 @@ pub enum AgentSelection {
 ///
 /// Packed is the historical layout: cache sits beside TTL, and 5h sits beside
 /// 7d. Stacked gives each field its own row so a narrow sidebar does not
-/// truncate both values. Empty tokens still collapse in both layouts.
+/// truncate both values. Gauges is stacked with a meter drawn beside each
+/// quota number. Empty tokens still collapse in every layout.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
 pub enum SidebarLayout {
     /// Join related tokens on one row (`cache · ttl`, `5h · 7d`).
@@ -183,6 +184,8 @@ pub enum SidebarLayout {
     Packed,
     /// One field per row (provider, model, cache, TTL, context, 5h, 7d).
     Stacked,
+    /// One field per row, with a meter beside each quota percentage.
+    Gauges,
 }
 
 /// A quota field the sidebar can be told to leave out.
@@ -636,11 +639,14 @@ fn parse_low_quota_alert(value: &str) -> Result<LowQuotaAlert, String> {
 
 impl SidebarLayout {
     pub const ENV: &'static str = "HERDR_AGENT_QUOTA_SIDEBAR_LAYOUT";
+    /// The layouts the settings pane cycles through, the default first.
+    pub const CHOICES: [Self; 3] = [Self::Packed, Self::Stacked, Self::Gauges];
 
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Packed => "packed",
             Self::Stacked => "stacked",
+            Self::Gauges => "gauges",
         }
     }
 
@@ -648,6 +654,7 @@ impl SidebarLayout {
         match name.trim().to_ascii_lowercase().as_str() {
             "packed" => Some(Self::Packed),
             "stacked" => Some(Self::Stacked),
+            "gauges" => Some(Self::Gauges),
             _ => None,
         }
     }
@@ -865,11 +872,18 @@ mod tests {
     }
 
     #[test]
-    fn sidebar_layout_parses_packed_and_stacked_and_ignores_junk() {
-        assert_eq!(SidebarLayout::parse("packed"), Some(SidebarLayout::Packed));
+    fn sidebar_layout_parses_every_choice_and_ignores_junk() {
+        for layout in SidebarLayout::CHOICES {
+            assert_eq!(SidebarLayout::parse(layout.as_str()), Some(layout));
+        }
         assert_eq!(
             SidebarLayout::parse("Stacked"),
             Some(SidebarLayout::Stacked)
+        );
+        assert_eq!(SidebarLayout::parse("Gauges"), Some(SidebarLayout::Gauges));
+        assert_eq!(
+            SidebarLayout::parse(" gauges "),
+            Some(SidebarLayout::Gauges)
         );
         assert_eq!(SidebarLayout::parse("nonsense"), None);
         assert_eq!(

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Item, Table, Value};
 
-const QUOTA_ROW_MARKERS: [&str; 40] = [
+const QUOTA_ROW_MARKERS: [&str; 43] = [
     "$quota_badge",
     "$quota_state",
     "$quota_icon",
@@ -18,6 +18,9 @@ const QUOTA_ROW_MARKERS: [&str; 40] = [
     "$quota_summary",
     "$quota_session",
     "$quota_context",
+    "$quota_context_normal",
+    "$quota_context_warning",
+    "$quota_context_danger",
     "$quota_cache",
     "$quota_cache_ttl",
     "$quota_cache_state",
@@ -65,6 +68,28 @@ const CONFIG_PRESENCE_FILE: &str = "herdr-config.original.present";
 const QUOTA_SAFE_COLOR: &str = "#82d978";
 const QUOTA_WARNING_COLOR: &str = "#e4b957";
 const QUOTA_DANGER_COLOR: &str = "#f16f7e";
+// The same three bands, muted, for the meter rows only. `packed` and
+// `stacked` tint one short token, where a full-strength hue is legible; a
+// `gauges` row repeats it across a dozen bar glyphs, where it reads as alarm
+// rather than as a reading. Both sets exist because Herdr fixes `fg` per token
+// name, so a layout cannot restyle a token it shares with another layout.
+const GAUGE_QUOTA_SAFE_COLOR: &str = "#98b17d";
+const GAUGE_QUOTA_WARNING_COLOR: &str = "#dec27f";
+const GAUGE_QUOTA_DANGER_COLOR: &str = "#df919b";
+const SEVERITY_PALETTE: [&str; 3] = [QUOTA_SAFE_COLOR, QUOTA_WARNING_COLOR, QUOTA_DANGER_COLOR];
+const GAUGE_SEVERITY_PALETTE: [&str; 3] = [
+    GAUGE_QUOTA_SAFE_COLOR,
+    GAUGE_QUOTA_WARNING_COLOR,
+    GAUGE_QUOTA_DANGER_COLOR,
+];
+
+/// The normal/warning/danger hues a layout paints its quota rows with.
+fn severity_palette(layout: SidebarLayout) -> [&'static str; 3] {
+    match layout {
+        SidebarLayout::Gauges => GAUGE_SEVERITY_PALETTE,
+        SidebarLayout::Packed | SidebarLayout::Stacked => SEVERITY_PALETTE,
+    }
+}
 const PROVIDER_STYLES: [(Harness, &str, Option<&str>, Option<&str>); 8] = [
     (Harness::Claude, "claude", Some("#e88461"), Some("#f0a080")),
     (Harness::Codex, "codex", Some("#c4d7f5"), Some("#aab9d0")),
@@ -213,6 +238,114 @@ pub fn config_path() -> Result<PathBuf> {
     Ok(PathBuf::from(home).join(".config/herdr/config.toml"))
 }
 
+/// Herdr's own documented defaults for the sidebar width keys, used whenever
+/// its config does not say (or says something unusable).
+pub(crate) const DEFAULT_SIDEBAR_WIDTH: usize = 26;
+pub(crate) const DEFAULT_SIDEBAR_MIN_WIDTH: usize = 18;
+pub(crate) const DEFAULT_SIDEBAR_MAX_WIDTH: usize = 36;
+/// No terminal is this wide, so a larger value is a typo rather than a choice.
+const MAX_PLAUSIBLE_SIDEBAR_WIDTH: i64 = 1_000;
+
+/// The sidebar width Herdr is drawing, clamped into its own configured
+/// minimum and maximum.
+///
+/// Herdr auto-scales the sidebar and persists the width it settled on in its
+/// client-shell state, so that file describes the sidebar the user is looking
+/// at; `ui.sidebar_width` is a request they may never have made. Client state
+/// therefore wins, config is the second source, and Herdr's documented
+/// default the last.
+///
+/// Read live on every refresh pass rather than cached: the watcher is
+/// long-lived and each hook is its own process, so a cached width would let
+/// the two publish different meter widths for the same pane.
+pub fn sidebar_width() -> usize {
+    let config = config_path()
+        .ok()
+        .and_then(|path| fs::read_to_string(path).ok())
+        .unwrap_or_default();
+    let (configured, minimum, maximum) = sidebar_width_settings(&config);
+    client_shell_sidebar_width()
+        .or(configured)
+        .unwrap_or(DEFAULT_SIDEBAR_WIDTH)
+        .clamp(minimum, maximum)
+}
+
+/// Where Herdr's client shell persists the width it rendered. Every failure
+/// along the way — no state directory, no file, unreadable, malformed JSON,
+/// missing or non-integer key — degrades to the next width source.
+fn client_shell_sidebar_width() -> Option<usize> {
+    let state = client_shell_state_dir()?;
+    let file = newest_json_file(&state)?;
+    let contents = fs::read_to_string(file).ok()?;
+    client_shell_width_for_config(&contents)
+}
+
+fn client_shell_state_dir() -> Option<PathBuf> {
+    if let Some(state) = std::env::var_os("XDG_STATE_HOME") {
+        if !state.is_empty() {
+            return Some(PathBuf::from(state).join("herdr/client-shell"));
+        }
+    }
+    let home = std::env::var_os("HOME")?;
+    Some(PathBuf::from(home).join(".local/state/herdr/client-shell"))
+}
+
+/// The state file is named for the client session (`local-<hash>.json`), so
+/// the most recently written one is the shell whose width is current.
+fn newest_json_file(directory: &Path) -> Option<PathBuf> {
+    let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
+    for entry in fs::read_dir(directory).ok()?.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(std::time::UNIX_EPOCH);
+        let better = match &newest {
+            Some((best, best_path)) => (modified, &path) > (*best, best_path),
+            None => true,
+        };
+        if better {
+            newest = Some((modified, path));
+        }
+    }
+    newest.map(|(_, path)| path)
+}
+
+fn client_shell_width_for_config(state: &str) -> Option<usize> {
+    let value: serde_json::Value = serde_json::from_str(state).ok()?;
+    let width = value.get("sidebar_width")?.as_i64()?;
+    (1..=MAX_PLAUSIBLE_SIDEBAR_WIDTH)
+        .contains(&width)
+        .then(|| usize::try_from(width).ok())
+        .flatten()
+}
+
+/// Strictly read-only: a refresh must never rewrite or reformat the user's
+/// config, and an unreadable or malformed one must not abort the refresh.
+///
+/// The configured width if the config states a usable one, and the bounds any
+/// width — wherever it came from — is clamped into.
+fn sidebar_width_settings(config: &str) -> (Option<usize>, usize, usize) {
+    let Ok(document) = config.parse::<DocumentMut>() else {
+        return (None, DEFAULT_SIDEBAR_MIN_WIDTH, DEFAULT_SIDEBAR_MAX_WIDTH);
+    };
+    let ui = document.get("ui").and_then(Item::as_table_like);
+    let width = |key: &str| {
+        ui.and_then(|table| table.get(key))
+            .and_then(Item::as_integer)
+            .filter(|value| (1..=MAX_PLAUSIBLE_SIDEBAR_WIDTH).contains(value))
+            .and_then(|value| usize::try_from(value).ok())
+    };
+    let minimum = width("sidebar_min_width").unwrap_or(DEFAULT_SIDEBAR_MIN_WIDTH);
+    let maximum = width("sidebar_max_width")
+        .unwrap_or(DEFAULT_SIDEBAR_MAX_WIDTH)
+        .max(minimum);
+    (width("sidebar_width"), minimum, maximum)
+}
+
 fn backup_path() -> Result<Option<PathBuf>> {
     let state = std::env::var_os("HERDR_PLUGIN_STATE_DIR");
     Ok(state.map(|directory| PathBuf::from(directory).join("herdr-config.original.toml")))
@@ -261,7 +394,7 @@ fn reversible_backup(
 /// The stored field set and brand choice come first: they are the ones that
 /// produced the rows on disk. The full defaults follow, so a configuration
 /// written before those settings existed is still recognised. Layout and row
-/// gap stay brute-forced — there are only four combinations, and neither is
+/// gap stay brute-forced — there are only six combinations, and neither is
 /// recoverable from a config this function is deciding whether to trust.
 fn matches_installed_quota_rows(
     original: &str,
@@ -274,7 +407,7 @@ fn matches_installed_quota_rows(
         variants.push((FieldSet::all(), BrandColors::On));
     }
     for (fields, brand) in variants {
-        for layout in [SidebarLayout::Packed, SidebarLayout::Stacked] {
+        for layout in SidebarLayout::CHOICES {
             for gap in [SidebarRowGap::FLUSH, SidebarRowGap::SEPARATED] {
                 if add_quota_row_with(
                     original,
@@ -793,13 +926,11 @@ fn is_standalone_agent_row(row: &Array) -> bool {
 }
 
 fn append_quota_rows(rows: &mut Array, layout: SidebarLayout) {
+    // Gauges shares packed's identity line and stacked's body: the identity is
+    // not a quota field so it stays compact, while a meter needs its own row
+    // per field. Both halves are shared rather than copied so they cannot drift.
     match layout {
-        SidebarLayout::Packed => rows.push(Value::Array(styled_row(
-            "$quota_provider_model",
-            None,
-            Some(true),
-            Some(false),
-        ))),
+        SidebarLayout::Packed | SidebarLayout::Gauges => append_identity_row(rows),
         SidebarLayout::Stacked => {
             rows.push(Value::Array(styled_row(
                 "$quota_provider",
@@ -824,21 +955,32 @@ fn append_quota_rows(rows: &mut Array, layout: SidebarLayout) {
     // Context folds the weekly quota when 5h is absent; empty rows collapse.
     match layout {
         SidebarLayout::Packed => append_packed_quota_rows(rows),
-        SidebarLayout::Stacked => append_stacked_quota_rows(rows),
+        SidebarLayout::Stacked | SidebarLayout::Gauges => append_stacked_quota_rows(rows, layout),
     }
 }
 
+fn append_identity_row(rows: &mut Array) {
+    rows.push(Value::Array(styled_row(
+        "$quota_provider_model",
+        None,
+        Some(true),
+        Some(false),
+    )));
+}
+
 fn append_packed_quota_rows(rows: &mut Array) {
+    let palette = severity_palette(SidebarLayout::Packed);
     append_cache_row(rows);
 
     let mut context_row = styled_row("$quota_context", None, Some(false), Some(false));
-    append_window_style_tokens(&mut context_row, "quota_week_inline");
+    append_window_style_tokens(&mut context_row, "quota_week_inline", palette);
     rows.push(Value::Array(context_row));
 
-    append_window_row(rows);
+    append_window_row(rows, palette);
 }
 
-fn append_stacked_quota_rows(rows: &mut Array) {
+fn append_stacked_quota_rows(rows: &mut Array, layout: SidebarLayout) {
+    let palette = severity_palette(layout);
     rows.push(Value::Array(styled_row(
         "$quota_cache",
         None,
@@ -863,21 +1005,30 @@ fn append_stacked_quota_rows(rows: &mut Array) {
         Some(false),
         Some(false),
     )));
-    rows.push(Value::Array(styled_row(
-        "$quota_context",
-        None,
-        Some(false),
-        Some(false),
-    )));
+    match layout {
+        // Beside two coloured window rows, an uncoloured context row reads as
+        // an oversight rather than a decision.
+        SidebarLayout::Gauges => {
+            let mut context_row = Array::new();
+            append_context_style_tokens(&mut context_row, palette);
+            rows.push(Value::Array(context_row));
+        }
+        _ => rows.push(Value::Array(styled_row(
+            "$quota_context",
+            None,
+            Some(false),
+            Some(false),
+        ))),
+    }
     let mut five_hour = Array::new();
-    append_window_style_tokens(&mut five_hour, "quota_5h");
+    append_window_style_tokens(&mut five_hour, "quota_5h", palette);
     rows.push(Value::Array(five_hour));
     // Both week style families live on this row so the existing publish
     // choice (inline when 5h is empty, limits when 5h is present) still
     // renders exactly one 7d line.
     let mut week = Array::new();
-    append_window_style_tokens(&mut week, "quota_week_inline");
-    append_window_style_tokens(&mut week, "quota_week");
+    append_window_style_tokens(&mut week, "quota_week_inline", palette);
+    append_window_style_tokens(&mut week, "quota_week", palette);
     rows.push(Value::Array(week));
 }
 
@@ -928,7 +1079,10 @@ fn field_for_token(token: &str) -> Option<SidebarField> {
         "$quota_model" | "$quota_provider_model" => Some(SidebarField::Model),
         "$quota_cache" | "$quota_cache_state" => Some(SidebarField::Cache),
         "$quota_cache_ttl" => Some(SidebarField::Ttl),
-        "$quota_context" => Some(SidebarField::Context),
+        "$quota_context"
+        | "$quota_context_normal"
+        | "$quota_context_warning"
+        | "$quota_context_danger" => Some(SidebarField::Context),
         _ if token.starts_with("$quota_5h") => Some(SidebarField::FiveHour),
         _ if token.starts_with("$quota_week") => Some(SidebarField::Week),
         _ => None,
@@ -954,16 +1108,16 @@ fn append_cache_row(rows: &mut Array) {
     ])));
 }
 
-fn append_window_style_tokens(row: &mut Array, base: &str) {
+fn append_window_style_tokens(row: &mut Array, base: &str, palette: [&'static str; 3]) {
     // One compact token per window (`5h 0% 1h18m`). Herdr joins sibling
     // tokens with ` · `, so splitting label/percent/eta cannot stay compact.
     // Exactly the bands `Severity::for_window` can produce. There is no
     // "caution" row: that variant was unreachable, so the token could never
     // be filled and only ever consumed a slot.
     for (suffix, color) in [
-        ("normal", Some(QUOTA_SAFE_COLOR)),
-        ("warning", Some(QUOTA_WARNING_COLOR)),
-        ("danger", Some(QUOTA_DANGER_COLOR)),
+        ("normal", Some(palette[0])),
+        ("warning", Some(palette[1])),
+        ("danger", Some(palette[2])),
         ("unknown", None),
     ] {
         row.push(styled_token(
@@ -975,10 +1129,24 @@ fn append_window_style_tokens(row: &mut Array, base: &str) {
     }
 }
 
-fn append_window_row(rows: &mut Array) {
+/// The context row's own severity family. Context severity is read from the
+/// context *left*, and `Severity::for_context_remaining` always lands on one
+/// of these three, so there is no `unknown` variant to fill.
+fn append_context_style_tokens(row: &mut Array, palette: [&'static str; 3]) {
+    for (suffix, color) in ["normal", "warning", "danger"].into_iter().zip(palette) {
+        row.push(styled_token(
+            &format!("$quota_context_{suffix}"),
+            Some(color),
+            Some(false),
+            Some(false),
+        ));
+    }
+}
+
+fn append_window_row(rows: &mut Array, palette: [&'static str; 3]) {
     let mut row = Array::new();
     for base in ["quota_5h", "quota_week"] {
-        append_window_style_tokens(&mut row, base);
+        append_window_style_tokens(&mut row, base, palette);
     }
     rows.push(Value::Array(row));
 }
@@ -1074,6 +1242,19 @@ fn print_diff_hint(layout: SidebarLayout, fields: FieldSet, brand: BrandColors) 
                 "  show provider, model, the user prompt, then cache, TTL, context, 5h, and 7d on their own rows"
             );
         }
+        SidebarLayout::Gauges if crate::presentation::meter_cells(sidebar_width()).is_some() => {
+            println!(
+                "  show the user prompt, then cache, TTL, context, 5h, and 7d on their own rows, each with a meter beside the number"
+            );
+        }
+        SidebarLayout::Gauges => {
+            println!(
+                "  show the user prompt, then cache, TTL, context, 5h, and 7d on their own rows"
+            );
+            println!(
+                "  draw no meter: this sidebar is too narrow for one, so the rows render as they do under stacked"
+            );
+        }
     }
     let hidden: Vec<&str> = SidebarField::ALL
         .into_iter()
@@ -1130,7 +1311,7 @@ mod tests {
         rows.insert(1, Value::Array(custom.clone()));
         let customized = document.to_string();
 
-        for layout in [SidebarLayout::Packed, SidebarLayout::Stacked] {
+        for layout in SidebarLayout::CHOICES {
             for brand in [BrandColors::On, BrandColors::Off] {
                 let apply = |input: &str| {
                     add_quota_row_with(
@@ -1180,7 +1361,7 @@ mod tests {
             "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"machine\", \"workspace\", \"tab\"], [\"agent\"]]\n",
             "[ui.sidebar.agents]\nrows = [[\"state_icon\", { token = \"tab\", bold = true }, \"$quota_provider_model\"], [\"$quota_topic\"]] # herdr-agent-quota-row\n",
         ] {
-            for layout in [SidebarLayout::Packed, SidebarLayout::Stacked] {
+            for layout in SidebarLayout::CHOICES {
                 let updated = add_quota_row_for(original, &[Harness::Claude], layout).unwrap();
                 let document = updated.parse::<DocumentMut>().unwrap();
                 for rows in [
@@ -1418,21 +1599,331 @@ rows = [["state_icon", "agent"]]
     }
 
     #[test]
-    fn switching_between_packed_and_stacked_is_idempotent() {
-        let original = "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"tab\", \"agent\"]]\n";
-        let packed = add_quota_row(original).unwrap();
-        let stacked =
-            add_quota_row_for(&packed, &AgentSelection::SUPPORTED, SidebarLayout::Stacked).unwrap();
-        let stacked_document = stacked.parse::<DocumentMut>().unwrap();
-        assert!(row_is_only_token(
-            stacked_document["ui"]["sidebar"]["agents"]["rows"]
+    fn gauges_layout_keeps_a_packed_identity_row_above_a_stacked_body() {
+        let original = "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n";
+        let updated =
+            add_quota_row_for(original, &AgentSelection::SUPPORTED, SidebarLayout::Gauges).unwrap();
+        let document = updated.parse::<DocumentMut>().unwrap();
+        for rows in [
+            document["ui"]["sidebar"]["agents"]["rows"]
                 .as_array()
                 .unwrap(),
-            "$quota_cache"
-        ));
-        let packed_again =
-            add_quota_row_for(&stacked, &AgentSelection::SUPPORTED, SidebarLayout::Packed).unwrap();
-        assert_eq!(packed_again, packed);
+            document["ui"]["sidebar"]["agents"]["rows_by_agent"]["claude"]
+                .as_array()
+                .unwrap(),
+        ] {
+            assert!(row_is_only_token(rows, "$quota_provider_model"));
+            assert!(!rows
+                .iter()
+                .any(|row| row_contains_token(row, "$quota_provider")));
+            assert!(!rows
+                .iter()
+                .any(|row| row_contains_token(row, "$quota_model")));
+            for token in ["$quota_cache", "$quota_cache_ttl", "$quota_error"] {
+                assert!(row_is_only_token(rows, token), "{token} shares a row");
+            }
+            // The context row is the severity family here, not the plain
+            // token, so it is a row of three names rather than one.
+            assert!(rows.iter().any(|row| {
+                row_contains_token(row, "$quota_context_normal")
+                    && !row_contains_token(row, "$quota_5h_normal")
+                    && !row_contains_token(row, "$quota_week_normal")
+            }));
+            assert!(rows.iter().any(|row| {
+                row_contains_token(row, "$quota_5h_normal")
+                    && !row_contains_token(row, "$quota_week_normal")
+            }));
+            assert!(rows.iter().any(|row| {
+                row_contains_token(row, "$quota_week_normal")
+                    && row_contains_token(row, "$quota_week_inline_normal")
+                    && !row_contains_token(row, "$quota_5h_normal")
+            }));
+        }
+        assert_eq!(
+            remove_quota_row(
+                &add_quota_row_for("", &AgentSelection::SUPPORTED, SidebarLayout::Gauges).unwrap()
+            )
+            .unwrap(),
+            ""
+        );
+    }
+
+    /// Herdr fixes `fg` per token name, so a coloured context row is a
+    /// severity-suffixed family exactly like the windows have.
+    #[test]
+    fn gauges_gives_the_context_row_its_own_severity_colours() {
+        let updated =
+            add_quota_row_for("", &AgentSelection::SUPPORTED, SidebarLayout::Gauges).unwrap();
+        let document = updated.parse::<DocumentMut>().unwrap();
+        let rows = document["ui"]["sidebar"]["agents"]["rows"]
+            .as_array()
+            .unwrap();
+        let context_row = rows
+            .iter()
+            .find(|row| row_contains_token(row, "$quota_context_normal"))
+            .and_then(Value::as_array)
+            .expect("gauges context row");
+        let styled = context_row
+            .iter()
+            .map(|item| {
+                let table = item.as_inline_table().expect("styled token");
+                (
+                    table.get("token").and_then(Value::as_str).unwrap_or(""),
+                    table.get("fg").and_then(Value::as_str).unwrap_or(""),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            styled,
+            vec![
+                ("$quota_context_normal", GAUGE_QUOTA_SAFE_COLOR),
+                ("$quota_context_warning", GAUGE_QUOTA_WARNING_COLOR),
+                ("$quota_context_danger", GAUGE_QUOTA_DANGER_COLOR),
+            ]
+        );
+        assert!(!rows
+            .iter()
+            .any(|row| row_contains_token(row, "$quota_context")));
+    }
+
+    /// `packed` and `stacked` keep the plain uncoloured context token.
+    #[test]
+    fn packed_and_stacked_leave_the_context_row_uncoloured() {
+        for layout in [SidebarLayout::Packed, SidebarLayout::Stacked] {
+            let updated = add_quota_row_for("", &AgentSelection::SUPPORTED, layout).unwrap();
+            let document = updated.parse::<DocumentMut>().unwrap();
+            let rows = document["ui"]["sidebar"]["agents"]["rows"]
+                .as_array()
+                .unwrap();
+            assert!(
+                rows.iter()
+                    .any(|row| row_contains_token(row, "$quota_context")),
+                "{layout:?}"
+            );
+            for suffix in ["normal", "warning", "danger"] {
+                let token = format!("$quota_context_{suffix}");
+                assert!(
+                    !rows.iter().any(|row| row_contains_token(row, &token)),
+                    "{layout:?} wrote {token}"
+                );
+            }
+        }
+    }
+
+    /// Uninstall strips by token name, so a name missing from the strip list
+    /// leaves an orphaned row behind.
+    #[test]
+    fn uninstall_strips_every_context_token_from_a_gauges_install() {
+        let installed = add_quota_row_for(
+            "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n",
+            &AgentSelection::SUPPORTED,
+            SidebarLayout::Gauges,
+        )
+        .unwrap();
+        assert!(installed.contains("$quota_context_normal"), "{installed}");
+        let removed = remove_quota_row(&installed).unwrap();
+        assert!(!removed.contains("quota_context"), "{removed}");
+        assert!(!removed.contains("$quota_"), "{removed}");
+    }
+
+    /// `--fields` without `context` has to drop the row whichever family the
+    /// layout publishes it into.
+    #[test]
+    fn hiding_context_drops_the_row_in_every_layout() {
+        for layout in SidebarLayout::CHOICES {
+            let updated = add_quota_row_with(
+                "",
+                &AgentSelection::SUPPORTED,
+                layout,
+                SidebarRowGap::default(),
+                FieldSet::all().toggled(SidebarField::Context),
+                BrandColors::On,
+            )
+            .unwrap();
+            assert!(
+                !updated.contains("$quota_context"),
+                "{layout:?}:\n{updated}"
+            );
+        }
+    }
+
+    #[test]
+    fn switching_between_any_two_layouts_is_idempotent() {
+        let original = "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"tab\", \"agent\"]]\n";
+        let apply = |input: &str, layout| {
+            add_quota_row_for(input, &AgentSelection::SUPPORTED, layout).unwrap()
+        };
+        for first in SidebarLayout::CHOICES {
+            for second in SidebarLayout::CHOICES {
+                let switched = apply(&apply(original, first), second);
+                assert_eq!(
+                    apply(&switched, second),
+                    switched,
+                    "{first:?} then {second:?} is not a fixed point"
+                );
+                assert_eq!(
+                    switched,
+                    apply(original, second),
+                    "{first:?} then {second:?} differs from a fresh {second:?} install"
+                );
+                assert_severity_palette(&switched, second);
+            }
+        }
+    }
+
+    /// The bytes `packed` and `stacked` write are the contract for every
+    /// installation that already exists: these digests were taken before
+    /// `gauges` was added, and a change to either is a defect.
+    #[test]
+    fn packed_and_stacked_write_the_same_bytes_as_before_gauges() {
+        use sha2::{Digest, Sha256};
+
+        for (original, expected) in [
+            (
+                "",
+                [
+                    "9209065bd93f9d5f6aa7786fa9cd5730d3e5ce61caeee510a99c0fee84700c0f",
+                    "6fa28ff4e54301637d40188c849aa161c9d5d55cbce21395f4ca94bc03d654fc",
+                ],
+            ),
+            (
+                "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"machine\", \"workspace\", \"tab\"], [\"agent\"]]\n",
+                [
+                    "142675cea142ff8ec5b170668586f0cad5456c73fd0d6206a8b762ca60e25956",
+                    "96b87721865ede810f1b730820f20c39429f991aa95917090e5fe1f002d2d996",
+                ],
+            ),
+            (
+                "[ui.sidebar.agents]\nrows = [[\"state_icon\", { token = \"tab\", bold = true }, \"$quota_provider_model\"], [\"$quota_topic\"]] # herdr-agent-quota-row\n",
+                [
+                    "142675cea142ff8ec5b170668586f0cad5456c73fd0d6206a8b762ca60e25956",
+                    "96b87721865ede810f1b730820f20c39429f991aa95917090e5fe1f002d2d996",
+                ],
+            ),
+        ] {
+            for (layout, digest) in [SidebarLayout::Packed, SidebarLayout::Stacked]
+                .into_iter()
+                .zip(expected)
+            {
+                let updated = add_quota_row_with(
+                    original,
+                    &AgentSelection::SUPPORTED,
+                    layout,
+                    SidebarRowGap::default(),
+                    FieldSet::all(),
+                    BrandColors::On,
+                )
+                .unwrap();
+                assert_eq!(
+                    format!("{:x}", Sha256::digest(updated.as_bytes())),
+                    digest,
+                    "{layout:?} output changed:\n{updated}"
+                );
+            }
+        }
+    }
+
+    /// The severity hexes a layout is expected to publish on its meter rows.
+    /// `gauges` gets the muted set; the other two keep the saturated one.
+    fn assert_severity_palette(sidebar: &str, layout: SidebarLayout) {
+        let document = sidebar.parse::<DocumentMut>().unwrap();
+        let expected = severity_palette(layout);
+        for base in ["quota_5h", "quota_week", "quota_week_inline"] {
+            for (suffix, hex) in ["normal", "warning", "danger"].into_iter().zip(expected) {
+                let token = format!("${base}_{suffix}");
+                assert_eq!(
+                    token_fg(&document, &token).as_deref(),
+                    Some(hex),
+                    "{layout:?} wrote the wrong fg on {token}"
+                );
+            }
+        }
+        for (suffix, hex) in ["normal", "warning", "danger"].into_iter().zip(expected) {
+            let token = format!("$quota_context_{suffix}");
+            let fg = token_fg(&document, &token);
+            match layout {
+                SidebarLayout::Gauges => assert_eq!(
+                    fg.as_deref(),
+                    Some(hex),
+                    "{layout:?} wrote the wrong fg on {token}"
+                ),
+                _ => assert_eq!(fg, None, "{layout:?} wrote {token}"),
+            }
+        }
+    }
+
+    /// The `fg` a named token carries in `rows`, or `None` when the layout
+    /// never publishes it.
+    fn token_fg(document: &DocumentMut, token: &str) -> Option<String> {
+        document["ui"]["sidebar"]["agents"]["rows"]
+            .as_array()?
+            .iter()
+            .filter_map(Value::as_array)
+            .flat_map(Array::iter)
+            .find(|item| configured_token_name(item) == Some(token))
+            .and_then(Value::as_inline_table)
+            .and_then(|table| table.get("fg"))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    }
+
+    /// A whole row of bar glyphs in a full-strength hue reads as alarm, so
+    /// `gauges` publishes its own muted set. The other two layouts colour one
+    /// short token and must keep the saturated hexes byte for byte.
+    #[test]
+    fn only_gauges_publishes_the_muted_severity_palette() {
+        for layout in SidebarLayout::CHOICES {
+            let updated = add_quota_row_for("", &AgentSelection::SUPPORTED, layout).unwrap();
+            assert_severity_palette(&updated, layout);
+        }
+        let gauged =
+            add_quota_row_for("", &AgentSelection::SUPPORTED, SidebarLayout::Gauges).unwrap();
+        for hex in [
+            GAUGE_QUOTA_SAFE_COLOR,
+            GAUGE_QUOTA_WARNING_COLOR,
+            GAUGE_QUOTA_DANGER_COLOR,
+        ] {
+            assert!(gauged.contains(hex), "gauges lacks {hex}:\n{gauged}");
+        }
+        for hex in [QUOTA_SAFE_COLOR, QUOTA_DANGER_COLOR] {
+            assert!(
+                !gauged.contains(hex),
+                "gauges still writes {hex}:\n{gauged}"
+            );
+        }
+        for layout in [SidebarLayout::Packed, SidebarLayout::Stacked] {
+            let plain = add_quota_row_for("", &AgentSelection::SUPPORTED, layout).unwrap();
+            for hex in [
+                GAUGE_QUOTA_SAFE_COLOR,
+                GAUGE_QUOTA_WARNING_COLOR,
+                GAUGE_QUOTA_DANGER_COLOR,
+            ] {
+                assert!(!plain.contains(hex), "{layout:?} wrote {hex}:\n{plain}");
+            }
+        }
+    }
+
+    /// `rows_by_agent` is a themed copy of `rows`, so a palette that only
+    /// reached the shared rows would leave every per-provider row saturated.
+    #[test]
+    fn the_gauges_palette_reaches_the_per_provider_rows() {
+        let updated =
+            add_quota_row_for("", &AgentSelection::SUPPORTED, SidebarLayout::Gauges).unwrap();
+        let document = updated.parse::<DocumentMut>().unwrap();
+        let rows = document["ui"]["sidebar"]["agents"]["rows_by_agent"]["claude"]
+            .as_array()
+            .unwrap();
+        for token in ["$quota_5h_normal", "$quota_context_normal"] {
+            let fg = rows
+                .iter()
+                .filter_map(Value::as_array)
+                .flat_map(Array::iter)
+                .find(|item| configured_token_name(item) == Some(token))
+                .and_then(Value::as_inline_table)
+                .and_then(|table| table.get("fg"))
+                .and_then(Value::as_str);
+            assert_eq!(fg, Some(GAUGE_QUOTA_SAFE_COLOR), "{token}");
+        }
     }
 
     fn row_contains_token(row: &Value, token: &str) -> bool {
@@ -2164,6 +2655,38 @@ mod field_tests {
         assert_eq!(once, twice);
     }
 
+    /// The `gauges` body is stacked's, so a hidden field has to take its whole
+    /// row with it there too — and the identity row still has to survive
+    /// hiding the model.
+    #[test]
+    fn a_hidden_field_leaves_no_row_behind_in_gauges() {
+        let gauges = |fields| {
+            add_quota_row_with(
+                "",
+                &AgentSelection::SUPPORTED,
+                SidebarLayout::Gauges,
+                SidebarRowGap::default(),
+                fields,
+                BrandColors::On,
+            )
+            .unwrap()
+        };
+        let windowless = gauges(
+            FieldSet::all()
+                .toggled(SidebarField::FiveHour)
+                .toggled(SidebarField::Week),
+        );
+        assert!(!windowless.contains("$quota_5h"), "{windowless}");
+        assert!(!windowless.contains("$quota_week"), "{windowless}");
+        assert!(windowless.contains("$quota_context"), "{windowless}");
+        assert!(windowless.contains("$quota_provider_model"), "{windowless}");
+
+        let modelless = gauges(FieldSet::all().toggled(SidebarField::Model));
+        assert!(modelless.contains("$quota_provider\""), "{modelless}");
+        assert!(!modelless.contains("$quota_provider_model"), "{modelless}");
+        assert!(!modelless.contains("$quota_model"), "{modelless}");
+    }
+
     /// Uninstall has to recognise rows written with a non-default selection,
     /// or it falls back to token-stripping and leaves the file behind.
     #[test]
@@ -2173,6 +2696,185 @@ mod field_tests {
         assert!(
             matches_installed_quota_rows("", &installed, fields, BrandColors::Off).unwrap(),
             "{installed}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod sidebar_width_tests {
+    use super::*;
+
+    #[test]
+    fn a_config_without_a_sidebar_width_reads_as_herdrs_documented_default() {
+        assert_eq!(width_for_config(""), DEFAULT_SIDEBAR_WIDTH);
+        assert_eq!(width_for_config("[ui]\ntheme = \"dark\"\n"), 26);
+    }
+
+    #[test]
+    fn a_configured_sidebar_width_is_read_as_written() {
+        assert_eq!(width_for_config("[ui]\nsidebar_width = 30\n"), 30);
+        assert_eq!(width_for_config("ui = { sidebar_width = 22 }\n"), 22);
+    }
+
+    /// A user's typo must cost them the default bar, never the refresh.
+    #[test]
+    fn an_unusable_sidebar_width_degrades_to_the_documented_default() {
+        for config in [
+            "[ui]\nsidebar_width = \"wide\"\n",
+            "[ui]\nsidebar_width = 26.5\n",
+            "[ui]\nsidebar_width = -8\n",
+            "[ui]\nsidebar_width = 0\n",
+            "[ui]\nsidebar_width = 99999999\n",
+            "[ui]\nsidebar_width = true\n",
+            "[ui\nsidebar_width = 30\n",
+            "sidebar_width = 30\n",
+        ] {
+            assert_eq!(width_for_config(config), DEFAULT_SIDEBAR_WIDTH, "{config}");
+        }
+    }
+
+    #[test]
+    fn a_sidebar_width_outside_the_configured_bounds_is_clamped_into_them() {
+        assert_eq!(width_for_config("[ui]\nsidebar_width = 48\n"), 36);
+        assert_eq!(width_for_config("[ui]\nsidebar_width = 12\n"), 18);
+        assert_eq!(
+            width_for_config("[ui]\nsidebar_width = 48\nsidebar_max_width = 40\n"),
+            40
+        );
+        assert_eq!(
+            width_for_config("[ui]\nsidebar_width = 12\nsidebar_min_width = 10\n"),
+            12
+        );
+    }
+
+    /// The width sources in precedence order: what Herdr rendered, then what
+    /// the config asked for, then the documented default.
+    #[test]
+    fn client_shell_state_outranks_the_config_which_outranks_the_default() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let state = directory.path().join("state");
+        let shell = state.join("herdr/client-shell");
+        fs::create_dir_all(&shell).unwrap();
+        fs::write(&config, "[ui]\nsidebar_width = 30\n").unwrap();
+
+        with_width_sources(&config, &state, || assert_eq!(sidebar_width(), 30));
+
+        fs::write(shell.join("local-abc.json"), "{\"sidebar_width\": 22}").unwrap();
+        with_width_sources(&config, &state, || assert_eq!(sidebar_width(), 22));
+
+        fs::remove_file(&config).unwrap();
+        with_width_sources(&config, &state, || assert_eq!(sidebar_width(), 22));
+
+        fs::remove_file(shell.join("local-abc.json")).unwrap();
+        with_width_sources(&config, &state, || {
+            assert_eq!(sidebar_width(), DEFAULT_SIDEBAR_WIDTH)
+        });
+    }
+
+    /// Whatever source the width came from, it lands inside the bounds the
+    /// config sets.
+    #[test]
+    fn a_client_shell_width_outside_the_configured_bounds_is_clamped_into_them() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let state = directory.path().join("state");
+        let shell = state.join("herdr/client-shell");
+        fs::create_dir_all(&shell).unwrap();
+        fs::write(&config, "[ui]\nsidebar_max_width = 32\n").unwrap();
+        fs::write(shell.join("local-abc.json"), "{\"sidebar_width\": 48}").unwrap();
+        with_width_sources(&config, &state, || assert_eq!(sidebar_width(), 32));
+    }
+
+    /// A state file the plugin cannot make sense of costs the meter nothing:
+    /// the next source answers instead.
+    #[test]
+    fn an_unusable_client_shell_state_falls_through_to_the_config() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let state = directory.path().join("state");
+        let shell = state.join("herdr/client-shell");
+        fs::create_dir_all(&shell).unwrap();
+        fs::write(&config, "[ui]\nsidebar_width = 30\n").unwrap();
+        for contents in [
+            "",
+            "not json at all",
+            "{\"agent_panel_sort\": \"priority\"}",
+            "{\"sidebar_width\": \"35\"}",
+            "{\"sidebar_width\": 35.5}",
+            "{\"sidebar_width\": 0}",
+            "{\"sidebar_width\": -8}",
+            "{\"sidebar_width\": 99999999}",
+            "[35]",
+        ] {
+            fs::write(shell.join("local-abc.json"), contents).unwrap();
+            with_width_sources(&config, &state, || {
+                assert_eq!(sidebar_width(), 30, "{contents}")
+            });
+        }
+    }
+
+    /// Herdr names the file after the client session, so the plugin reads the
+    /// newest one rather than a name it cannot know.
+    #[test]
+    fn the_newest_state_file_is_the_one_read() {
+        let directory = tempfile::tempdir().unwrap();
+        let shell = directory.path().join("herdr/client-shell");
+        fs::create_dir_all(&shell).unwrap();
+        fs::write(shell.join("local-old.json"), "{\"sidebar_width\": 22}").unwrap();
+        fs::write(shell.join("notes.txt"), "{\"sidebar_width\": 30}").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        fs::write(shell.join("local-new.json"), "{\"sidebar_width\": 35}").unwrap();
+        let absent = directory.path().join("absent.toml");
+        with_width_sources(&absent, directory.path(), || {
+            assert_eq!(sidebar_width(), 35)
+        });
+    }
+
+    #[test]
+    fn an_absent_config_and_state_directory_read_as_the_documented_default() {
+        let directory = tempfile::tempdir().unwrap();
+        with_width_sources(
+            &directory.path().join("absent.toml"),
+            &directory.path().join("absent-state"),
+            || assert_eq!(sidebar_width(), DEFAULT_SIDEBAR_WIDTH),
+        );
+    }
+
+    #[test]
+    fn reading_the_sidebar_width_leaves_the_config_file_byte_identical() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("config.toml");
+        let original = "# my herdr config\n[ui]\nsidebar_width   =    30\ntheme='dark'\n";
+        fs::write(&path, original).unwrap();
+        with_width_sources(&path, &directory.path().join("absent-state"), || {
+            assert_eq!(sidebar_width(), 30)
+        });
+        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+    }
+
+    /// The width a config alone resolves to, with no client-shell state for
+    /// it to lose to.
+    fn width_for_config(config: &str) -> usize {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("config.toml");
+        fs::write(&path, config).unwrap();
+        let mut width = 0;
+        with_width_sources(&path, &directory.path().join("absent-state"), || {
+            width = sidebar_width()
+        });
+        width
+    }
+
+    /// Both width sources are process-global environment lookups, so they
+    /// move under the one env lock.
+    fn with_width_sources(config: &Path, state: &Path, body: impl FnOnce()) {
+        crate::prefs::testing::with_env(
+            &[
+                ("HERDR_CONFIG_FILE", Some(config.as_os_str())),
+                ("XDG_STATE_HOME", Some(state.as_os_str())),
+            ],
+            body,
         );
     }
 }

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -1,5 +1,5 @@
 use crate::model::{ContextUsage, Harness, Provider};
-use crate::presentation::MetadataTokens;
+use crate::presentation::{MetadataTokens, RowStyle, SidebarShape};
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -14,11 +14,14 @@ const MAX_METADATA_TOKENS: usize = 16;
 /// not free: it is compared on every refresh and it competes for Herdr's
 /// 16-token report budget. Add a name here only together with the field that
 /// fills it.
-const METADATA_TOKEN_NAMES: [&str; 22] = [
+const METADATA_TOKEN_NAMES: [&str; 25] = [
     "quota_provider",
     "quota_model",
     "quota_provider_model",
     "quota_context",
+    "quota_context_normal",
+    "quota_context_warning",
+    "quota_context_danger",
     "quota_cache",
     "quota_cache_ttl",
     "quota_cache_state",
@@ -74,15 +77,32 @@ const LEGACY_METADATA_TOKEN_NAMES: [&str; 4] = [
     "quota_week_inline_label",
     "quota_week_inline_eta",
 ];
+/// The names the context row can be published into, in the order a report
+/// clears them. Herdr fixes a token's colour by name, so the only way to
+/// colour the context row is to publish it into a name whose row template
+/// already carries that colour — which is why `gauges` needs the three
+/// severity variants and `packed`/`stacked` keep the plain one.
+///
+/// Exactly one is ever filled. Publishing a second would draw two context
+/// rows in the same pane.
+const CONTEXT_TOKEN_NAMES: [&str; 4] = [
+    "quota_context",
+    "quota_context_normal",
+    "quota_context_warning",
+    "quota_context_danger",
+];
 /// Values that must reach the pane in the *same* report that changed them,
 /// even when the budget is tight: the identity, the live diagnostics, and the
 /// inline week variants, whose styling flips as soon as a 5h window appears.
-const ROWS_THAT_MUST_NOT_LAG: [&str; 12] = [
+const ROWS_THAT_MUST_NOT_LAG: [&str; 15] = [
     "quota_provider",
     "quota_model",
     "quota_provider_model",
     "quota_topic",
     "quota_context",
+    "quota_context_normal",
+    "quota_context_warning",
+    "quota_context_danger",
     "quota_cache",
     "quota_cache_ttl",
     "quota_cache_state",
@@ -460,6 +480,7 @@ pub fn publish_pane_tokens(
     panes: &[AgentPane],
     tokens: &[PaneTokens],
     sequence: u64,
+    row: RowStyle,
 ) -> Result<()> {
     let executable = std::env::var_os("HERDR_BIN_PATH").unwrap_or_else(|| "herdr".into());
     let mut reported = 0usize;
@@ -470,7 +491,7 @@ pub fn publish_pane_tokens(
         };
         let topic = display_topic(pane);
         let mut desired = match &pane_tokens.quota {
-            PaneQuotaUpdate::Replace(values) => desired_tokens(values, &topic),
+            PaneQuotaUpdate::Replace(values) => desired_tokens(values, &topic, row.shape),
             PaneQuotaUpdate::Clear => desired_cleared_quota(pane),
             PaneQuotaUpdate::Preserve => pane.tokens.clone(),
         };
@@ -478,7 +499,7 @@ pub fn publish_pane_tokens(
             apply_identity(&mut desired, identity);
         }
         if let Some(context) = &pane_tokens.context {
-            apply_context(&mut desired, context, sequence / 1_000);
+            apply_context(&mut desired, context, sequence / 1_000, row);
         }
         if metadata_matches(&pane.tokens, &desired) {
             continue;
@@ -545,7 +566,11 @@ fn pane_is_scrolled(executable: &std::ffi::OsStr, pane_id: &str) -> bool {
         .is_some_and(|offset| offset > 0)
 }
 
-fn desired_tokens(values: &MetadataTokens, topic: &str) -> BTreeMap<String, String> {
+fn desired_tokens(
+    values: &MetadataTokens,
+    topic: &str,
+    shape: SidebarShape,
+) -> BTreeMap<String, String> {
     let mut tokens = BTreeMap::from([
         ("quota_provider".to_string(), values.quota_provider.clone()),
         (
@@ -554,7 +579,12 @@ fn desired_tokens(values: &MetadataTokens, topic: &str) -> BTreeMap<String, Stri
         ),
     ]);
     insert_optional_token(&mut tokens, "quota_model", &values.quota_model);
-    insert_optional_token(&mut tokens, "quota_context", &values.quota_context);
+    insert_context_token(
+        &mut tokens,
+        &values.quota_context,
+        values.quota_context_severity,
+        shape,
+    );
     insert_optional_token(&mut tokens, "quota_cache", &values.quota_cache);
     insert_optional_token(&mut tokens, "quota_cache_ttl", &values.quota_cache_ttl);
     insert_optional_token(&mut tokens, "quota_cache_state", &values.quota_cache_state);
@@ -624,11 +654,17 @@ fn apply_identity(tokens: &mut BTreeMap<String, String>, identity: &PaneIdentity
     }
 }
 
-fn apply_context(tokens: &mut BTreeMap<String, String>, context: &ContextUsage, now_unix: u64) {
-    insert_optional_token(
+fn apply_context(
+    tokens: &mut BTreeMap<String, String>,
+    context: &ContextUsage,
+    now_unix: u64,
+    row: RowStyle,
+) {
+    insert_context_token(
         tokens,
-        "quota_context",
-        &crate::presentation::sidebar_context(Some(context)),
+        &crate::presentation::sidebar_context(Some(context), row.percent, row.shape),
+        Some(crate::presentation::context_severity(context, row.percent)),
+        row.shape,
     );
     let cache = crate::presentation::sidebar_cache(Some(context));
     if cache.is_empty() {
@@ -718,6 +754,46 @@ fn week_style_base(quota_5h: &str) -> &'static str {
         "quota_week_inline"
     } else {
         "quota_week"
+    }
+}
+
+/// Publish the context row into the one name its layout and severity choose,
+/// and clear the other three.
+///
+/// The clear is the point: a severity change or a layout switch moves the
+/// value to a different name, and a pane that kept the old one would show two
+/// context rows at once.
+fn insert_context_token(
+    tokens: &mut BTreeMap<String, String>,
+    value: &str,
+    severity: Option<crate::model::Severity>,
+    shape: SidebarShape,
+) {
+    for name in CONTEXT_TOKEN_NAMES {
+        tokens.remove(name);
+    }
+    if value.trim().is_empty() {
+        return;
+    }
+    tokens.insert(
+        context_token_name(shape, severity).to_string(),
+        value.to_string(),
+    );
+}
+
+fn context_token_name(
+    shape: SidebarShape,
+    severity: Option<crate::model::Severity>,
+) -> &'static str {
+    if shape.layout != crate::cli::SidebarLayout::Gauges {
+        return "quota_context";
+    }
+    // `Severity::for_context_remaining` never returns `Unknown`, and a caller
+    // with no severity has no coloured band to claim, so both read as normal.
+    match severity {
+        Some(crate::model::Severity::Warning) => "quota_context_warning",
+        Some(crate::model::Severity::Danger) => "quota_context_danger",
+        _ => "quota_context_normal",
     }
 }
 
@@ -830,6 +906,7 @@ fn is_status_line(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::PercentStyle;
     use crate::model::{
         CacheUsage, ContextUsage, ProviderSnapshot, ResetAt, UsageWindow, WindowKind,
     };
@@ -842,7 +919,9 @@ mod tests {
         let token = |headroom: Option<u8>| {
             let mut values = MetadataTokens::unavailable(Provider::Claude, "test");
             values.quota_headroom = headroom;
-            desired_tokens(&values, "").get(HEADROOM_TOKEN).cloned()
+            desired_tokens(&values, "", SidebarShape::default())
+                .get(HEADROOM_TOKEN)
+                .cloned()
         };
         assert_eq!(token(Some(7)).as_deref(), Some("007"));
         assert_eq!(token(Some(42)).as_deref(), Some("042"));
@@ -964,6 +1043,7 @@ mod tests {
             let desired = desired_tokens(
                 &MetadataTokens::from_snapshot(&snapshot, 0),
                 "a topic that is present",
+                SidebarShape::default(),
             );
             assert!(
                 desired.len() <= HERDR_TOKEN_REPORT_CAP,
@@ -1137,7 +1217,11 @@ mod tests {
                         ),
                 )),
         ));
-        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        let desired = desired_tokens(
+            &MetadataTokens::from_snapshot(&snapshot, 0),
+            "prompt",
+            SidebarShape::default(),
+        );
         let pane = AgentPane {
             pane_id: "w1:p1".to_string(),
             harness: Harness::Grok,
@@ -1179,7 +1263,11 @@ mod tests {
                         ),
                 )),
         ));
-        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        let desired = desired_tokens(
+            &MetadataTokens::from_snapshot(&snapshot, 0),
+            "prompt",
+            SidebarShape::default(),
+        );
         let pane = AgentPane {
             pane_id: "w1:p1".to_string(),
             harness: Harness::Claude,
@@ -1194,6 +1282,163 @@ mod tests {
         assert!(names.contains(&"quota_cache_ttl"));
     }
 
+    /// The context row is coloured by the context *left* under `gauges`, on
+    /// the windows' own bands, whichever side of the ledger it prints.
+    #[test]
+    fn gauges_publishes_context_into_the_severity_name_its_headroom_earns() {
+        let gauges = SidebarShape::from(crate::cli::SidebarLayout::Gauges);
+        for (used, expected) in [
+            (31.0, "quota_context_normal"),
+            (49.0, "quota_context_normal"),
+            (50.0, "quota_context_normal"),
+            (51.0, "quota_context_warning"),
+            (53.0, "quota_context_warning"),
+            (79.0, "quota_context_warning"),
+            (80.0, "quota_context_warning"),
+            (81.0, "quota_context_danger"),
+            (85.0, "quota_context_danger"),
+        ] {
+            for percent in [PercentStyle::Remaining, PercentStyle::Used] {
+                let mut tokens = BTreeMap::new();
+                apply_context(
+                    &mut tokens,
+                    &ContextUsage::new(used).unwrap(),
+                    0,
+                    RowStyle::new(percent, gauges),
+                );
+                let published = CONTEXT_TOKEN_NAMES
+                    .into_iter()
+                    .filter(|name| tokens.contains_key(*name))
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    published,
+                    vec![expected],
+                    "context {used} used, {percent:?}"
+                );
+            }
+        }
+    }
+
+    /// Only one context name is ever filled, so a severity change or a layout
+    /// switch can never leave a pane showing two context rows.
+    #[test]
+    fn a_context_severity_change_clears_the_name_it_moved_away_from() {
+        let gauges = SidebarShape::from(crate::cli::SidebarLayout::Gauges);
+        let mut tokens = BTreeMap::new();
+        let row = RowStyle::new(PercentStyle::Used, gauges);
+        apply_context(&mut tokens, &ContextUsage::new(31.0).unwrap(), 0, row);
+        apply_context(&mut tokens, &ContextUsage::new(85.0).unwrap(), 0, row);
+        assert!(!tokens.contains_key("quota_context_normal"));
+        assert_eq!(
+            tokens.get("quota_context_danger").map(String::as_str),
+            Some("context 85%")
+        );
+        apply_context(
+            &mut tokens,
+            &ContextUsage::new(85.0).unwrap(),
+            0,
+            RowStyle::default(),
+        );
+        assert_eq!(
+            tokens.get("quota_context").map(String::as_str),
+            Some("context 85%")
+        );
+        for name in ["quota_context_normal", "quota_context_danger"] {
+            assert!(!tokens.contains_key(name), "{name}");
+        }
+    }
+
+    /// `packed` and `stacked` keep the plain uncoloured name they have always
+    /// published, and the used percent they have always printed, whatever the
+    /// context value and whichever percent style the windows are drawn with.
+    #[test]
+    fn packed_and_stacked_keep_publishing_the_plain_context_token() {
+        for layout in [
+            crate::cli::SidebarLayout::Packed,
+            crate::cli::SidebarLayout::Stacked,
+        ] {
+            for percent in [PercentStyle::Remaining, PercentStyle::Used] {
+                let mut tokens = BTreeMap::new();
+                apply_context(
+                    &mut tokens,
+                    &ContextUsage::new(85.0).unwrap(),
+                    0,
+                    RowStyle::new(percent, SidebarShape::from(layout)),
+                );
+                assert_eq!(
+                    tokens.get("quota_context").map(String::as_str),
+                    Some("context 85%"),
+                    "{layout:?} {percent:?}"
+                );
+                for name in [
+                    "quota_context_normal",
+                    "quota_context_warning",
+                    "quota_context_danger",
+                ] {
+                    assert!(!tokens.contains_key(name), "{layout:?} wrote {name}");
+                }
+            }
+        }
+    }
+
+    /// The three context names are three more slots against Herdr's sixteen,
+    /// even though at most one of them is ever filled.
+    #[test]
+    fn a_full_gauges_pane_stays_inside_herdr_metadata_cap() {
+        let gauges = SidebarShape::from(crate::cli::SidebarLayout::Gauges);
+        let snapshot = crate::model::ProviderSnapshot::new(
+            Provider::Claude,
+            vec![
+                crate::model::UsageWindow::new(
+                    crate::model::WindowKind::FiveHour,
+                    20.0,
+                    Some(crate::model::ResetAt::from_unix_seconds(18_000)),
+                )
+                .unwrap(),
+                crate::model::UsageWindow::new(
+                    crate::model::WindowKind::Weekly,
+                    30.0,
+                    Some(crate::model::ResetAt::from_unix_seconds(183_600)),
+                )
+                .unwrap(),
+            ],
+            0,
+        )
+        .with_context(Some(
+            crate::model::ContextUsage::new(85.0)
+                .unwrap()
+                .with_cache(Some(
+                    crate::model::CacheUsage::from_token_counts(100, 800, 100)
+                        .unwrap()
+                        .with_ttl_estimate(3_600, 0)
+                        .with_session_totals(
+                            crate::model::CacheTotals::from_token_counts(100, 800, 100),
+                            "session-1",
+                            1,
+                        ),
+                )),
+        ));
+        let values = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            crate::cli::PercentStyle::default(),
+            gauges,
+        );
+        let desired = desired_tokens(&values, "prompt", gauges);
+        assert!(desired.contains_key("quota_context_danger"));
+        let pane = AgentPane {
+            pane_id: "w1:p1".to_string(),
+            harness: Harness::Claude,
+            session: None,
+            session_summary: String::new(),
+            topic: String::new(),
+            tokens: BTreeMap::new(),
+        };
+        let names = metadata_report_names(&pane, &desired);
+        assert!(names.len() <= MAX_METADATA_TOKENS, "{names:?}");
+    }
+
     #[test]
     fn exact_context_without_cache_clears_stale_cache_diagnostics() {
         let mut tokens = BTreeMap::from([
@@ -1201,7 +1446,12 @@ mod tests {
             ("quota_cache".to_string(), "cache 95.0%".to_string()),
             ("quota_cache_ttl".to_string(), "ttl≈1h".to_string()),
         ]);
-        apply_context(&mut tokens, &ContextUsage::new(12.0).unwrap(), 0);
+        apply_context(
+            &mut tokens,
+            &ContextUsage::new(12.0).unwrap(),
+            0,
+            RowStyle::default(),
+        );
         assert_eq!(
             tokens.get("quota_context").map(String::as_str),
             Some("context 12%")
@@ -1236,7 +1486,11 @@ mod tests {
                         ),
                 )),
         ));
-        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        let desired = desired_tokens(
+            &MetadataTokens::from_snapshot(&snapshot, 0),
+            "prompt",
+            SidebarShape::default(),
+        );
         let mut tokens = desired.clone();
         tokens.insert("quota_icon".to_string(), "✦Cl".to_string());
         tokens.insert("quota_status".to_string(), "OK".to_string());
@@ -1324,7 +1578,11 @@ mod tests {
             .unwrap()],
             0,
         );
-        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        let desired = desired_tokens(
+            &MetadataTokens::from_snapshot(&snapshot, 0),
+            "prompt",
+            SidebarShape::default(),
+        );
         assert_eq!(
             desired.get("quota_5h_unknown").map(String::as_str),
             Some("5h N/A")
@@ -1348,7 +1606,11 @@ mod tests {
             .unwrap()],
             0,
         );
-        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        let desired = desired_tokens(
+            &MetadataTokens::from_snapshot(&snapshot, 0),
+            "prompt",
+            SidebarShape::default(),
+        );
         assert!(!desired.contains_key("quota_5h_normal"));
         assert!(!desired.contains_key("quota_5h_label"));
         assert!(desired.contains_key("quota_week_inline_normal"));
@@ -1376,7 +1638,11 @@ mod tests {
             ],
             0,
         );
-        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        let desired = desired_tokens(
+            &MetadataTokens::from_snapshot(&snapshot, 0),
+            "prompt",
+            SidebarShape::default(),
+        );
         assert_eq!(
             desired.get("quota_5h_normal").map(String::as_str),
             Some("5h 95% 4h07m")
@@ -1406,7 +1672,11 @@ mod tests {
             .unwrap()],
             0,
         );
-        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        let desired = desired_tokens(
+            &MetadataTokens::from_snapshot(&snapshot, 0),
+            "prompt",
+            SidebarShape::default(),
+        );
         let mut tokens = desired.clone();
         tokens.remove("quota_week_inline_normal");
         tokens.insert("quota_week_normal".to_string(), "7d 75% 5d0h".to_string());
@@ -1446,7 +1716,11 @@ mod tests {
             ],
             0,
         );
-        let desired = desired_tokens(&MetadataTokens::from_snapshot(&snapshot, 0), "prompt");
+        let desired = desired_tokens(
+            &MetadataTokens::from_snapshot(&snapshot, 0),
+            "prompt",
+            SidebarShape::default(),
+        );
         let mut tokens = desired.clone();
         tokens.insert("quota_week_inline_normal".to_string(), "7d 99%".to_string());
         let pane = AgentPane {

--- a/src/model.rs
+++ b/src/model.rs
@@ -267,6 +267,17 @@ impl WindowKind {
         }
     }
 
+    /// The label the `gauges` layout uses, where the column is two characters
+    /// wide. Only `Monthly` differs: `30d` would not fit, and a monthly plan
+    /// carries its only recurring quota on that row, so it takes a two-letter
+    /// alias rather than losing its meter.
+    pub fn gauge_label(self) -> &'static str {
+        match self {
+            Self::Monthly => "mo",
+            other => other.label(),
+        }
+    }
+
     pub fn duration_seconds(self) -> u64 {
         match self {
             Self::FiveHour => 5 * 60 * 60,
@@ -381,6 +392,15 @@ impl UsageWindow {
         self.source_label
             .as_deref()
             .unwrap_or_else(|| self.kind.label())
+    }
+
+    /// The label for the `gauges` layout's two-character column. A
+    /// provider-supplied label is never rewritten - only the built-in kind
+    /// labels have a short form (see [`WindowKind::gauge_label`]).
+    pub fn gauge_display_label(&self) -> &str {
+        self.source_label
+            .as_deref()
+            .unwrap_or_else(|| self.kind.gauge_label())
     }
 
     /// Whether this window can still be shown as a live reading.
@@ -944,7 +964,23 @@ impl Severity {
     pub fn for_window(window: &UsageWindow, _now_unix: u64) -> Self {
         // Remaining quota only. Three sidebar bands so packed 5h/7d rows
         // do not mix two nearby greens. Classify the rounded integer shown.
-        let displayed_remaining = window.remaining_percent.round();
+        Self::for_headroom(window.remaining_percent)
+    }
+
+    /// Headroom left in the context window, on the same bands as
+    /// [`Self::for_window`] — a sidebar row means the same thing whichever
+    /// row it is.
+    ///
+    /// Never `Unknown`: a context row exists only when a percent was read.
+    pub fn for_context_remaining(remaining_percent: f64) -> Self {
+        Self::for_headroom(remaining_percent)
+    }
+
+    /// The one band table every sidebar row is coloured by. Classify the
+    /// rounded integer, so a row's colour and its printed number can never
+    /// disagree at a threshold.
+    fn for_headroom(remaining_percent: f64) -> Self {
+        let displayed_remaining = remaining_percent.round();
         if displayed_remaining >= 50.0 {
             Self::Normal
         } else if displayed_remaining >= 20.0 {
@@ -957,6 +993,16 @@ impl Severity {
 
 pub fn format_percent(value: f64) -> String {
     format!("{value:.0}")
+}
+
+/// The whole number the sidebar prints, for callers that must agree with it —
+/// the gauges meter derives its cell count from this.
+///
+/// Read back out of [`format_percent`] rather than rounded again: `{:.0}`
+/// rounds half to even while `f64::round` rounds half away from zero, so an
+/// exactly-reachable 18.5% would otherwise draw a two-cell bar beside `18%`.
+pub fn printed_percent(value: f64) -> u32 {
+    format_percent(value).parse().unwrap_or(0)
 }
 
 #[derive(Debug, Error)]
@@ -1110,6 +1156,33 @@ mod tests {
         ] {
             let window = UsageWindow::new(WindowKind::Weekly, used_percent, Some(reset)).unwrap();
             assert_eq!(Severity::for_window(&window, now), expected);
+        }
+    }
+
+    /// Context severity reads headroom, exactly like a window's: it bands on
+    /// the context left, so every sidebar row means the same thing.
+    #[test]
+    fn context_severity_is_thresholded_on_remaining_at_fifty_and_twenty() {
+        for (used_percent, expected) in [
+            (0.0, Severity::Normal),
+            (31.0, Severity::Normal),
+            (49.0, Severity::Normal),
+            (49.4, Severity::Normal),
+            (50.0, Severity::Normal),
+            (51.0, Severity::Warning),
+            (53.0, Severity::Warning),
+            (79.0, Severity::Warning),
+            (79.4, Severity::Warning),
+            (80.0, Severity::Warning),
+            (81.0, Severity::Danger),
+            (85.0, Severity::Danger),
+            (100.0, Severity::Danger),
+        ] {
+            assert_eq!(
+                Severity::for_context_remaining(100.0 - used_percent),
+                expected,
+                "{used_percent} used"
+            );
         }
     }
 

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -71,13 +71,15 @@ pub fn clear(name: &str) -> Result<()> {
     }
 }
 
-/// Scoped overrides of the process-global config directory.
+/// Scoped overrides of the process-global environment.
 ///
-/// `HERDR_PLUGIN_CONFIG_DIR` is read from the environment, and Rust runs unit
-/// tests as threads of one process, so every test that touches it has to share
-/// a single lock. This is that one lock — do not add another.
+/// `HERDR_PLUGIN_CONFIG_DIR` and the other variables the plugin reads live in
+/// the environment, and Rust runs unit tests as threads of one process, so
+/// every test that writes one has to share a single lock. This is that one
+/// lock — do not add another.
 #[cfg(test)]
 pub(crate) mod testing {
+    use std::ffi::{OsStr, OsString};
     use std::path::Path;
     use std::sync::{Mutex, MutexGuard};
 
@@ -95,6 +97,41 @@ pub(crate) mod testing {
     /// Run `body` as a direct CLI invocation, with no Herdr config directory.
     pub(crate) fn without_config_dir(body: impl FnOnce()) {
         swap(None, body);
+    }
+
+    /// Run `body` with `variables` applied to the process environment, each
+    /// restored to its previous value afterwards.
+    ///
+    /// There is one process environment, so this shares the lock above rather
+    /// than taking one of its own.
+    pub(crate) fn with_env(variables: &[(&str, Option<&OsStr>)], body: impl FnOnce()) {
+        let _guard = guard();
+        let previous: Vec<(&str, Option<OsString>)> = variables
+            .iter()
+            .map(|(name, _)| (*name, std::env::var_os(name)))
+            .collect();
+        // SAFETY: every writer of these variables holds `LOCK`, and the
+        // previous values are restored before the guard is released.
+        unsafe {
+            for (name, value) in variables {
+                set(name, *value);
+            }
+        }
+        body();
+        unsafe {
+            for (name, value) in &previous {
+                set(name, value.as_deref());
+            }
+        }
+    }
+
+    /// # Safety
+    /// The caller must hold `LOCK`.
+    unsafe fn set(name: &str, value: Option<&OsStr>) {
+        match value {
+            Some(value) => std::env::set_var(name, value),
+            None => std::env::remove_var(name),
+        }
     }
 
     fn swap(path: Option<&Path>, body: impl FnOnce()) {

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1,8 +1,112 @@
-use crate::cli::PercentStyle;
+use crate::cli::{PercentStyle, SidebarLayout};
+use crate::configure::herdr::{DEFAULT_SIDEBAR_MAX_WIDTH, DEFAULT_SIDEBAR_MIN_WIDTH};
 use crate::model::{
-    format_percent, live_windows, long_window, window_in, Provider, ProviderSnapshot, ResetAt,
-    Severity, UsageWindow, WindowKind,
+    format_percent, live_windows, long_window, printed_percent, window_in, Provider,
+    ProviderSnapshot, ResetAt, Severity, UsageWindow, WindowKind,
 };
+
+/// A window row's fixed cost in columns: a two-character label, the two
+/// spaces separating it from the meter and the number, `100%`, and the longest
+/// ETA `format_duration` can print (`23h59m`, `29d23h`).
+const METER_ROW_OVERHEAD: usize = 15;
+/// One column the meter never claims, because Herdr auto-scales the rendered
+/// sidebar around the configured width.
+const METER_SAFETY_MARGIN: usize = 1;
+/// Past a dozen cells a bar stops being read at a glance and becomes texture.
+const MAX_METER_CELLS: usize = 12;
+/// Below four cells the bar cannot distinguish enough levels to be worth the
+/// columns it costs, so the row keeps its non-gauge shape instead.
+const MIN_METER_CELLS: usize = 4;
+// `\u{25b0}` and `\u{25b1}` are East-Asian-Width Neutral, so both are one
+// column wide in a CJK locale and identical in width to each other.
+const METER_FILLED: char = '\u{25b0}';
+const METER_EMPTY: char = '\u{25b1}';
+/// The gauges label column, the width of `5h` and `7d`. A longer label —
+/// `30d`, or an omp window naming itself — renders through the non-gauge
+/// shape rather than being truncated.
+const GAUGE_LABEL_WIDTH: usize = 2;
+/// `context` does not fit the label column; `cx` does, and only here.
+const GAUGE_CONTEXT_LABEL: &str = "cx";
+/// How many meter cells a window row can afford at `sidebar_width` columns,
+/// or `None` when the row should render through its existing non-gauge shape
+/// rather than lose the number the bar labels to truncation.
+pub(crate) fn meter_cells(sidebar_width: usize) -> Option<usize> {
+    let width = sidebar_width.clamp(DEFAULT_SIDEBAR_MIN_WIDTH, DEFAULT_SIDEBAR_MAX_WIDTH);
+    let cells = width
+        .saturating_sub(METER_SAFETY_MARGIN + METER_ROW_OVERHEAD)
+        .min(MAX_METER_CELLS);
+    (cells >= MIN_METER_CELLS).then_some(cells)
+}
+
+/// How the sidebar draws a row: the layout the user chose, and the meter size
+/// their configured sidebar width affords. The two always travel together,
+/// from the publish sites down to each rendered row.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SidebarShape {
+    pub layout: SidebarLayout,
+    pub meter_cells: Option<usize>,
+}
+
+impl SidebarShape {
+    pub fn new(layout: SidebarLayout, sidebar_width: usize) -> Self {
+        Self {
+            layout,
+            meter_cells: meter_cells(sidebar_width),
+        }
+    }
+}
+
+/// The two rendering knobs a pane's tokens are drawn with: whether a percent
+/// reads remaining or used, and the shape of the row it sits in. They are
+/// chosen together once per refresh pass and never vary between panes, so
+/// they travel as one value rather than as two parallel parameters.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RowStyle {
+    pub percent: PercentStyle,
+    pub shape: SidebarShape,
+}
+
+impl RowStyle {
+    pub fn new(percent: PercentStyle, shape: SidebarShape) -> Self {
+        Self { percent, shape }
+    }
+}
+
+impl From<SidebarLayout> for SidebarShape {
+    fn from(layout: SidebarLayout) -> Self {
+        Self {
+            layout,
+            meter_cells: None,
+        }
+    }
+}
+
+/// A meter that agrees with the integer printed beside it: only 0
+/// draws an empty bar and only 100 draws a full one, so a window with quota
+/// left never reads as spent.
+fn meter(printed: u32, cells: usize) -> String {
+    let filled = (f64::from(printed) * cells as f64 / 100.0).round() as usize;
+    let filled = if (1..=99).contains(&printed) {
+        filled.clamp(1, cells - 1)
+    } else {
+        filled.min(cells)
+    };
+    std::iter::repeat_n(METER_FILLED, filled)
+        .chain(std::iter::repeat_n(METER_EMPTY, cells - filled))
+        .collect()
+}
+
+/// How many meter cells a row labelled `label` draws, or `None` when it keeps
+/// its existing non-gauge shape: another layout, a sidebar too narrow for a
+/// bar, or a label that would not fit the label column.
+fn gauge_cells(shape: SidebarShape, label: &str) -> Option<usize> {
+    match shape.layout {
+        SidebarLayout::Packed | SidebarLayout::Stacked => None,
+        SidebarLayout::Gauges => shape
+            .meter_cells
+            .filter(|_| label.chars().count() <= GAUGE_LABEL_WIDTH),
+    }
+}
 
 /// Exactly the values a pane can be given.
 ///
@@ -21,6 +125,9 @@ pub struct MetadataTokens {
     pub quota_week: String,
     pub quota_week_severity: Option<Severity>,
     pub quota_context: String,
+    /// Read from context *left*, on the same bands as the window severities,
+    /// whichever side of the ledger the row prints. Only `gauges` renders it.
+    pub quota_context_severity: Option<Severity>,
     pub quota_cache: String,
     pub quota_cache_ttl: String,
     /// A lapsed prompt cache (`no cached`). Normal, unlike `quota_error`.
@@ -38,7 +145,13 @@ pub struct MetadataTokens {
 
 impl MetadataTokens {
     pub fn from_snapshot(snapshot: &ProviderSnapshot, now_unix: u64) -> Self {
-        Self::from_snapshot_for_session(snapshot, now_unix, None, PercentStyle::default())
+        Self::from_snapshot_for_session(
+            snapshot,
+            now_unix,
+            None,
+            PercentStyle::default(),
+            SidebarShape::default(),
+        )
     }
 
     pub fn from_snapshot_for_session(
@@ -46,6 +159,7 @@ impl MetadataTokens {
         now_unix: u64,
         session_id: Option<&str>,
         style: PercentStyle,
+        shape: SidebarShape,
     ) -> Self {
         Self::from_snapshot_parts(
             snapshot,
@@ -58,6 +172,7 @@ impl MetadataTokens {
                 snapshot.windows_for_session(session_id)
             },
             style,
+            shape,
         )
     }
 
@@ -74,6 +189,7 @@ impl MetadataTokens {
         now_unix: u64,
         session_id: Option<&str>,
         style: PercentStyle,
+        shape: SidebarShape,
     ) -> Self {
         let quota_model = match session_id {
             Some(session_id) => snapshot.model_for_session(Some(session_id)),
@@ -82,7 +198,15 @@ impl MetadataTokens {
         let context =
             session_id.and_then(|session_id| snapshot.context_for_session(Some(session_id)));
         let windows = snapshot.windows_for_session(session_id);
-        Self::from_snapshot_parts(snapshot, now_unix, quota_model, context, windows, style)
+        Self::from_snapshot_parts(
+            snapshot,
+            now_unix,
+            quota_model,
+            context,
+            windows,
+            style,
+            shape,
+        )
     }
 
     fn from_snapshot_parts(
@@ -92,6 +216,7 @@ impl MetadataTokens {
         context: Option<&crate::model::ContextUsage>,
         windows: &[UsageWindow],
         style: PercentStyle,
+        shape: SidebarShape,
     ) -> Self {
         let live = live_windows(windows, now_unix);
         let windows = live.as_slice();
@@ -106,10 +231,10 @@ impl MetadataTokens {
         let long = long_window(windows);
         let quota_5h = if omp_windows {
             short_window
-                .map(|window| compact_window_parts(window, now_unix, style).rendered())
+                .map(|window| compact_window_parts(window, now_unix, style, shape).rendered())
                 .unwrap_or_default()
         } else {
-            five_hour_slot(windows, snapshot.provider, now_unix, style)
+            five_hour_slot(windows, snapshot.provider, now_unix, style, shape)
         };
         Self {
             quota_provider_model: provider_model_label(&quota_provider, &quota_model),
@@ -125,10 +250,11 @@ impl MetadataTokens {
                 }),
             quota_5h,
             quota_week: long
-                .map(|window| compact_window_parts(window, now_unix, style).rendered())
+                .map(|window| compact_window_parts(window, now_unix, style, shape).rendered())
                 .unwrap_or_default(),
             quota_week_severity: long.map(|window| Severity::for_window(window, now_unix)),
-            quota_context: sidebar_context(context),
+            quota_context: sidebar_context(context, style, shape),
+            quota_context_severity: context.map(|context| context_severity(context, style)),
             quota_cache: sidebar_cache(context),
             quota_cache_ttl: sidebar_cache_ttl(context, now_unix),
             quota_cache_state: sidebar_cache_state(context, now_unix),
@@ -153,6 +279,7 @@ impl MetadataTokens {
             quota_week: "7d N/A".to_string(),
             quota_week_severity: Some(Severity::Unknown),
             quota_context: String::new(),
+            quota_context_severity: None,
             quota_cache: String::new(),
             quota_cache_ttl: String::new(),
             quota_cache_state: String::new(),
@@ -236,9 +363,10 @@ fn five_hour_slot(
     provider: Provider,
     now_unix: u64,
     style: PercentStyle,
+    shape: SidebarShape,
 ) -> String {
     match window_in(windows, WindowKind::FiveHour) {
-        Some(window) => compact_window_parts(window, now_unix, style).rendered(),
+        Some(window) => compact_window_parts(window, now_unix, style, shape).rendered(),
         None => missing_five_hour_label(provider)
             .unwrap_or_default()
             .to_string(),
@@ -263,11 +391,58 @@ fn missing_five_hour_severity(provider: Provider, quota_5h: &str) -> Option<Seve
         .then_some(Severity::Unknown)
 }
 
-pub(crate) fn sidebar_context(context: Option<&crate::model::ContextUsage>) -> String {
+/// The percentage the `gauges` context row prints under `style`.
+///
+/// One scale per sidebar: the context row joins a column with the window
+/// rows, and a column of aligned numbers reads as one quantity, so it prints
+/// the same side of the ledger they do.
+fn context_percent(context: &crate::model::ContextUsage, style: PercentStyle) -> f64 {
+    match style {
+        PercentStyle::Remaining => 100.0 - context.used_percent,
+        PercentStyle::Used => context.used_percent,
+    }
+}
+
+/// The context row's colour, always read from headroom and never from the
+/// number printed beside it. The meter still fills to that number, so under
+/// `used` a filling bar runs green → amber → red and under `remaining` a
+/// draining one does the same: colour means "how much is left" either way.
+///
+/// Classified on the integer the row prints, like [`Severity::for_window`],
+/// so colour and number cannot disagree at a band edge.
+pub(crate) fn context_severity(
+    context: &crate::model::ContextUsage,
+    style: PercentStyle,
+) -> Severity {
+    let printed = f64::from(printed_percent(context_percent(context, style)));
+    let remaining = match style {
+        PercentStyle::Remaining => printed,
+        PercentStyle::Used => 100.0 - printed,
+    };
+    Severity::for_context_remaining(remaining)
+}
+
+pub(crate) fn sidebar_context(
+    context: Option<&crate::model::ContextUsage>,
+    style: PercentStyle,
+    shape: SidebarShape,
+) -> String {
     let Some(context) = context else {
         return String::new();
     };
-    format!("context {}%", format_percent(context.used_percent))
+    match gauge_cells(shape, GAUGE_CONTEXT_LABEL) {
+        Some(cells) => {
+            let percent = context_percent(context, style);
+            format!(
+                "{GAUGE_CONTEXT_LABEL} {} {:>3}%",
+                meter(printed_percent(percent), cells),
+                format_percent(percent)
+            )
+        }
+        // `packed` and `stacked` never joined that column, and their row has
+        // always printed consumption; the style must not leak into them.
+        None => format!("context {}%", format_percent(context.used_percent)),
+    }
 }
 
 pub(crate) fn sidebar_cache(context: Option<&crate::model::ContextUsage>) -> String {
@@ -338,6 +513,9 @@ struct WindowParts {
     label: String,
     percent: String,
     eta: String,
+    /// Set only when this row draws a meter, so every caller of `rendered`
+    /// picks up the gauge shape without deciding anything itself.
+    meter: Option<String>,
 }
 
 impl WindowParts {
@@ -345,21 +523,46 @@ impl WindowParts {
     /// ` · `. The period label leads, so the value is self-describing however
     /// the sidebar arranges it.
     fn rendered(&self) -> String {
+        let head = match &self.meter {
+            Some(meter) => format!("{} {meter} {}", self.label, self.percent),
+            None => format!("{} {}", self.label, self.percent),
+        };
         if self.eta.is_empty() {
-            return format!("{} {}", self.label, self.percent);
+            return head;
         }
-        format!("{} {} {}", self.label, self.percent, self.eta)
+        format!("{head} {}", self.eta)
     }
 }
 
-fn compact_window_parts(window: &UsageWindow, now_unix: u64, style: PercentStyle) -> WindowParts {
-    WindowParts {
-        label: window.display_label().to_string(),
-        percent: format!("{}%", format_percent(style.percent_of(window))),
-        eta: window
-            .resets_at
-            .map(|reset| format_reset_eta(reset, now_unix))
-            .unwrap_or_default(),
+fn compact_window_parts(
+    window: &UsageWindow,
+    now_unix: u64,
+    style: PercentStyle,
+    shape: SidebarShape,
+) -> WindowParts {
+    let label = match shape.layout {
+        SidebarLayout::Gauges => window.gauge_display_label(),
+        SidebarLayout::Packed | SidebarLayout::Stacked => window.display_label(),
+    };
+    let percent = style.percent_of(window);
+    let eta = window
+        .resets_at
+        .map(|reset| format_reset_eta(reset, now_unix))
+        .unwrap_or_default();
+    match gauge_cells(shape, label) {
+        // The number is right-aligned so the ETA column lines up across rows.
+        Some(cells) => WindowParts {
+            label: format!("{label:<width$}", width = GAUGE_LABEL_WIDTH),
+            percent: format!("{:>3}%", format_percent(percent)),
+            eta,
+            meter: Some(meter(printed_percent(percent), cells)),
+        },
+        None => WindowParts {
+            label: label.to_string(),
+            percent: format!("{}%", format_percent(percent)),
+            eta,
+            meter: None,
+        },
     }
 }
 
@@ -567,17 +770,104 @@ mod tests {
             ],
             0,
         );
-        let remaining =
-            MetadataTokens::from_snapshot_for_session(&snapshot, 0, None, PercentStyle::Remaining);
+        let remaining = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            SidebarShape::default(),
+        );
         assert_eq!(remaining.quota_5h, "5h 42% 4h07m");
         assert_eq!(remaining.quota_week, "7d 73% 2d3h");
 
-        let used =
-            MetadataTokens::from_snapshot_for_session(&snapshot, 0, None, PercentStyle::Used);
+        let used = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Used,
+            SidebarShape::default(),
+        );
         assert_eq!(used.quota_5h, "5h 58% 4h07m");
         assert_eq!(used.quota_week, "7d 27% 2d3h");
         assert_eq!(used.quota_5h_severity, remaining.quota_5h_severity);
         assert_eq!(used.quota_week_severity, remaining.quota_week_severity);
+    }
+
+    /// U4 gives `gauges` a meter; `packed` and `stacked` must stay identical
+    /// to each other and to what they printed before the layout existed.
+    #[test]
+    fn the_sidebar_layout_does_not_move_any_packed_or_stacked_token() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![
+                window(WindowKind::FiveHour, 19.0, 2_580),
+                window(WindowKind::Weekly, 27.0, 183_600),
+            ],
+            0,
+        )
+        .with_context(Some(crate::model::ContextUsage::new(23.5).unwrap()));
+        let packed = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::default(),
+            SidebarLayout::Packed.into(),
+        );
+        let stacked = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::default(),
+            SidebarLayout::Stacked.into(),
+        );
+        assert_eq!(packed, stacked);
+        assert_eq!(packed.quota_5h, "5h 81% 43m");
+    }
+
+    #[test]
+    fn the_existing_literals_survive_every_layout() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![
+                window(WindowKind::FiveHour, 58.0, 14_820),
+                window(WindowKind::Weekly, 27.0, 183_600),
+            ],
+            0,
+        )
+        .with_context(Some(crate::model::ContextUsage::new(23.5).unwrap()));
+        for layout in [SidebarLayout::Packed, SidebarLayout::Stacked] {
+            let values = MetadataTokens::from_snapshot_for_session(
+                &snapshot,
+                0,
+                None,
+                PercentStyle::default(),
+                layout.into(),
+            );
+            assert_eq!(values.quota_5h, "5h 42% 4h07m");
+            assert_eq!(values.quota_week, "7d 73% 2d3h");
+            assert_eq!(values.quota_context, "context 24%");
+        }
+    }
+
+    /// The dashboard renders through `format_window`, not the sidebar path,
+    /// so no layout may ever reach it.
+    #[test]
+    fn the_dashboard_never_carries_a_meter() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![
+                window(WindowKind::FiveHour, 58.0, 14_820),
+                window(WindowKind::Weekly, 27.0, 183_600),
+            ],
+            0,
+        );
+        let summary = dashboard_summary(&snapshot, 0, PercentStyle::default());
+        assert_eq!(
+            summary,
+            "5h 42% left reset 4h07m \u{b7} 7d 73% left reset 2d3h"
+        );
+        assert!(!summary.contains('\u{25b0}'));
+        assert!(!summary.contains('\u{25b1}'));
     }
 
     #[test]
@@ -647,6 +937,7 @@ mod tests {
             0,
             Some("session-1"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         assert_eq!(session_one.quota_model, "Sonnet");
         assert_eq!(session_one.quota_provider_model, "Claude/Sonnet");
@@ -656,6 +947,7 @@ mod tests {
             0,
             Some("session-2"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         assert_eq!(session_two.quota_model, "");
         assert_eq!(session_two.quota_provider_model, "Claude");
@@ -674,6 +966,7 @@ mod tests {
             0,
             Some("session-a"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         assert_eq!(pane.quota_model, "SWE-1.7 Medium");
         assert_eq!(pane.quota_provider_model, "Devin/SWE-1.7 Medium");
@@ -696,6 +989,7 @@ mod tests {
             0,
             Some("session-a"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         assert_eq!(switched.quota_model, "Opus 4.6");
         assert_eq!(switched.quota_provider_model, "Devin/Opus 4.6");
@@ -705,6 +999,7 @@ mod tests {
             0,
             Some("session-b"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         assert_eq!(untouched.quota_model, "SWE-1.7 Medium");
         assert_eq!(untouched.quota_provider_model, "Devin/SWE-1.7 Medium");
@@ -724,6 +1019,7 @@ mod tests {
             0,
             Some("session-1"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         assert_eq!(values.quota_context, "context 43%");
         assert_eq!(values.quota_cache, "cache 72.7%");
@@ -732,7 +1028,8 @@ mod tests {
                 &snapshot,
                 0,
                 Some("session-2"),
-                PercentStyle::default()
+                PercentStyle::default(),
+                SidebarShape::default()
             )
             .quota_context,
             ""
@@ -748,8 +1045,13 @@ mod tests {
                     .unwrap()
                     .with_cache(crate::model::CacheUsage::from_token_counts(200, 800, 100)),
             ));
-        let values =
-            MetadataTokens::from_snapshot_for_pane(&snapshot, 0, None, PercentStyle::default());
+        let values = MetadataTokens::from_snapshot_for_pane(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::default(),
+            SidebarShape::default(),
+        );
         assert_eq!(values.quota_provider_model, "Grok/grok-4.6");
         assert_eq!(values.quota_context, "");
         assert_eq!(values.quota_cache, "");
@@ -806,6 +1108,7 @@ mod tests {
             1_000,
             Some("codex-session"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         assert_eq!(values.quota_cache, "cache 80.0%");
         assert_eq!(values.quota_cache_ttl, "ttl≈1h");
@@ -883,6 +1186,7 @@ mod tests {
             0,
             Some("session-1"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         assert_eq!(grok_pane.quota_week, "7d 69% 6d0h");
         assert_eq!(grok_pane.quota_5h, "");
@@ -900,6 +1204,7 @@ mod tests {
             0,
             Some("session-1"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         assert_eq!(codex_pane.quota_5h, "5h 60% 4h07m");
         assert_eq!(codex_pane.quota_week, "7d 69% 6d0h");
@@ -932,6 +1237,7 @@ mod tests {
             0,
             Some("work"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         assert_eq!(work.quota_5h, "5h 82% 4h07m");
         assert_eq!(work.quota_week, "7d 90% 6d0h");
@@ -941,6 +1247,7 @@ mod tests {
             0,
             Some("personal"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         assert_eq!(personal.quota_5h, "5h 18% 4h07m");
         assert_eq!(personal.quota_week, "7d 10% 6d0h");
@@ -950,6 +1257,7 @@ mod tests {
             0,
             Some("other"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         assert_eq!(unknown.quota_5h, "5h N/A");
         assert_eq!(unknown.quota_week, "");
@@ -986,12 +1294,14 @@ mod tests {
             0,
             Some("session-c"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         let live = MetadataTokens::from_snapshot_for_pane(
             &snapshot,
             0,
             Some("session-a"),
             PercentStyle::default(),
+            SidebarShape::default(),
         );
         assert_eq!(idle.quota_5h, "5h 8% 4h07m");
         assert_eq!(live.quota_5h, "5h 8% 4h07m");
@@ -1055,5 +1365,598 @@ mod tests {
         ));
         let values = MetadataTokens::from_snapshot(&snapshot, 0);
         assert_eq!(values.quota_cache, "cache 99.2%");
+    }
+
+    /// The bar shortens with the sidebar and disappears rather
+    /// than truncating the number it labels.
+    #[test]
+    fn the_meter_cell_count_follows_the_configured_sidebar_width() {
+        assert_eq!(meter_cells(18), None);
+        assert_eq!(meter_cells(22), Some(6));
+        assert_eq!(meter_cells(26), Some(10));
+        assert_eq!(meter_cells(30), Some(12));
+        assert_eq!(meter_cells(36), Some(12));
+    }
+
+    #[test]
+    fn a_sidebar_width_outside_the_documented_range_is_sized_as_its_nearest_bound() {
+        assert_eq!(meter_cells(0), meter_cells(18));
+        assert_eq!(meter_cells(12), meter_cells(18));
+        assert_eq!(meter_cells(48), meter_cells(36));
+    }
+
+    /// At the narrowest meter the clamp does all the work: one spent cell
+    /// cannot read as empty, and one unspent cell cannot read as full.
+    #[test]
+    fn the_narrowest_meter_still_separates_almost_empty_from_almost_full() {
+        assert_eq!(
+            meter(1, MIN_METER_CELLS),
+            "\u{25b0}\u{25b1}\u{25b1}\u{25b1}"
+        );
+        assert_eq!(
+            meter(99, MIN_METER_CELLS),
+            "\u{25b0}\u{25b0}\u{25b0}\u{25b1}"
+        );
+        assert_eq!(
+            meter(0, MIN_METER_CELLS),
+            "\u{25b1}\u{25b1}\u{25b1}\u{25b1}"
+        );
+        assert_eq!(
+            meter(100, MIN_METER_CELLS),
+            "\u{25b0}\u{25b0}\u{25b0}\u{25b0}"
+        );
+    }
+
+    /// `METER_ROW_OVERHEAD` budgets six columns for the ETA, so every reset a
+    /// provider can plausibly quote has to print within six. Past 99 days it
+    /// does not, and the meter would then be one column too long.
+    #[test]
+    fn a_reset_eta_prints_within_the_six_columns_the_row_overhead_budgets() {
+        for seconds in [
+            0,
+            1,
+            59,
+            60,
+            59 * 60 + 59,
+            60 * 60,
+            23 * 60 * 60 + 59 * 60,
+            24 * 60 * 60,
+            29 * 24 * 60 * 60 + 23 * 60 * 60,
+            99 * 24 * 60 * 60 + 23 * 60 * 60,
+        ] {
+            let printed = format_duration(seconds);
+            assert!(
+                printed.chars().count() <= 6,
+                "{seconds}s printed as {printed}"
+            );
+        }
+        assert_eq!(format_duration(1_000 * 24 * 60 * 60), "1000d0h");
+    }
+
+    #[test]
+    fn a_sidebar_too_narrow_for_four_cells_asks_for_no_meter_at_all() {
+        for width in 18..20 {
+            assert_eq!(meter_cells(width), None, "width {width}");
+        }
+        assert_eq!(meter_cells(20), Some(4));
+    }
+
+    /// The shape a `gauges` sidebar of `width` columns resolves to. Every
+    /// exact-string test below names the cell count it assumes, so a width
+    /// change moves one fixture rather than the suite.
+    fn gauges(width: usize) -> SidebarShape {
+        SidebarShape::new(SidebarLayout::Gauges, width)
+    }
+
+    /// Ten cells, the default 26-column sidebar. The bar fills to the
+    /// number beside it: 81% remaining draws a bar 81% full.
+    #[test]
+    fn the_gauges_meter_fills_to_the_remaining_number_it_prints() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![window(WindowKind::FiveHour, 19.0, 2_580)],
+            0,
+        );
+        let values = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            gauges(26),
+        );
+        assert_eq!(
+            values.quota_5h,
+            "5h \u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b1}\u{25b1}  81% 43m"
+        );
+        assert_eq!(values.quota_5h_severity, Some(Severity::Normal));
+    }
+
+    /// Ten cells. The `used` style flips both the number and the bar, and
+    /// neither touches severity, which still reads remaining.
+    #[test]
+    fn the_used_style_shortens_the_gauges_meter_without_changing_its_colour() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![window(WindowKind::FiveHour, 19.0, 2_580)],
+            0,
+        );
+        let remaining = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            gauges(26),
+        );
+        let used = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Used,
+            gauges(26),
+        );
+        assert_eq!(
+            used.quota_5h,
+            "5h \u{25b0}\u{25b0}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}  19% 43m"
+        );
+        assert_eq!(used.quota_5h_severity, remaining.quota_5h_severity);
+    }
+
+    /// One scale per sidebar: under `gauges` the context row prints through
+    /// the same percent style as the window rows, so the column of numbers
+    /// reads as one quantity. Twelve cells, a 30-column sidebar.
+    #[test]
+    fn the_gauges_context_row_prints_through_the_chosen_percent_style() {
+        let snapshot = ProviderSnapshot::new(Provider::Claude, vec![], 0)
+            .with_context(Some(crate::model::ContextUsage::new(43.0).unwrap()));
+        let remaining = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            gauges(30),
+        );
+        assert_eq!(
+            remaining.quota_context,
+            "cx \u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}  57%"
+        );
+        let used = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Used,
+            gauges(30),
+        );
+        assert_eq!(
+            used.quota_context,
+            "cx \u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}  43%"
+        );
+    }
+
+    /// The style must not leak into the layouts that never joined the column:
+    /// `packed` and `stacked` keep printing consumption as `context N%`.
+    #[test]
+    fn packed_and_stacked_print_context_used_under_either_percent_style() {
+        let snapshot = ProviderSnapshot::new(Provider::Claude, vec![], 0)
+            .with_context(Some(crate::model::ContextUsage::new(43.0).unwrap()));
+        for layout in [SidebarLayout::Packed, SidebarLayout::Stacked] {
+            for style in [PercentStyle::Remaining, PercentStyle::Used] {
+                let plain = MetadataTokens::from_snapshot_for_session(
+                    &snapshot,
+                    0,
+                    None,
+                    style,
+                    layout.into(),
+                );
+                assert_eq!(plain.quota_context, "context 43%", "{layout:?} {style:?}");
+            }
+        }
+    }
+
+    /// The whole point of the fix: cntx, 5h and 7d print the same quantity,
+    /// and all three move together when the style flips.
+    #[test]
+    fn every_gauges_row_prints_the_same_quantity_when_the_style_flips() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![
+                window(WindowKind::FiveHour, 31.0, 2_400),
+                window(WindowKind::Weekly, 23.0, 388_200),
+            ],
+            0,
+        )
+        .with_context(Some(crate::model::ContextUsage::new(43.0).unwrap()));
+        let used = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Used,
+            gauges(30),
+        );
+        for (token, expected) in [
+            (&used.quota_context, "43%"),
+            (&used.quota_5h, "31%"),
+            (&used.quota_week, "23%"),
+        ] {
+            assert!(token.contains(expected), "{token} lacks {expected}");
+        }
+        let remaining = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            gauges(30),
+        );
+        for (token, expected) in [
+            (&remaining.quota_context, "57%"),
+            (&remaining.quota_5h, "69%"),
+            (&remaining.quota_week, "77%"),
+        ] {
+            assert!(token.contains(expected), "{token} lacks {expected}");
+        }
+    }
+
+    /// Colour reads headroom on every row, so the context row bands on
+    /// remaining context and not on the number it happens to print.
+    #[test]
+    fn the_context_row_is_coloured_by_remaining_context_under_either_style() {
+        for (used, expected) in [
+            (0.0, Severity::Normal),
+            (31.0, Severity::Normal),
+            (49.0, Severity::Normal),
+            (50.0, Severity::Normal),
+            (51.0, Severity::Warning),
+            (53.0, Severity::Warning),
+            (79.0, Severity::Warning),
+            (80.0, Severity::Warning),
+            (81.0, Severity::Danger),
+            (85.0, Severity::Danger),
+            (100.0, Severity::Danger),
+        ] {
+            let snapshot = ProviderSnapshot::new(Provider::Claude, vec![], 0)
+                .with_context(Some(crate::model::ContextUsage::new(used).unwrap()));
+            for style in [PercentStyle::Remaining, PercentStyle::Used] {
+                let values = MetadataTokens::from_snapshot_for_session(
+                    &snapshot,
+                    0,
+                    None,
+                    style,
+                    gauges(30),
+                );
+                assert_eq!(
+                    values.quota_context_severity,
+                    Some(expected),
+                    "{used} used, {style:?}"
+                );
+            }
+        }
+    }
+
+    /// Ten cells, the default 26-column sidebar. The meter fills to the
+    /// number beside it, and `cx` exists only under `gauges`.
+    #[test]
+    fn the_context_meter_fills_to_its_number_and_is_labelled_cx_only_under_gauges() {
+        let snapshot = ProviderSnapshot::new(Provider::Claude, vec![], 0)
+            .with_context(Some(crate::model::ContextUsage::new(31.0).unwrap()));
+        let gauged = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Used,
+            gauges(26),
+        );
+        assert_eq!(
+            gauged.quota_context,
+            "cx \u{25b0}\u{25b0}\u{25b0}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}  31%"
+        );
+        for layout in [SidebarLayout::Packed, SidebarLayout::Stacked] {
+            let plain = MetadataTokens::from_snapshot_for_session(
+                &snapshot,
+                0,
+                None,
+                PercentStyle::Used,
+                layout.into(),
+            );
+            assert_eq!(plain.quota_context, "context 31%", "{layout:?}");
+        }
+    }
+
+    /// Ten cells. The weekly slot renders through `from_snapshot_parts`
+    /// rather than `five_hour_slot`, so it needs its own pin.
+    #[test]
+    fn the_weekly_window_carries_a_meter_of_its_own() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![window(WindowKind::Weekly, 17.0, 424_800)],
+            0,
+        );
+        let values = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            gauges(26),
+        );
+        assert_eq!(
+            values.quota_week,
+            "7d \u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b1}\u{25b1}  83% 4d22h"
+        );
+        assert_eq!(values.quota_week.chars().count(), 24);
+    }
+
+    /// Eight cells. Only 0 may draw nothing and only 100 may draw everything,
+    /// so a window with quota left never looks spent.
+    #[test]
+    fn only_zero_draws_an_empty_meter_and_only_a_hundred_draws_a_full_one() {
+        assert_eq!(
+            meter(0, 8),
+            "\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}"
+        );
+        assert_eq!(
+            meter(100, 8),
+            "\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}"
+        );
+        for printed in [1, 6] {
+            assert_eq!(
+                meter(printed, 8).matches('\u{25b0}').count(),
+                1,
+                "printed {printed}"
+            );
+        }
+        assert_eq!(meter(99, 8).matches('\u{25b0}').count(), 7);
+        assert_eq!(meter(50, 8).matches('\u{25b0}').count(), 4);
+        assert_eq!(meter(56, 8).matches('\u{25b0}').count(), 4);
+        assert_eq!(meter(57, 8).matches('\u{25b0}').count(), 5);
+    }
+
+    /// Eight cells, at 24 columns. `{:.0}` rounds half to even and
+    /// `f64::round` rounds half away from zero; at exactly 18.5 they
+    /// disagree, and a bar that read the float directly would show two cells
+    /// beside `18%`.
+    #[test]
+    fn the_meter_and_the_number_round_the_same_way_at_a_half_percent() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![window(WindowKind::FiveHour, 81.5, 2_580)],
+            0,
+        );
+        let values = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            gauges(24),
+        );
+        assert_eq!(
+            values.quota_5h,
+            "5h \u{25b0}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}\u{25b1}  18% 43m"
+        );
+    }
+
+    /// Twelve cells at 36 columns; none at 18, where the row must be exactly
+    /// what `stacked` publishes rather than a truncated meter.
+    #[test]
+    fn a_wider_sidebar_lengthens_the_meter_and_a_narrow_one_drops_it() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![window(WindowKind::Weekly, 17.0, 424_800)],
+            0,
+        );
+        let wide = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            gauges(36),
+        );
+        assert_eq!(
+            wide.quota_week,
+            "7d \u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b1}\u{25b1}  83% 4d22h"
+        );
+
+        let narrow = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            gauges(18),
+        );
+        let stacked = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            SidebarLayout::Stacked.into(),
+        );
+        assert_eq!(narrow.quota_week, stacked.quota_week);
+        assert!(!narrow.quota_week.contains('\u{2026}'));
+    }
+
+    /// `missing_five_hour_severity` finds the placeholder by string equality,
+    /// so padding its label would silently drop the Unknown severity.
+    #[test]
+    fn the_missing_five_hour_placeholder_is_byte_identical_under_every_layout() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![window(WindowKind::Weekly, 17.0, 424_800)],
+            0,
+        );
+        for shape in [
+            SidebarLayout::Packed.into(),
+            SidebarLayout::Stacked.into(),
+            gauges(26),
+        ] {
+            let values = MetadataTokens::from_snapshot_for_session(
+                &snapshot,
+                0,
+                None,
+                PercentStyle::Remaining,
+                shape,
+            );
+            assert_eq!(values.quota_5h, "5h N/A", "{shape:?}");
+            assert_eq!(
+                values.quota_5h_severity,
+                Some(Severity::Unknown),
+                "{shape:?}"
+            );
+        }
+    }
+
+    /// A label wider than the two-character column keeps the whole row on
+    /// the non-gauge shape, because truncating a label is worse than
+    /// dropping a bar.
+    #[test]
+    fn a_label_too_long_for_the_gauges_column_keeps_the_non_gauge_shape() {
+        let mut snapshot = ProviderSnapshot::new(
+            Provider::Omp,
+            vec![window(WindowKind::FiveHour, 58.0, 11_400).with_source_window("usage", None)],
+            0,
+        );
+        snapshot.source = "omp.acme".to_string();
+        let values = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            gauges(26),
+        );
+        assert_eq!(values.quota_5h, "usage 42% 3h10m");
+    }
+
+    /// Ten cells. `week_style_base` folds week beside context when 5h is
+    /// empty; the meter has to ride along into that token too.
+    #[test]
+    fn a_week_row_folded_beside_context_still_carries_its_meter() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Grok,
+            vec![window(WindowKind::Weekly, 17.0, 424_800)],
+            0,
+        );
+        let values = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            gauges(26),
+        );
+        assert_eq!(values.quota_5h, "");
+        assert_eq!(
+            values.quota_week,
+            "7d \u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b1}\u{25b1}  83% 4d22h"
+        );
+    }
+
+    /// Herdr joins sibling tokens with ` \u{b7} `, so a value carrying one
+    /// reads as two tokens; and no value may approach the token budget.
+    #[test]
+    fn no_gauges_token_carries_a_separator_or_approaches_the_token_budget() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![
+                window(WindowKind::FiveHour, 0.0, 86_340),
+                window(WindowKind::Weekly, 17.0, 424_800),
+            ],
+            0,
+        )
+        .with_context(Some(crate::model::ContextUsage::new(31.0).unwrap()));
+        let values = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            gauges(26),
+        );
+        // 100% with the longest ETA `format_duration` prints is the widest
+        // row the default width has to hold.
+        assert_eq!(
+            values.quota_5h,
+            "5h \u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0}\u{25b0} 100% 23h59m"
+        );
+        for value in [&values.quota_5h, &values.quota_week, &values.quota_context] {
+            assert!(!value.contains('\u{b7}'), "{value}");
+            assert!(value.chars().count() < 80, "{value}");
+        }
+        assert_eq!(values.quota_5h.chars().count(), 25);
+    }
+
+    /// Ten cells. The label column is two characters wide, so every label the
+    /// gauges layout can draw a meter for is already exactly that wide and no
+    /// row pads.
+    #[test]
+    fn the_gauges_label_column_is_two_characters_wide() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![window(WindowKind::FiveHour, 19.0, 2_580)],
+            0,
+        )
+        .with_context(Some(crate::model::ContextUsage::new(31.0).unwrap()));
+        let values = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Used,
+            gauges(26),
+        );
+        assert!(
+            values.quota_5h.starts_with("5h \u{25b0}"),
+            "{}",
+            values.quota_5h
+        );
+        assert!(
+            values.quota_context.starts_with("cx \u{25b0}"),
+            "{}",
+            values.quota_context
+        );
+    }
+
+    /// A monthly allowance rides the long-window slot when a plan has no
+    /// weekly bucket, so losing its meter would leave that user without one
+    /// on their only recurring row. `30d` is one character past the column;
+    /// the short form fits, and `packed` keeps the full label.
+    #[test]
+    fn a_monthly_window_keeps_its_meter_under_a_two_letter_label() {
+        let snapshot = ProviderSnapshot::new(
+            Provider::Claude,
+            vec![window(WindowKind::Monthly, 17.0, 424_800)],
+            0,
+        );
+        let gauged = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            gauges(26),
+        );
+        assert_eq!(gauged.quota_week, "mo ▰▰▰▰▰▰▰▰▱▱  83% 4d22h");
+
+        let packed = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            SidebarLayout::Packed.into(),
+        );
+        assert_eq!(packed.quota_week, "30d 83% 4d22h");
+    }
+
+    /// A provider-supplied label is never rewritten, so one too long for the
+    /// column keeps the plain row rather than being abbreviated by guesswork.
+    #[test]
+    fn a_provider_supplied_long_label_still_keeps_the_plain_row() {
+        let long = UsageWindow::new(
+            WindowKind::Monthly,
+            17.0,
+            Some(ResetAt::from_unix_seconds(424_800)),
+        )
+        .unwrap()
+        .with_source_window("Monthly", None);
+        let snapshot = ProviderSnapshot::new(Provider::Omp, vec![long], 0);
+        let values = MetadataTokens::from_snapshot_for_session(
+            &snapshot,
+            0,
+            None,
+            PercentStyle::Remaining,
+            gauges(26),
+        );
+        assert_eq!(values.quota_week, "Monthly 83% 4d22h");
     }
 }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -1,5 +1,5 @@
 use crate::cache::CacheStore;
-use crate::cli::{AgentSelection, LowQuotaAlert, PercentStyle};
+use crate::cli::{AgentSelection, LowQuotaAlert};
 use crate::herdr::{
     current_focused_pane, list_agent_panes, list_agent_state, plugin_quota_present,
     publish_pane_tokens, refresh_pane_topic, AgentPane, PaneQuotaUpdate, PaneTokens,
@@ -9,7 +9,7 @@ use crate::model::{
 };
 use crate::omp::OmpEvidence;
 use crate::opencode::OpenCodePaths;
-use crate::presentation::MetadataTokens;
+use crate::presentation::{MetadataTokens, RowStyle, SidebarShape};
 use crate::providers::statusline::enrich_cache_session;
 use crate::providers::{codex, devin, grok, omp as omp_provider, opencode_go};
 use crate::route;
@@ -457,13 +457,14 @@ fn handle_named_pane(cache: &CacheStore, pane: AgentPane, topic_pane: Option<&st
             refresh_selected(cache, &[provider], false, &panes)?;
         }
     }
-    let style = cache.percent_style().unwrap_or_default();
+    let shape = sidebar_shape(cache);
+    let row = RowStyle::new(cache.percent_style().unwrap_or_default(), shape);
     let tokens = resolved_pane_tokens(
         cache,
         &mut panes[0],
         resolved,
         CacheStore::now_unix(),
-        style,
+        row,
         false,
     )?
     .into_iter()
@@ -474,7 +475,17 @@ fn handle_named_pane(cache: &CacheStore, pane: AgentPane, topic_pane: Option<&st
     // what makes the alert land at the end of the turn that spent the quota
     // rather than at the next poll.
     notify_low_quota(cache, &tokens);
-    publish_pane_tokens(&panes, &tokens, CacheStore::now_millis())
+    publish_pane_tokens(&panes, &tokens, CacheStore::now_millis(), row)
+}
+
+/// The layout the user chose and the meter size their sidebar affords,
+/// resolved once per refresh: the layout from the state-dir cache the publish
+/// hooks can see, the width from Herdr's own config.
+fn sidebar_shape(cache: &CacheStore) -> SidebarShape {
+    SidebarShape::new(
+        cache.sidebar_layout().unwrap_or_default(),
+        crate::configure::herdr::sidebar_width(),
+    )
 }
 
 fn resolved_pane_tokens(
@@ -482,7 +493,7 @@ fn resolved_pane_tokens(
     pane: &mut AgentPane,
     resolved: route::ResolvedPane,
     now: u64,
-    style: PercentStyle,
+    row: RowStyle,
     force: bool,
 ) -> Result<Option<PaneTokens>> {
     let route::ResolvedPane {
@@ -495,7 +506,7 @@ fn resolved_pane_tokens(
         Resolution::Subscription(target)
             if target.credential_scope == CredentialScope::OMP_STORE =>
         {
-            omp_quota(cache, &target, omp.as_ref(), now, style, force)
+            omp_quota(cache, &target, omp.as_ref(), now, row, force)
         }
         Resolution::Subscription(target) => {
             if let Some(provider) = target.original_provider() {
@@ -518,7 +529,7 @@ fn resolved_pane_tokens(
                     usable,
                     now,
                     pane.session.as_ref().and_then(|session| session.id()),
-                    style,
+                    row,
                 )
                 .map(|values| PaneQuotaUpdate::Replace(Box::new(values)))
             } else {
@@ -534,7 +545,7 @@ fn resolved_pane_tokens(
                     usable.as_ref(),
                     now,
                     pane.session.as_ref().and_then(|session| session.id()),
-                    style,
+                    row,
                 )
                 .map(|values| PaneQuotaUpdate::Replace(Box::new(values)))
             }
@@ -570,19 +581,11 @@ fn omp_quota(
     target: &BillingTarget,
     evidence: Option<&OmpEvidence>,
     now: u64,
-    style: PercentStyle,
+    row: RowStyle,
     force: bool,
 ) -> Option<PaneQuotaUpdate> {
     let evidence = evidence?;
-    omp_quota_with_refresh(
-        cache,
-        target,
-        evidence,
-        now,
-        style,
-        force,
-        refresh_omp_target,
-    )
+    omp_quota_with_refresh(cache, target, evidence, now, row, force, refresh_omp_target)
 }
 
 fn omp_quota_with_refresh(
@@ -590,7 +593,7 @@ fn omp_quota_with_refresh(
     target: &BillingTarget,
     evidence: &OmpEvidence,
     now: u64,
-    style: PercentStyle,
+    row: RowStyle,
     force: bool,
     refresh: impl FnOnce(&CacheStore, &BillingTarget, &OmpEvidence, u64) -> OmpUsage,
 ) -> Option<PaneQuotaUpdate> {
@@ -622,13 +625,13 @@ fn omp_quota_with_refresh(
         return cached
             .as_ref()
             .and_then(|snapshot| {
-                tokens_for_provider(Some(snapshot), now, None, style)
+                tokens_for_provider(Some(snapshot), now, None, row)
                     .map(|values| PaneQuotaUpdate::Replace(Box::new(values)))
             })
             .or_else(unavailable);
     }
     match refresh(cache, target, evidence, now) {
-        OmpUsage::Account(snapshot) => tokens_for_provider(Some(&snapshot), now, None, style)
+        OmpUsage::Account(snapshot) => tokens_for_provider(Some(&snapshot), now, None, row)
             .map(|values| PaneQuotaUpdate::Replace(Box::new(values))),
         // omp holds an API key for this provider and no subscription account
         // at all, so any subscription numbers still on the pane belong to a
@@ -640,7 +643,7 @@ fn omp_quota_with_refresh(
         OmpUsage::Unavailable | OmpUsage::Unknown => cached
             .as_ref()
             .and_then(|snapshot| {
-                tokens_for_provider(Some(snapshot), now, None, style)
+                tokens_for_provider(Some(snapshot), now, None, row)
                     .map(|values| PaneQuotaUpdate::Replace(Box::new(values)))
             })
             .or_else(unavailable),
@@ -1036,7 +1039,8 @@ fn publish_resolved(
     }
     let mut tokens = Vec::new();
     let now = CacheStore::now_unix();
-    let style = cache.percent_style().unwrap_or_default();
+    let shape = sidebar_shape(cache);
+    let row = RowStyle::new(cache.percent_style().unwrap_or_default(), shape);
     let mut refreshed_targets = Vec::new();
     for pane in panes.iter_mut() {
         let resolved = route::resolve_with_identity(pane);
@@ -1048,13 +1052,13 @@ fn publish_resolved(
             false
         };
         if let Some(pane_tokens) =
-            resolved_pane_tokens(cache, pane, resolved, now, style, force_target)?
+            resolved_pane_tokens(cache, pane, resolved, now, row, force_target)?
         {
             tokens.push(pane_tokens);
         }
     }
     notify_low_quota(cache, &tokens);
-    publish_pane_tokens(panes, &tokens, CacheStore::now_millis())
+    publish_pane_tokens(panes, &tokens, CacheStore::now_millis(), row)
 }
 
 /// The lowest headroom each provider is showing in this pass.
@@ -1253,10 +1257,16 @@ fn tokens_for_provider(
     snapshot: Option<&crate::model::ProviderSnapshot>,
     now_unix: u64,
     session_id: Option<&str>,
-    style: PercentStyle,
+    row: RowStyle,
 ) -> Option<MetadataTokens> {
     snapshot.map(|snapshot| {
-        MetadataTokens::from_snapshot_for_pane(snapshot, now_unix, session_id, style)
+        MetadataTokens::from_snapshot_for_pane(
+            snapshot,
+            now_unix,
+            session_id,
+            row.percent,
+            row.shape,
+        )
     })
 }
 
@@ -1266,10 +1276,10 @@ fn tokens_for_loaded_snapshot(
     usable: Option<&ProviderSnapshot>,
     now_unix: u64,
     session_id: Option<&str>,
-    style: PercentStyle,
+    row: RowStyle,
 ) -> Option<MetadataTokens> {
     match (usable, raw) {
-        (Some(snapshot), _) => tokens_for_provider(Some(snapshot), now_unix, session_id, style),
+        (Some(snapshot), _) => tokens_for_provider(Some(snapshot), now_unix, session_id, row),
         (None, Some(_)) => Some(MetadataTokens::unavailable(
             provider,
             "signed-in account changed",
@@ -1281,6 +1291,7 @@ fn tokens_for_loaded_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::{PercentStyle, SidebarLayout};
     use crate::model::{ProviderSnapshot, ResetAt, UsageWindow, WindowKind};
     use tempfile::tempdir;
 
@@ -1571,7 +1582,7 @@ mod tests {
                 &target,
                 &evidence,
                 110,
-                PercentStyle::default(),
+                RowStyle::default(),
                 false,
                 |_, _, _, _| panic!("must not spawn once per account"),
             );
@@ -1704,10 +1715,83 @@ mod tests {
         assert_eq!(cache.load(Provider::Grok).unwrap(), Some(snapshot));
     }
 
+    /// Both legs of the shape have to be live: the layout comes from the
+    /// state-dir cache the publish hooks can see, the meter size from the
+    /// width Herdr is actually rendering.
+    #[test]
+    fn the_sidebar_shape_carries_both_the_chosen_layout_and_the_rendered_width() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path().join("cache"));
+        cache.set_sidebar_layout(SidebarLayout::Gauges).unwrap();
+        let state = directory.path().join("state");
+        let shell = state.join("herdr/client-shell");
+        std::fs::create_dir_all(&shell).unwrap();
+        let absent_config = directory.path().join("absent.toml");
+        for (width, cells) in [(22, 6), (35, 12)] {
+            std::fs::write(
+                shell.join("local-abc.json"),
+                format!("{{\"sidebar_width\": {width}}}"),
+            )
+            .unwrap();
+            crate::prefs::testing::with_env(
+                &[
+                    ("HERDR_CONFIG_FILE", Some(absent_config.as_os_str())),
+                    ("XDG_STATE_HOME", Some(state.as_os_str())),
+                ],
+                || {
+                    let shape = sidebar_shape(&cache);
+                    assert_eq!(shape.layout, SidebarLayout::Gauges);
+                    assert_eq!(shape.meter_cells, Some(cells), "width {width}");
+                },
+            );
+        }
+    }
+
     #[test]
     fn missing_snapshot_does_not_overwrite_sidebar_with_unavailable() {
-        let values = tokens_for_provider(None, 1, None, PercentStyle::default());
+        let values = tokens_for_provider(None, 1, None, RowStyle::default());
         assert!(values.is_none());
+    }
+
+    /// The publish path reads the layout from the state dir. A layout on its
+    /// own carries no meter, so a cache that has one recorded still publishes
+    /// exactly what an empty cache publishes.
+    #[test]
+    fn a_recorded_sidebar_layout_does_not_change_a_published_token() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let snapshot = crate::model::ProviderSnapshot::new(
+            Provider::Claude,
+            vec![crate::model::UsageWindow::new(
+                WindowKind::FiveHour,
+                58.0,
+                Some(crate::model::ResetAt::from_unix_seconds(14_820)),
+            )
+            .unwrap()],
+            0,
+        );
+        let unset = tokens_for_provider(
+            Some(&snapshot),
+            0,
+            None,
+            RowStyle::new(
+                PercentStyle::default(),
+                cache.sidebar_layout().unwrap_or_default().into(),
+            ),
+        );
+        cache.set_sidebar_layout(SidebarLayout::Stacked).unwrap();
+        let stacked = tokens_for_provider(
+            Some(&snapshot),
+            0,
+            None,
+            RowStyle::new(
+                PercentStyle::default(),
+                cache.sidebar_layout().unwrap_or_default().into(),
+            ),
+        );
+        assert_eq!(cache.sidebar_layout(), Some(SidebarLayout::Stacked));
+        assert_eq!(unset, stacked);
+        assert_eq!(stacked.unwrap().quota_5h, "5h 42% 4h07m");
     }
 
     #[test]
@@ -1728,7 +1812,7 @@ mod tests {
             &target,
             &evidence,
             100,
-            PercentStyle::default(),
+            RowStyle::default(),
             false,
             |_, _, _, _| OmpUsage::Unavailable,
         )
@@ -1762,7 +1846,7 @@ mod tests {
             &target,
             &evidence,
             120,
-            PercentStyle::default(),
+            RowStyle::default(),
             false,
             |_, _, _, _| panic!("debounced refresh must not run"),
         );
@@ -1801,7 +1885,7 @@ mod tests {
             &target,
             &evidence,
             1_001,
-            PercentStyle::default(),
+            RowStyle::default(),
             false,
             |_, _, _, _| {
                 OmpUsage::Account(Box::new(
@@ -1850,7 +1934,7 @@ mod tests {
             &target,
             &evidence,
             200,
-            PercentStyle::default(),
+            RowStyle::default(),
             false,
             |_, _, _, _| OmpUsage::Unavailable,
         )
@@ -1876,7 +1960,7 @@ mod tests {
             None,
             1,
             None,
-            PercentStyle::default(),
+            RowStyle::default(),
         )
         .unwrap();
         assert_eq!(values.quota_week, "7d N/A");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -133,6 +133,13 @@ impl Settings {
         }
     }
 
+    /// Whether the sidebar Herdr is drawing has room for a meter at all.
+    /// Without one, `gauges` renders exactly as `stacked`, and the hint has
+    /// to say so rather than promise a bar the user will not see.
+    fn gauges_fit() -> bool {
+        crate::presentation::meter_cells(crate::configure::herdr::sidebar_width()).is_some()
+    }
+
     fn choice_hint(self, choice: Choice) -> &'static str {
         match choice {
             Choice::Percent => match self.percent {
@@ -142,6 +149,10 @@ impl Settings {
             Choice::Layout => match self.layout {
                 SidebarLayout::Packed => "cache·ttl and 5h·7d share a row",
                 SidebarLayout::Stacked => "every field on its own row",
+                SidebarLayout::Gauges => match Self::gauges_fit() {
+                    true => "a meter beside each quota number",
+                    false => "sidebar too narrow: renders as stacked",
+                },
             },
             Choice::RowGap => match self.gap.as_u8() {
                 0 => "panes packed flush",
@@ -195,10 +206,13 @@ impl Settings {
                 }
             }
             Row::Choice(Choice::Layout) => {
-                self.layout = match self.layout {
-                    SidebarLayout::Packed => SidebarLayout::Stacked,
-                    SidebarLayout::Stacked => SidebarLayout::Packed,
-                }
+                let current = SidebarLayout::CHOICES
+                    .iter()
+                    .position(|value| *value == self.layout)
+                    .unwrap_or(0);
+                let count = SidebarLayout::CHOICES.len() as i8;
+                let next = (current as i8 + step).rem_euclid(count);
+                self.layout = SidebarLayout::CHOICES[next as usize];
             }
             Row::Choice(Choice::RowGap) => {
                 self.gap = match self.gap.as_u8() {
@@ -648,6 +662,28 @@ mod tests {
         assert_eq!(draft.gap, SidebarRowGap::FLUSH);
         draft.cycle(Row::Choice(Choice::Brand), 1);
         assert_eq!(draft.brand, BrandColors::Off);
+    }
+
+    #[test]
+    fn the_layout_cycles_through_all_three_choices_in_both_directions() {
+        let mut draft = settings();
+        draft.cycle(Row::Choice(Choice::Layout), -1);
+        assert_eq!(draft.layout, SidebarLayout::Gauges);
+        draft.cycle(Row::Choice(Choice::Layout), 1);
+        assert_eq!(draft.layout, SidebarLayout::Packed);
+        for _ in 0..SidebarLayout::CHOICES.len() {
+            draft.cycle(Row::Choice(Choice::Layout), 1);
+        }
+        assert_eq!(draft.layout, SidebarLayout::Packed);
+
+        // The gauges hint is the longest of the three, so check it against the
+        // same width budget the frame test holds the other layouts to.
+        draft.cycle(Row::Choice(Choice::Layout), -1);
+        let frame = render(&draft, settings(), 2, 24, None);
+        assert!(frame.contains("gauges"), "{frame}");
+        for line in frame.trim_end_matches("\r\n").split("\r\n") {
+            assert!(line.chars().count() <= 70, "too wide: {line}");
+        }
     }
 
     #[test]

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -1902,6 +1902,114 @@ fn an_installer_can_select_flush_gap_through_the_plugin_config_dir() {
     );
 }
 
+#[test]
+fn gauges_sidebar_layout_is_persisted_across_a_repair() {
+    let root = tempdir().unwrap();
+    let homes = AgentHomes::new(root.path());
+    let output = homes.configure(&["--apply", "--sidebar-layout", "gauges"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        sidebar_is_gauges(&homes.sidebar()),
+        "first apply was not gauges: {}",
+        homes.sidebar()
+    );
+
+    assert!(homes.configure(&["--apply"]).status.success());
+    assert!(
+        sidebar_is_gauges(&homes.sidebar()),
+        "repair dropped gauges: {}",
+        homes.sidebar()
+    );
+
+    assert!(homes
+        .configure(&["--apply", "--sidebar-layout", "packed"])
+        .status
+        .success());
+    assert!(
+        sidebar_is_packed(&homes.sidebar()),
+        "explicit packed did not switch: {}",
+        homes.sidebar()
+    );
+}
+
+#[test]
+fn an_installer_can_select_gauges_layout_through_the_environment() {
+    let root = tempdir().unwrap();
+    let homes = AgentHomes::new(root.path());
+    let output = homes.configure_with_env(
+        &["--apply"],
+        &[("HERDR_AGENT_QUOTA_SIDEBAR_LAYOUT", "gauges")],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(sidebar_is_gauges(&homes.sidebar()), "{}", homes.sidebar());
+}
+
+#[test]
+fn an_installer_can_select_gauges_layout_through_the_plugin_config_dir() {
+    let root = tempdir().unwrap();
+    let homes = AgentHomes::new(root.path());
+    let config_dir = root.path().join("plugin-config");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(config_dir.join("sidebar-layout"), "gauges\n").unwrap();
+    let output = homes.configure_with_env(
+        &["--apply"],
+        &[("HERDR_PLUGIN_CONFIG_DIR", config_dir.to_str().unwrap())],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(sidebar_is_gauges(&homes.sidebar()), "{}", homes.sidebar());
+}
+
+/// A gauges install is only reversible if uninstall recognises the rows it
+/// wrote; otherwise it falls back to stripping tokens and the user never gets
+/// their own file back.
+#[test]
+fn a_full_uninstall_of_a_gauges_install_restores_the_original_config() {
+    let root = tempdir().unwrap();
+    let homes = AgentHomes::new(root.path());
+    let original = concat!(
+        "# hand-written\n",
+        "[ui]\nagent_panel_sort = \"spaces\"\n\n",
+        "[ui.sidebar.agents]\n",
+        "row_gap = 2\n",
+        "rows = [\n    [\"state_icon\", \"machine\"],\n    [\"agent\"],\n]\n",
+    );
+    fs::create_dir_all(homes.herdr_config.parent().unwrap()).unwrap();
+    fs::write(&homes.herdr_config, original).unwrap();
+
+    assert!(homes
+        .configure(&["--apply", "--sidebar-layout", "gauges"])
+        .status
+        .success());
+    assert!(sidebar_is_gauges(&homes.sidebar()), "{}", homes.sidebar());
+
+    assert!(homes.configure(&["--uninstall"]).status.success());
+    assert_eq!(homes.sidebar(), original);
+}
+
+fn sidebar_is_gauges(sidebar: &str) -> bool {
+    !quota_tokens_share_a_row(sidebar, "$quota_cache", "$quota_cache_ttl")
+        && !quota_tokens_share_a_row(sidebar, "$quota_context", "$quota_week_inline_normal")
+        && !quota_tokens_share_a_row(sidebar, "$quota_5h_normal", "$quota_week_normal")
+        && !tab_shares_row_with_provider_model(sidebar)
+        && sidebar_has_token(sidebar, "$quota_provider_model")
+        && !sidebar_has_token(sidebar, "$quota_provider")
+        && !sidebar_has_token(sidebar, "$quota_model")
+        && sidebar.contains("$quota_cache")
+        && sidebar.contains("$quota_week_normal")
+}
+
 fn sidebar_is_packed(sidebar: &str) -> bool {
     quota_tokens_share_a_row(sidebar, "$quota_cache", "$quota_cache_ttl")
         && quota_tokens_share_a_row(sidebar, "$quota_5h_normal", "$quota_week_normal")


### PR DESCRIPTION
## What this changes

Adds `gauges` as a third `sidebar-layout` value. Each quota field gets its own row with a unicode meter beside the number the plugin already prints, so remaining headroom reads as a bar length before any digit is read:

```
cx ▰▰▰▰▰▱▱▱▱▱▱▱  43%
5h ▰▰▰▰▱▱▱▱▱▱▱▱  33% 2h07m
7d ▰▰▰▱▱▱▱▱▱▱▱▱  24% 4d11h
```

Four decisions worth surfacing for review:

- **The bars live inside existing token values.** A meter as its own token would need a severity-suffixed name per window, and `METADATA_TOKEN_NAMES` is already at 22 against a 16-token report cap. The one addition is `quota_context_{normal,warning,danger}`, because the context row cannot take colour without a name per colour the way the windows have; only one is ever non-empty, and all three are registered in `METADATA_TOKEN_NAMES`, `ROWS_THAT_MUST_NOT_LAG`, `QUOTA_ROW_MARKERS` and `field_for_token`.
- **`packed` and `stacked` are byte-identical**, in the written `config.toml` and in every published token value, pinned by SHA-256 digests captured from a pre-change build (`packed_and_stacked_write_the_same_bytes_as_before_gauges`).
- **Cell count follows the width Herdr renders**, read from the client-shell state file (`sidebar_width`) and falling back to `ui.sidebar_width` then 26 — the auto-scaled width can differ from the configured one. Capped at twelve; below four cells the row renders exactly as `stacked` rather than truncating the number the bar labels.
- **Colour always reads headroom, never the printed number**, so a bar that fills as you spend and one that drains as you spend both mean the same thing. Every gauges row prints the one quantity `quota-percent` selects, including the context row, so the column reads as one scale.

Glyphs are `▰` U+25B0 / `▱` U+25B1, both East-Asian-Width Neutral (verified) so they stay single-width in CJK locales; the obvious alternatives (`█`, `●`, `━`) are Ambiguous and would double up. The label column is two characters, so `context` renders as `cx` and `30d` as `mo` — a monthly plan carries its only recurring quota on that row and would otherwise lose its meter — while a provider-named window is never rewritten and keeps the plain row.

No screenshot for the README table: mine shows real workspace names I cannot publish. Happy to add one you capture, or to drop the table row entirely if you would rather not have a third column.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --release --all-targets --all-features -- -D warnings` (clean on the pinned 1.95.0; a local Homebrew 1.98 raises one pre-existing `question_mark` in `src/providers/omp.rs`, untouched here)
- [x] `cargo test --all-targets --all-features --locked` — 477 lib + 64 integration, 0 failures
- [x] No parser change, so no new fixture needed
- [x] No new network call, background process, or credential write

## Provider impact

None — rendering only. All providers; no CLI version dependency. Verified live against Claude panes on Herdr 0.9.0.