### PR TITLE
feat: make the sidebar provider name an optional field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- The provider name is a sidebar field like any other: `--fields` and the
+  settings pane accept `provider`, listed first. It defaults on, so an
+  existing configuration renders exactly as before; turning it off leaves the
+  row with its icon and numbers. A packed identity row follows its two halves,
+  so hiding the model degrades `$quota_provider_model` to `$quota_provider`,
+  hiding the provider degrades it to `$quota_model`, and hiding both writes
+  no identity row. The error token stays unconditional: it says the plugin
+  could not speak for a pane, which is a failure, not a field.
+
 ## [1.5.4] - 2026-09-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ herdr plugin pane open --plugin herdr-agent-quota --entrypoint settings --focus
 | Layout | `gauges` (default) adds a meter beside each quota number; `packed` groups related fields; `stacked` gives each field a row |
 | Row gap | Zero or one blank line between agents |
 | Watch interval | 30 seconds–1 hour; default 60 seconds |
-| Fields | Topic, model, cache, TTL, context, short/long quota |
+| Fields | Provider, topic, model, cache, TTL, context, short/long quota |
 | Brand colors | On or off |
 | Agent order | Herdr default or lowest remaining quota first |
 | Low quota alert | Off or a threshold from 1% to 100% |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,7 +69,7 @@ herdr plugin pane open --plugin herdr-agent-quota --entrypoint settings --focus
 | Layout | `gauges`（默认）在每个额度数字旁加进度条；`packed` 合并相关字段；`stacked` 将字段分行显示 |
 | Row gap | Agent 之间保留零行或一行空白 |
 | Watch interval | 30 秒–1 小时，默认 60 秒 |
-| Fields | 主题、模型、缓存、TTL、上下文、短期／长期额度 |
+| Fields | 提供方、主题、模型、缓存、TTL、上下文、短期／长期额度 |
 | Brand colors | 开启或关闭品牌色 |
 | Agent order | Herdr 默认排序，或剩余额度最少的优先 |
 | Low quota alert | 关闭，或设置 1%–100% 的提醒阈值 |

--- a/install.sh
+++ b/install.sh
@@ -28,8 +28,8 @@
 # how much has been consumed. The colour always follows what is left.
 #
 # --fields picks the quota fields the sidebar shows: all (default), none, or a
-# comma-separated list of topic, model, cache, ttl, context, 5h, 7d. The
-# provider and the error token are always shown.
+# comma-separated list of provider, topic, model, cache, ttl, context, 5h, 7d.
+# The error token is always shown.
 #
 # --brand-colors on (default) tints provider and model with each agent's hue;
 # off leaves them in the sidebar's own text colour. Severity colours stay.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,8 +98,8 @@ pub enum Command {
         #[arg(long, value_enum)]
         quota_percent: Option<PercentStyle>,
         /// Quota fields the sidebar shows: all (default), none, or a
-        /// comma-separated list of topic, model, cache, ttl, context, 5h, 7d.
-        /// Provider and the error token are always shown.
+        /// comma-separated list of provider, topic, model, cache, ttl,
+        /// context, 5h, 7d. The error token is always shown.
         #[arg(long, value_parser = parse_field_set)]
         fields: Option<FieldSet>,
         /// Whether provider and model carry each agent's brand hue. Severity
