### PR TITLE
fix: republish an idle pane whose cached quota moved on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- An idle pane now follows its own session's quota as soon as the cache has it.
+  A Claude statusLine hook only writes the observation mailbox, so a pane that
+  never starts a turn kept publishing whatever it last published: one pane sat
+  on `7d 24%` and `5h N/A` while its session's stored windows had moved on and
+  every sibling pane showed the new reading. A watch pass now also covers an
+  idle pane whose published quota rows differ from the ones its cached
+  snapshot would render, alongside the existing expired-window case.
 - A `fields` preference saved before the provider was a field no longer hides
   the provider on upgrade. Those builds wrote "everything on" as
   `topic,model,cache,ttl,context,5h,7d` and drew the provider name regardless,

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -52,6 +52,24 @@ const METADATA_TOKEN_NAMES: [&str; 25] = [
 /// costs no extra writes — the value only moves when a quota token beside it
 /// moves anyway.
 pub(crate) const HEADROOM_TOKEN: &str = "quota_headroom";
+/// The subset of [`METADATA_TOKEN_NAMES`] whose value comes from the cached
+/// quota windows and nothing else. [`quota_rows_have_drifted`] compares these,
+/// so a name added here must be one a snapshot alone can render.
+const QUOTA_WINDOW_TOKEN_NAMES: [&str; 13] = [
+    "quota_5h_normal",
+    "quota_5h_warning",
+    "quota_5h_danger",
+    "quota_5h_unknown",
+    "quota_week_normal",
+    "quota_week_warning",
+    "quota_week_danger",
+    "quota_week_unknown",
+    "quota_week_inline_normal",
+    "quota_week_inline_warning",
+    "quota_week_inline_danger",
+    "quota_week_inline_unknown",
+    HEADROOM_TOKEN,
+];
 /// Names a pane may still carry from an older build of this plugin. They are
 /// never produced again, so a report clears them until the pane is clean.
 const OBSOLETE_METADATA_TOKEN_NAMES: [&str; 15] = [
@@ -765,6 +783,33 @@ fn fold_cache_row(tokens: &mut BTreeMap<String, String>, row: RowStyle) {
         tokens.insert("quota_cache".to_string(), joined);
         tokens.remove("quota_cache_ttl");
     }
+}
+
+/// True when the quota rows this pane is carrying are not the ones `values`
+/// would render.
+///
+/// Only the window rows are comparable against a snapshot alone: publishing
+/// rewrites provider, model, context and cache rows from pane-local evidence
+/// this caller does not have, so including them would report drift that no
+/// republish can settle.
+///
+/// A pane carrying no quota row at all has never been published to, and is not
+/// drift: waking those would pull every quota-less pane into every pass.
+pub(crate) fn quota_rows_have_drifted(
+    current: &BTreeMap<String, String>,
+    values: &MetadataTokens,
+    shape: SidebarShape,
+) -> bool {
+    if !QUOTA_WINDOW_TOKEN_NAMES
+        .into_iter()
+        .any(|name| current.contains_key(name))
+    {
+        return false;
+    }
+    let desired = desired_tokens(values, "", shape);
+    QUOTA_WINDOW_TOKEN_NAMES
+        .into_iter()
+        .any(|name| current.get(name) != desired.get(name))
 }
 
 fn metadata_matches(

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -224,10 +224,11 @@ fn pane_in_watch_scope(pane: &AgentPane, providers: &[Provider]) -> bool {
             .is_some_and(|provider| providers.contains(&provider))
 }
 
-/// Working and settling panes, plus idle panes whose displayed quota has lapsed.
+/// Working and settling panes, plus idle panes the cache has left behind.
 ///
-/// An expired window is no longer a live reading. Including those pane ids in
-/// an already-running watch pass rewrites the sidebar after a reset without
+/// An idle pane is only ever republished by a pass it is named in, so a pane
+/// that never starts a turn shows whatever it last published. Including those
+/// pane ids in an already-running watch pass rewrites the sidebar without
 /// waiting for that pane to start a turn, and without starting a second
 /// watcher while everything is idle.
 fn watch_pass_ids(
@@ -240,31 +241,51 @@ fn watch_pass_ids(
     now: u64,
 ) -> Vec<String> {
     let mut affected = watch_targets(active, previous, settling, now);
+    // Reading the row style costs the config file, so a pass with no idle
+    // candidate at all must not pay for it.
+    let mut style = None;
     for pane in panes {
         if !pane_in_watch_scope(pane, providers) || affected.contains(&pane.pane_id) {
             continue;
         }
-        if cached_quota_has_expired(cache, pane, now) {
+        let row = *style.get_or_insert_with(|| publish_row(cache));
+        if cached_quota_is_stale(cache, pane, now, row) {
             affected.push(pane.pane_id.clone());
         }
     }
     affected
 }
 
-fn cached_quota_has_expired(cache: &CacheStore, pane: &AgentPane, now: u64) -> bool {
+/// True when what this pane is showing is no longer what the cache says.
+///
+/// Two separate readings are stale, and neither implies the other:
+///
+/// - the window the pane shows has reset, so the number on it is not a live
+///   reading whatever the cache holds; and
+/// - the cache has moved on while nothing woke this pane to republish it.
+///   Claude's statusLine hook only writes the observation mailbox, so an idle
+///   pane whose session gained a fresh window has no other way back in.
+///
+/// A pane already showing `N/A` for an expired window is the case the second
+/// reading misses: the rendered rows agree, and only the first pulls it in for
+/// the fetch that replaces them.
+///
+/// This decides membership only. It loads the one snapshot the pass would read
+/// anyway and publishes nothing.
+fn cached_quota_is_stale(cache: &CacheStore, pane: &AgentPane, now: u64, row: RowStyle) -> bool {
     let Resolution::Subscription(target) = route::resolve(pane) else {
         return false;
     };
-    cache
-        .load_target(&target)
-        .ok()
-        .flatten()
-        .is_some_and(|snapshot| {
-            snapshot.displayed_quota_has_expired(
-                pane.session.as_ref().and_then(|session| session.id()),
-                now,
-            )
-        })
+    let Some(snapshot) = cache.load_target(&target).ok().flatten() else {
+        return false;
+    };
+    let session_id = pane.session.as_ref().and_then(|session| session.id());
+    if snapshot.displayed_quota_has_expired(session_id, now) {
+        return true;
+    }
+    let values =
+        MetadataTokens::from_snapshot_for_pane(&snapshot, now, session_id, row.percent, row.shape);
+    crate::herdr::quota_rows_have_drifted(&pane.tokens, &values, row.shape)
 }
 
 fn wait_for_watch_tick(
@@ -454,11 +475,7 @@ fn handle_named_pane(cache: &CacheStore, pane: AgentPane, topic_pane: Option<&st
             refresh_selected(cache, &[provider], false, &panes)?;
         }
     }
-    let shape = sidebar_shape(cache);
-    let row = RowStyle {
-        fields: cache.fields().unwrap_or_default(),
-        ..RowStyle::new(cache.percent_style().unwrap_or_default(), shape)
-    };
+    let row = publish_row(cache);
     let tokens = resolved_pane_tokens(
         cache,
         &mut panes[0],
@@ -486,6 +503,17 @@ fn sidebar_shape(cache: &CacheStore) -> SidebarShape {
         cache.sidebar_layout().unwrap_or_default(),
         crate::configure::herdr::sidebar_width(),
     )
+}
+
+/// The row style every pane in one pass is rendered with.
+fn publish_row(cache: &CacheStore) -> RowStyle {
+    RowStyle {
+        fields: cache.fields().unwrap_or_default(),
+        ..RowStyle::new(
+            cache.percent_style().unwrap_or_default(),
+            sidebar_shape(cache),
+        )
+    }
 }
 
 /// Muse's session summary is the last submitted prompt, the same evidence
@@ -1053,11 +1081,7 @@ fn publish_resolved(
     }
     let mut tokens = Vec::new();
     let now = CacheStore::now_unix();
-    let shape = sidebar_shape(cache);
-    let row = RowStyle {
-        fields: cache.fields().unwrap_or_default(),
-        ..RowStyle::new(cache.percent_style().unwrap_or_default(), shape)
-    };
+    let row = publish_row(cache);
     let mut refreshed_targets = Vec::new();
     for pane in panes.iter_mut() {
         let resolved = route::resolve_with_identity(pane);
@@ -1581,6 +1605,149 @@ mod tests {
         assert!(!affected.contains(&"claude-live".to_string()));
     }
 
+    #[test]
+    fn an_idle_pane_follows_its_sessions_new_windows_without_an_agent_event() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let mut snapshot = ProviderSnapshot::new(Provider::Claude, vec![], 900).session_local();
+        snapshot.session_windows.insert(
+            "sibling".to_string(),
+            vec![window(WindowKind::FiveHour, 20.0, 9_000)],
+        );
+        cache.save(&snapshot).unwrap();
+
+        // Its own session had no stored window, so the pane published N/A.
+        let mut idle = test_pane_with_session("claude-idle", Harness::Claude, "s1");
+        idle.tokens
+            .insert("quota_5h_unknown".to_string(), "5h N/A".to_string());
+        let panes = [idle, test_pane("grok-working", Harness::Grok)];
+        let grok = "grok-working".to_string();
+        let mut settling = BTreeMap::new();
+
+        let unchanged = watch_pass_ids(
+            &cache,
+            &panes,
+            &Provider::ALL,
+            std::slice::from_ref(&grok),
+            std::slice::from_ref(&grok),
+            &mut settling,
+            1_001,
+        );
+        assert!(!unchanged.contains(&"claude-idle".to_string()));
+
+        snapshot.session_windows.insert(
+            "s1".to_string(),
+            vec![
+                window(WindowKind::FiveHour, 40.0, 9_000),
+                window(WindowKind::Weekly, 20.0, 90_000),
+            ],
+        );
+        cache.save(&snapshot).unwrap();
+
+        let affected = watch_pass_ids(
+            &cache,
+            &panes,
+            &Provider::ALL,
+            std::slice::from_ref(&grok),
+            std::slice::from_ref(&grok),
+            &mut settling,
+            1_001,
+        );
+        assert!(affected.contains(&"claude-idle".to_string()));
+    }
+
+    #[test]
+    fn an_idle_pane_already_showing_the_cached_windows_stays_out_of_the_pass() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let mut snapshot = ProviderSnapshot::new(Provider::Claude, vec![], 900).session_local();
+        snapshot.session_windows.insert(
+            "s1".to_string(),
+            vec![
+                window(WindowKind::FiveHour, 40.0, 9_000),
+                window(WindowKind::Weekly, 20.0, 90_000),
+            ],
+        );
+        cache.save(&snapshot).unwrap();
+
+        let row = publish_row(&cache);
+        let values = MetadataTokens::from_snapshot_for_pane(
+            &snapshot,
+            1_001,
+            Some("s1"),
+            row.percent,
+            row.shape,
+        );
+        assert_eq!(
+            values.quota_5h_severity,
+            Some(crate::model::Severity::Normal)
+        );
+        assert_eq!(
+            values.quota_week_severity,
+            Some(crate::model::Severity::Normal)
+        );
+        let mut idle = test_pane_with_session("claude-idle", Harness::Claude, "s1");
+        idle.tokens
+            .insert("quota_5h_normal".to_string(), values.quota_5h.clone());
+        idle.tokens
+            .insert("quota_week_normal".to_string(), values.quota_week.clone());
+        idle.tokens.insert(
+            "quota_headroom".to_string(),
+            format!("{:03}", values.quota_headroom.unwrap()),
+        );
+        let panes = [idle, test_pane("grok-working", Harness::Grok)];
+        let grok = "grok-working".to_string();
+        let mut settling = BTreeMap::new();
+
+        let affected = watch_pass_ids(
+            &cache,
+            &panes,
+            &Provider::ALL,
+            std::slice::from_ref(&grok),
+            std::slice::from_ref(&grok),
+            &mut settling,
+            1_001,
+        );
+        assert_eq!(affected, vec![grok]);
+    }
+
+    #[test]
+    fn new_windows_for_one_session_leave_another_sessions_idle_pane_alone() {
+        let directory = tempdir().unwrap();
+        let cache = CacheStore::new(directory.path());
+        let mut snapshot = ProviderSnapshot::new(Provider::Claude, vec![], 900).session_local();
+        cache.save(&snapshot).unwrap();
+
+        let mut first = test_pane_with_session("claude-first", Harness::Claude, "s1");
+        first
+            .tokens
+            .insert("quota_5h_unknown".to_string(), "5h N/A".to_string());
+        let mut second = test_pane_with_session("claude-second", Harness::Claude, "s2");
+        second
+            .tokens
+            .insert("quota_5h_unknown".to_string(), "5h N/A".to_string());
+        let panes = [first, second, test_pane("grok-working", Harness::Grok)];
+        let grok = "grok-working".to_string();
+        let mut settling = BTreeMap::new();
+
+        snapshot.session_windows.insert(
+            "s1".to_string(),
+            vec![window(WindowKind::FiveHour, 40.0, 9_000)],
+        );
+        cache.save(&snapshot).unwrap();
+
+        let affected = watch_pass_ids(
+            &cache,
+            &panes,
+            &Provider::ALL,
+            std::slice::from_ref(&grok),
+            std::slice::from_ref(&grok),
+            &mut settling,
+            1_001,
+        );
+        assert!(affected.contains(&"claude-first".to_string()));
+        assert!(!affected.contains(&"claude-second".to_string()));
+    }
     #[test]
     fn omp_panes_keep_both_accounts_from_one_debounced_report() {
         let dir = tempdir().unwrap();


### PR DESCRIPTION
Closes #71.

## What this changes

An idle pane kept publishing quota rows the cache had already outrun. Observed across ten panes on one machine: one pane published `7d … 24%` while its own session's stored weekly was `27%` and every sibling pane already showed `27%`.

`watch_pass_ids` only pulled an idle pane in when `cached_quota_has_expired` fired. That covers "this pane's window has run out, go refetch" but not "the cache moved on and this pane's published rows never followed" — so a pane whose session got a fresh observation while idle stayed stale until its next event, focus, or full refresh.

`cached_quota_has_expired` becomes `cached_quota_is_stale`: same single `load_target`, expiry check first and unchanged, then a drift comparison. The new `quota_rows_have_drifted` renders the pane's tokens from the loaded snapshot and compares only the 13 names a snapshot alone can render (the three window families plus `quota_headroom`) — provider, model, context and cache rows are rewritten at publish from pane-local evidence this caller does not have, so comparing them would report drift no republish could settle. A pane carrying no quota row at all is never woken by drift; otherwise every quota-less pane would join every pass.

**The two checks are both needed — the drift check does not subsume expiry.** Verified by short-circuiting the expiry branch and re-running: `an_idle_pane_with_an_expired_window_joins_a_running_watch_pass` and `an_expired_session_does_not_pull_a_live_sibling_into_the_watch_pass` both go red. Rendering runs `live_windows`, so an expired window renders the same `N/A` the pane may already carry — zero drift, no wake, no refetch. Expiry triggers the *refetch*; drift repairs a *publish*. They are ORed.

Per the scope you set on #71: session attribution is untouched (the render goes through `from_snapshot_for_pane` → `windows_for_session`, so an idle session with no stored windows renders `N/A` rather than borrowing account-level windows), and `windows_for_session`, `live_windows` and `five_hour_slot` are unmodified — the ten-pane dump showed those were already correct.

**Cost:** no new I/O per pane — the predicate reuses the `load_target` the expiry check already did, and everything after is in-memory rendering. One new per-pass read for the row style, computed lazily so a pass with nothing to check pays nothing; it is the same work `publish_resolved` does on the same tick.

One second-order note I did not act on: a pane whose snapshot fails `usable_for_account` publishes `unavailable` while this predicate renders from the raw snapshot, so it can report drift each tick. Closing that would mean per-pane credential reads, well past the I/O budget above. The wake is bounded — it costs a debounced refresh attempt, `metadata_matches` still suppresses the write, and `watch_pass_ids` does not keep the watcher alive — but say the word if you would rather gate it.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo test --all-targets --all-features --locked` — 11/11 binaries, 625 tests, 0 failures
- [x] CI on the pin, since fork PRs do not run yours until approved: [run 34554803058](https://github.com/6temes/herdr-agent-quota/actions/runs/34554803058) — ubuntu, macos, plugin manifest, dependency audit all green
- [x] No parser change, so no new fixture needed
- [x] No new network call, background process, or credential write

Three tests, written red first: an idle pane follows its session's new windows with no agent event; a pane already showing the cached windows stays out of the pass (no-op suppression holds); new windows for one session leave another session's idle pane alone.

## Provider impact

None specific — the publish trigger is provider-agnostic. Motivated by Claude, where the statusLine hook writes only the observation mailbox and never publishes tokens, so idle panes depend entirely on this path. Verified live on Claude Code 2.1.267 with Herdr 0.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H31wKECBv9v5uoURkfqu64