### PR TITLE
chore: release v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.5.4] - 2026-09-10
+
 ### Added
 
 - A third sidebar layout, `gauges`, now the default: each quota field gets
@@ -649,7 +651,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - A popup dashboard pane, event-driven refresh, and a local snapshot cache that
   survives provider failures.
 
-[Unreleased]: https://github.com/levi-qiao/herdr-agent-quota/compare/v1.5.3...HEAD
+[Unreleased]: https://github.com/levi-qiao/herdr-agent-quota/compare/v1.5.4...HEAD
+[1.5.4]: https://github.com/levi-qiao/herdr-agent-quota/compare/v1.5.3...v1.5.4
 [1.5.3]: https://github.com/levi-qiao/herdr-agent-quota/compare/v1.5.2...v1.5.3
 [1.5.2]: https://github.com/levi-qiao/herdr-agent-quota/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/levi-qiao/herdr-agent-quota/compare/v1.5.0...v1.5.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-agent-quota"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-agent-quota"
-version = "1.5.3"
+version = "1.5.4"
 edition = "2021"
 rust-version = "1.95"
 description = "Credential-scoped AI quota and context in Herdr for Claude, Codex, Grok, Agy, OpenCode, Pi, omp, and Devin"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr-agent-quota"
 name = "Herdr Agent Quota"
-version = "1.5.3"
+version = "1.5.4"
 min_herdr_version = "0.9.0"
 description = "Credential-scoped AI quota and context for Claude, Codex, Grok, Agy, OpenCode, Pi, omp, and Devin."
 platforms = ["macos", "linux"]


### PR DESCRIPTION
## What this changes

Patch release so public versioning matches current `main` tip after #70 and #72.

- Move the Unreleased gauges notes into `## [1.5.4] - 2026-09-10`.
- Leave an empty `## [Unreleased]` section.
- Bump the same version fields as v1.5.3: `Cargo.toml`, `Cargo.lock`, `herdr-plugin.toml`.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-targets --all-features --locked`
- [x] `cargo clippy --release --all-targets --all-features --locked -- -D warnings`

## Provider impact

none — version/changelog only. Gauges layout shipped in #70 and #72.