@@ -191,12 +191,14 @@ pub enum SidebarLayout {
 
 /// A quota field the sidebar can be told to leave out.
 ///
-/// Provider is not here: it is the identity of the row, and a row that cannot
-/// say which subscription it belongs to is worse than no row. `$quota_error`
-/// is not here either — it is how the plugin reports that it could not speak
-/// for a pane at all, and hiding it would hide the failure, not the field.
+/// Provider is the identity of the row, so leaving it out costs the row its
+/// name; it is a real choice (a sidebar of numbers alone is a choice someone
+/// can make) and not a safe default, which is why it starts on. `$quota_error`
+/// is not here: it is how the plugin reports that it could not speak for a pane
+/// at all, and hiding it would hide the failure, not the field.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SidebarField {
+    Provider,
     Topic,
     Model,
     Cache,
@@ -207,7 +209,8 @@ pub enum SidebarField {
 }
 
 impl SidebarField {
-    pub const ALL: [Self; 7] = [
+    pub const ALL: [Self; 8] = [
+        Self::Provider,
         Self::Topic,
         Self::Model,
         Self::Cache,
@@ -219,6 +222,7 @@ impl SidebarField {
 
     pub fn name(self) -> &'static str {
         match self {
+            Self::Provider => "provider",
             Self::Topic => "topic",
             Self::Model => "model",
             Self::Cache => "cache",

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -909,8 +909,8 @@ fn is_standalone_agent_row(row: &Array) -> bool {
 
 fn append_quota_rows(rows: &mut Array, layout: SidebarLayout) {
     // Gauges shares packed's identity line and stacked's body: the identity is
-    // not a quota field so it stays compact, while a meter needs its own row
-    // per field. Both halves are shared rather than copied so they cannot drift.
+    // one name, not a quota gauge, so it stays compact, while a meter needs its
+    // own row per field. Both halves are shared rather than copied so they cannot drift.
     match layout {
         SidebarLayout::Packed | SidebarLayout::Gauges => append_identity_row(rows),
         SidebarLayout::Stacked => {
@@ -1029,20 +1029,31 @@ fn retain_selected_fields(rows: &mut Array, fields: FieldSet) {
         };
         let mut retained = Array::new();
         for item in items.iter() {
-            match configured_token_name(item).and_then(field_for_token) {
-                Some(field) if !fields.contains(field) => {
-                    // `$quota_provider_model` carries the identity as well as
-                    // the model, so hiding the model degrades it to the
-                    // provider instead of removing the row's only name.
-                    if configured_token_name(item) == Some("$quota_provider_model") {
-                        retained.push(styled_token(
-                            "$quota_provider",
-                            None,
-                            Some(true),
-                            Some(false),
-                        ));
+            // `$quota_provider_model` carries two fields on one token, so
+            // `field_for_token` cannot decide it: hiding the model degrades it
+            // to the provider, hiding the provider degrades it to the model,
+            // and hiding both drops the identity line.
+            if configured_token_name(item) == Some("$quota_provider_model") {
+                match (
+                    fields.contains(SidebarField::Provider),
+                    fields.contains(SidebarField::Model),
+                ) {
+                    (true, true) => retained.push(item.clone()),
+                    (true, false) => retained.push(styled_token(
+                        "$quota_provider",
+                        None,
+                        Some(true),
+                        Some(false),
+                    )),
+                    (false, true) => {
+                        retained.push(styled_token("$quota_model", None, Some(false), Some(false)))
                     }
+                    (false, false) => {}
                 }
+                continue;
+            }
+            match configured_token_name(item).and_then(field_for_token) {
+                Some(field) if !fields.contains(field) => {}
                 _ => retained.push(item.clone()),
             }
         }
@@ -1054,11 +1065,13 @@ fn retain_selected_fields(rows: &mut Array, fields: FieldSet) {
 }
 
 /// The field a published token belongs to, or `None` for a token that is not
-/// optional (the provider identity and the error channel).
+/// optional (the `$quota_error` channel). `$quota_provider_model` is not here:
+/// it names two fields at once and is decided in `retain_selected_fields`.
 fn field_for_token(token: &str) -> Option<SidebarField> {
     match token {
+        "$quota_provider" => Some(SidebarField::Provider),
         "$quota_topic" => Some(SidebarField::Topic),
-        "$quota_model" | "$quota_provider_model" => Some(SidebarField::Model),
+        "$quota_model" => Some(SidebarField::Model),
         "$quota_cache" | "$quota_cache_state" => Some(SidebarField::Cache),
         "$quota_cache_ttl" => Some(SidebarField::Ttl),
         "$quota_context"
@@ -2555,11 +2568,64 @@ mod field_tests {
         assert!(!packed.contains("$quota_model"), "{packed}");
     }
 
+    /// Hiding the provider must not take the row's model with it, and the
+    /// degraded token must still be a token the theming pass knows.
     #[test]
-    fn hiding_every_optional_field_keeps_the_official_row_and_the_provider() {
+    fn hiding_the_provider_leaves_the_model_on_the_identity_row() {
+        let packed = applied(
+            FieldSet::all().toggled(SidebarField::Provider),
+            BrandColors::On,
+        );
+        assert!(packed.contains("$quota_model\""), "{packed}");
+        assert!(!packed.contains("$quota_provider_model"), "{packed}");
+        assert!(!packed.contains("$quota_provider\""), "{packed}");
+    }
+
+    /// The user's own selection (`fields = 5h`) must leave no identity row at
+    /// all, and applying it twice must land on the same config.
+    #[test]
+    fn a_single_field_selection_writes_no_identity_row() {
+        let fields = FieldSet::parse("5h").unwrap();
+        let once = applied(fields, BrandColors::On);
+        assert!(!once.contains("$quota_provider"), "{once}");
+        assert!(once.contains("$quota_5h"), "{once}");
+        let twice = add_quota_row_with(
+            &once,
+            &AgentSelection::SUPPORTED,
+            SidebarLayout::Packed,
+            SidebarRowGap::default(),
+            fields,
+            BrandColors::On,
+        )
+        .unwrap();
+        assert_eq!(once, twice);
+    }
+
+    /// In `stacked` the provider and the model sit on rows of their own, so a
+    /// hidden provider has to take its row and leave the model's alone.
+    #[test]
+    fn a_stacked_layout_drops_the_provider_row_with_the_field() {
+        let stacked = add_quota_row_with(
+            "",
+            &AgentSelection::SUPPORTED,
+            SidebarLayout::Stacked,
+            SidebarRowGap::default(),
+            FieldSet::all().toggled(SidebarField::Provider),
+            BrandColors::On,
+        )
+        .unwrap();
+        assert!(!stacked.contains("$quota_provider\""), "{stacked}");
+        assert!(stacked.contains("$quota_model\""), "{stacked}");
+    }
+
+    #[test]
+    fn hiding_every_field_keeps_only_the_official_row_and_the_error_token() {
         let bare = applied(FieldSet::parse("none").unwrap(), BrandColors::On);
         assert!(bare.contains("state_icon"), "{bare}");
-        assert!(bare.contains("$quota_provider\""), "{bare}");
+        // The identity row is a field like any other: `none` means none of it.
+        assert!(!bare.contains("$quota_provider"), "{bare}");
+        // The error token is not optional: it is how a broken pane is reported.
+        assert!(bare.contains("$quota_error"), "{bare}");
         for token in ["$quota_topic", "$quota_context", "$quota_5h", "$quota_week"] {
             assert!(!bare.contains(token), "{token} survived:\n{}", rows(&bare));
         }
@@ -2667,6 +2733,10 @@ mod field_tests {
         assert!(modelless.contains("$quota_provider\""), "{modelless}");
         assert!(!modelless.contains("$quota_provider_model"), "{modelless}");
         assert!(!modelless.contains("$quota_model"), "{modelless}");
+
+        let providerless = gauges(FieldSet::all().toggled(SidebarField::Provider));
+        assert!(providerless.contains("$quota_model\""), "{providerless}");
+        assert!(!providerless.contains("$quota_provider"), "{providerless}");
     }
 
     /// Uninstall has to recognise rows written with a non-default selection,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -742,7 +742,7 @@ mod tests {
                 "--brand-colors",
                 "on",
                 "--fields",
-                "model,cache,ttl,context,5h,7d",
+                "provider,model,cache,ttl,context,5h,7d",
                 "--agent-order",
                 "default",
                 "--low-quota-alert",


### PR DESCRIPTION
## What this changes

Makes the provider name a sidebar field, so a row can be rendered without it.
`--fields` and the settings pane now accept `provider`, listed first in the
fields section, and it is **on by default** — an existing configuration renders
exactly as before. Fixes #74.

The provider was the one label `--fields` could not remove: it was written
outside the field list, and hiding `model` only degraded a packed identity row
*to* `$quota_provider`. Removing it meant hand-editing `rows` /
`rows_by_agent`, which gives up the plugin's management of those rows.

- `SidebarField::Provider` is first in `ALL`; `$quota_provider` maps to it in
  `field_for_token`.
- `$quota_provider_model` carries two fields, so `retain_selected_fields`
  handles its four combinations: keep it, degrade it to `$quota_model` when
  the provider is off, to `$quota_provider` when the model is off, and write
  no identity row when both are off.
- `$quota_error` stays unconditional. It reports that the plugin could not
  speak for a pane, which is a failure rather than a field.
- `provider` is still published as a metadata token; this only changes what
  `configure` writes into the layout.

Tests: hiding every field leaves only the official row and the error token,
hiding the provider keeps the model on the identity row, a single-field
selection writes no identity row (packed and stacked), and the stacked layout
drops the provider row with the field.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features --locked`
- [ ] A parser change comes with a fixture in `tests/fixtures/` and a test
      — not a parser change; no token grammar changed
- [x] No new network call, background process, or credential write

## Provider impact

None specific to one CLI. This changes the layout `configure` writes for every
agent that has quota rows; the token grammar, the collectors, and the published
metadata are untouched. Checked against a live Herdr session running OpenCode
Go (plugin v1.5.4, Herdr 0.9+ endpoint), applying the change with
`herdr plugin action invoke configure --plugin herdr-agent-quota`:
`diagnostics: []`, re-running it produces a byte-identical config, and with
`fields = 5h` every pane renders as

```
 ● tmp · π ⠦
   5h 100% 4h59m
```
