### PR TITLE
fix: keep a saved complete agent list full after a new provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ every time they press Enter. Budget accordingly.
 
 The working event starts one global `watch` pulse. It calls `herdr agent list`
 once per configured interval for every supported harness, including Pi, OMP,
-and OpenCode. Event-spawned watchers defer their first poll. They resolve local
+OpenCode, and Muse. Event-spawned watchers defer their first poll. They resolve local
 billing targets, refresh active/settling targets, and publish to siblings with
 the same target without reading terminal output. A finishing target stays in
 the pass until the 60-second debounce has elapsed. The interval defaults to
@@ -236,6 +236,44 @@ clients from redirecting a refresh to another pane:
 `find_agent` and `find_pane_id` in `src/refresh.rs` walk the tree rather than
 assuming a fixed path. Keep them tolerant — the shapes differ per event and are
 not part of a stable contract.
+
+## Adding a harness
+
+Append to `AgentSelection::SUPPORTED`. Never insert. A saved complete agent
+list is a proper prefix of that array, and `parse_list` still reads an unmarked
+prefix of length ≥ 6 as every agent. That is what #81 was: Muse grew
+`SUPPORTED`, a settings-saved
+`claude,codex,grok,agy,opencode,pi,omp,devin` became "partial", `ensure_omp`
+took the hard-failure path, and `configure` aborted on a machine without omp.
+The first six entries are the first complete list the settings pane wrote; do
+not reorder them.
+
+You do not add a historical snapshot by hand when you append — the prefix
+rule covers the new tail. Settings and `install.sh --agent` write `all` or
+`only,<names>` so a later "everything except the newest one" is not mistaken
+for a legacy full list.
+
+Wiring the new name is not enough. Also:
+
+1. `Harness`, `from_agent_name`, `AgentSelection` (the enum, `parse`,
+   `harness`, `harness_name`), clap `--agent` help, `install.sh` comments,
+   both READMEs, and the plugin description.
+2. A `PROVIDER_STYLES` row in `src/configure/herdr.rs`, in `SUPPORTED` order.
+3. Settings popup `height` in `herdr-plugin.toml` — one more row. The
+   `rows().len()` check fails if this is skipped.
+4. If it has a subscription collector: `Provider`, `Provider::ALL`,
+   `ProviderSelection`, the fetch path, and a cache identity. If Herdr has
+   no integration for it, `integration_id` returns `None` (Agy, Muse).
+5. If its own transcript is the evidence, `event` must not read the pane
+   (Pi, omp, Muse).
+6. Tests that name agents must walk `SUPPORTED`, not a copied list. A copied
+   list is how Muse missed the watcher-alive check and the "installs
+   everything" sidebar assertions.
+
+Adding a **sidebar field** is the same shape as #76: a saved "everything on"
+list will not name the new field. `FieldSet::parse` has to keep reading that
+exact legacy list as `all()`, and `as_list` needs a marker for the one new
+selection that would collide with it.
 
 ## Verifying
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- A saved agent list that was complete before a new provider was added no
+  longer makes `configure` abort when omp is not installed. Those builds
+  wrote "everything on" as an enumeration (`claude,codex,grok,agy,opencode,pi,omp,devin`
+  before Muse), which was then judged partial against the longer supported
+  list, so a missing omp integration became a hard failure. That exact
+  prefix is still read as every agent. A complete selection is now stored
+  as `all`, and a subset with a leading `only` marker, so turning the
+  newest agent off is not mistaken for the legacy full list.
 - An idle pane now follows its own session's quota as soon as the cache has it.
   A Claude statusLine hook only writes the observation mailbox, so a pane that
   never starts a turn kept publishing whatever it last published: one pane sat

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,11 @@ Timing-sensitive tests can be diagnosed with `-- --test-threads=1`.
 
 A harness and a billing provider are different concepts. Add a subscription
 route only when the credential source is verified; use session diagnostics
-without quota for unsupported or unconfirmed routes.
+without quota for unsupported or unconfirmed routes. When adding a harness,
+append it to `AgentSelection::SUPPORTED` and follow the checklist in
+[AGENTS.md](AGENTS.md#adding-a-harness) — a saved complete agent list is a
+prefix of that array, and inserting or forgetting the settings height, sidebar
+style, or `SUPPORTED`-driven tests recreates #81.
 
 ## Pull requests and documentation
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -58,8 +58,8 @@ title = "Agent quota settings"
 command = ["sh", "-c", "exec \"$HERDR_PLUGIN_ROOT/target/release/herdr-agent-quota\" settings"]
 placement = "popup"
 # Every option on screen at once. The default half-size popup is 24 rows and
-# the list plus controls needs 28 interior rows, so without this the agents
+# the list plus controls needs 31 interior rows, so without this the agents
 # section opens below the fold.
 # Herdr clamps to the terminal, and the pane still scrolls when it has to.
 width = 78
-height = 32
+height = 33

--- a/install.sh
+++ b/install.sh
@@ -181,7 +181,7 @@ write_plugin_pref() {
   printf '%s\n' "$value" > "$directory/$name"
 }
 
-write_plugin_pref agents "$AGENTS"
+write_plugin_pref agents "$(agents_pref_value "$AGENTS")"
 write_plugin_pref watch-interval-seconds "$WATCH_INTERVAL_SECONDS"
 write_plugin_pref sidebar-layout "$SIDEBAR_LAYOUT"
 write_plugin_pref row-gap "$ROW_GAP"

--- a/scripts/herdr-action.sh
+++ b/scripts/herdr-action.sh
@@ -9,6 +9,19 @@
 # Sourced by install.sh and uninstall.sh; not a standalone script.
 
 HERDR_ACTION_PLUGIN_ID="herdr-agent-quota"
+
+# Preference form of an `--agent` selection.
+#
+# A saved enumeration that was complete when written is later read as every
+# currently supported agent, so a new provider does not turn a once-complete
+# install into a partial one. Prefix an explicit subset with `only` so it
+# stays a subset after that upgrade. `all` is already the complete token.
+agents_pref_value() {
+  case "$1" in
+    ""|all|only,*) printf '%s\n' "$1" ;;
+    *) printf 'only,%s\n' "$1" ;;
+  esac
+}
 # Configuration writes touch a handful of small files. A minute is far beyond
 # any legitimate run and still bounds a hung action.
 HERDR_ACTION_TIMEOUT_SECONDS="${HERDR_ACTION_TIMEOUT_SECONDS:-60}"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -724,6 +724,10 @@ impl SidebarLayout {
 
 impl AgentSelection {
     /// Every agent `configure` supports, in the order they are reported.
+    ///
+    /// New agents are appended, never inserted, so a saved complete list from
+    /// an earlier build is a proper prefix of this array and can still mean
+    /// "everything on" after a provider is added.
     pub const SUPPORTED: [Harness; 9] = [
         Harness::Claude,
         Harness::Codex,
@@ -735,6 +739,17 @@ impl AgentSelection {
         Harness::Devin,
         Harness::Muse,
     ];
+
+    /// Length of the first complete list the settings pane persisted.
+    ///
+    /// Shorter enumerations were always subsets. Prefixes of this length or
+    /// more were "everything on" at write time.
+    pub(crate) const FIRST_PERSISTED_FULL: usize = 6;
+
+    /// Token `as_stored_list` puts in front of a subset so it is not mistaken
+    /// for a legacy complete list. `--agent` never carries it: clap has no
+    /// such value, and an explicit flag is already exact.
+    const EXPLICIT: &'static str = "only";
 
     fn harness(self) -> Option<Harness> {
         match self {
@@ -748,6 +763,20 @@ impl AgentSelection {
             Self::Omp => Some(Harness::Omp),
             Self::Devin => Some(Harness::Devin),
             Self::Muse => Some(Harness::Muse),
+        }
+    }
+
+    pub fn harness_name(harness: Harness) -> &'static str {
+        match harness {
+            Harness::Claude => "claude",
+            Harness::Codex => "codex",
+            Harness::Grok => "grok",
+            Harness::Agy => "agy",
+            Harness::OpenCode => "opencode",
+            Harness::Pi => "pi",
+            Harness::Omp => "omp",
+            Harness::Devin => "devin",
+            Harness::Muse => "muse",
         }
     }
 
@@ -776,12 +805,37 @@ impl AgentSelection {
     }
 
     /// A comma-separated selection, or `None` when it names nothing valid.
+    ///
+    /// An unmarked list that is a proper prefix of `SUPPORTED` of length
+    /// [`Self::FIRST_PERSISTED_FULL`] or more was complete when written, so it
+    /// is read as every agent — the same shape as a pre-`provider` field list.
+    /// `only` keeps a later subset that happens to match that prefix from
+    /// being upgraded.
     fn parse_list(raw: &str) -> Option<Vec<Harness>> {
-        let parsed: Vec<Self> = raw
+        let mut explicit = false;
+        let mut parsed = Vec::new();
+        for name in raw
             .split(',')
-            .filter_map(|name| Self::parse(name.trim()))
-            .collect();
-        (!parsed.is_empty()).then(|| Self::resolve(&parsed))
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            if name.eq_ignore_ascii_case(Self::EXPLICIT) {
+                explicit = true;
+                continue;
+            }
+            if let Some(value) = Self::parse(name) {
+                parsed.push(value);
+            }
+        }
+        if parsed.is_empty() {
+            return None;
+        }
+        let resolved = Self::resolve(&parsed);
+        if !explicit && Self::is_legacy_full(&resolved) {
+            Some(Self::SUPPORTED.to_vec())
+        } else {
+            Some(resolved)
+        }
     }
 
     fn parse(name: &str) -> Option<Self> {
@@ -798,6 +852,48 @@ impl AgentSelection {
             "muse" => Some(Self::Muse),
             _ => None,
         }
+    }
+
+    fn is_complete(agents: &[Harness]) -> bool {
+        agents == Self::SUPPORTED
+    }
+
+    fn is_legacy_full(agents: &[Harness]) -> bool {
+        let n = agents.len();
+        n >= Self::FIRST_PERSISTED_FULL
+            && n < Self::SUPPORTED.len()
+            && agents == &Self::SUPPORTED[..n]
+    }
+
+    /// Preference form: `all` when complete, `only,<names>` when a subset.
+    ///
+    /// `only` is what stops a subset that matches a legacy complete list —
+    /// turning Muse off today writes the pre-Muse full list — from being
+    /// read as every agent the next time a provider is added.
+    pub(crate) fn as_stored_list(agents: &[Harness]) -> String {
+        if Self::is_complete(agents) {
+            return "all".to_string();
+        }
+        format!("{},{}", Self::EXPLICIT, Self::names(agents))
+    }
+
+    /// `--agent` form: `all` when complete, otherwise the names. Never `only`;
+    /// clap has no such value, and a flag is already an exact selection.
+    pub(crate) fn as_cli_list(agents: &[Harness]) -> String {
+        if Self::is_complete(agents) {
+            "all".to_string()
+        } else {
+            Self::names(agents)
+        }
+    }
+
+    pub(crate) fn names(agents: &[Harness]) -> String {
+        agents
+            .iter()
+            .copied()
+            .map(Self::harness_name)
+            .collect::<Vec<_>>()
+            .join(",")
     }
 
     /// Flatten a `--agent` selection into a deduplicated harness list that
@@ -904,6 +1000,133 @@ mod tests {
                 AgentSelection::SUPPORTED.to_vec()
             );
         });
+    }
+
+    /// A build before Muse wrote "everything on" as the eight names that then
+    /// existed. That list has to keep meaning every agent after Muse is added,
+    /// or `configure` judges it partial and a missing omp install becomes
+    /// fatal.
+    #[test]
+    fn a_saved_complete_list_from_before_a_new_agent_still_selects_everything() {
+        let directory = tempfile::tempdir().unwrap();
+        crate::prefs::testing::with_config_dir(directory.path(), || {
+            crate::prefs::write(
+                crate::prefs::AGENTS,
+                "claude,codex,grok,agy,opencode,pi,omp,devin",
+            )
+            .unwrap();
+            assert_eq!(
+                AgentSelection::from_args_or_env(&[]),
+                AgentSelection::SUPPORTED.to_vec()
+            );
+
+            crate::prefs::write(
+                crate::prefs::AGENTS,
+                " claude, codex, grok, agy, opencode, pi, omp, devin ",
+            )
+            .unwrap();
+            assert_eq!(
+                AgentSelection::from_args_or_env(&[]),
+                AgentSelection::SUPPORTED.to_vec()
+            );
+
+            // The six- and seven-agent complete lists the settings pane wrote
+            // before Devin and omp are the same shape.
+            crate::prefs::write(
+                crate::prefs::AGENTS,
+                "claude,codex,grok,agy,opencode,pi,omp",
+            )
+            .unwrap();
+            assert_eq!(
+                AgentSelection::from_args_or_env(&[]),
+                AgentSelection::SUPPORTED.to_vec()
+            );
+            crate::prefs::write(crate::prefs::AGENTS, "claude,codex,grok,agy,opencode,pi").unwrap();
+            assert_eq!(
+                AgentSelection::from_args_or_env(&[]),
+                AgentSelection::SUPPORTED.to_vec()
+            );
+        });
+    }
+
+    /// Turning Muse off produces the pre-Muse full list. Without a marker that
+    /// selection would be upgraded back to everything on the next repair.
+    #[test]
+    fn an_explicit_subset_matching_a_legacy_full_list_is_not_upgraded() {
+        let directory = tempfile::tempdir().unwrap();
+        crate::prefs::testing::with_config_dir(directory.path(), || {
+            crate::prefs::write(
+                crate::prefs::AGENTS,
+                "only,claude,codex,grok,agy,opencode,pi,omp,devin",
+            )
+            .unwrap();
+            let selected = AgentSelection::from_args_or_env(&[]);
+            assert_eq!(
+                selected,
+                AgentSelection::SUPPORTED[..AgentSelection::SUPPORTED.len() - 1].to_vec()
+            );
+            assert!(!selected.contains(&Harness::Muse));
+
+            crate::prefs::write(crate::prefs::AGENTS, "only,grok").unwrap();
+            assert_eq!(AgentSelection::from_args_or_env(&[]), vec![Harness::Grok]);
+        });
+    }
+
+    #[test]
+    fn a_complete_selection_is_stored_as_all_and_a_subset_as_only() {
+        assert_eq!(
+            AgentSelection::as_stored_list(&AgentSelection::SUPPORTED),
+            "all"
+        );
+        assert_eq!(
+            AgentSelection::as_cli_list(&AgentSelection::SUPPORTED),
+            "all"
+        );
+        assert_eq!(
+            AgentSelection::as_stored_list(&[Harness::Grok, Harness::Claude]),
+            "only,grok,claude"
+        );
+        assert_eq!(
+            AgentSelection::as_cli_list(&[Harness::Grok, Harness::Claude]),
+            "grok,claude"
+        );
+        let pre_muse = &AgentSelection::SUPPORTED[..AgentSelection::SUPPORTED.len() - 1];
+        assert_eq!(
+            AgentSelection::as_stored_list(pre_muse),
+            "only,claude,codex,grok,agy,opencode,pi,omp,devin"
+        );
+        assert_eq!(
+            AgentSelection::as_cli_list(pre_muse),
+            "claude,codex,grok,agy,opencode,pi,omp,devin"
+        );
+    }
+
+    #[test]
+    fn every_supported_agent_round_trips_through_its_stored_name() {
+        for harness in AgentSelection::SUPPORTED {
+            let name = AgentSelection::harness_name(harness);
+            assert_eq!(
+                AgentSelection::parse(name).and_then(AgentSelection::harness),
+                Some(harness)
+            );
+        }
+    }
+
+    /// Inserting a harness in the middle would make a saved complete list
+    /// either fail to upgrade or upgrade the wrong subset.
+    #[test]
+    fn supported_agents_are_appended_so_legacy_full_lists_stay_prefixes() {
+        assert_eq!(
+            &AgentSelection::SUPPORTED[..AgentSelection::FIRST_PERSISTED_FULL],
+            &[
+                Harness::Claude,
+                Harness::Codex,
+                Harness::Grok,
+                Harness::Agy,
+                Harness::OpenCode,
+                Harness::Pi,
+            ]
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -785,8 +785,9 @@ impl AgentSelection {
     /// A Herdr plugin action runs a fixed command line in the *server's*
     /// environment, so a variable exported around `herdr plugin action invoke`
     /// never reaches it. The plugin config directory is the channel that does
-    /// work, and it is what `install.sh` writes; the environment is still
-    /// honoured first for a direct CLI run.
+    /// work, and it is what `install.sh` writes. A direct-CLI environment
+    /// override is still honoured first, but it is explicit and therefore
+    /// parsed exactly; only persisted preferences get the legacy-full upgrade.
     ///
     /// Anything unparsable falls through to the next source and finally to
     /// every supported agent, so `--uninstall` alone still removes everything.
@@ -794,24 +795,25 @@ impl AgentSelection {
         if !values.is_empty() {
             return Self::resolve(values);
         }
-        [
-            std::env::var("HERDR_AGENT_QUOTA_AGENTS").ok(),
-            crate::prefs::read(crate::prefs::AGENTS),
-        ]
-        .into_iter()
-        .flatten()
-        .find_map(|raw| Self::parse_list(&raw))
-        .unwrap_or_else(|| Self::SUPPORTED.to_vec())
+        if let Ok(raw) = std::env::var("HERDR_AGENT_QUOTA_AGENTS") {
+            if let Some(agents) = Self::parse_list(&raw, false) {
+                return agents;
+            }
+        }
+        crate::prefs::read(crate::prefs::AGENTS)
+            .and_then(|raw| Self::parse_list(&raw, true))
+            .unwrap_or_else(|| Self::SUPPORTED.to_vec())
     }
 
     /// A comma-separated selection, or `None` when it names nothing valid.
     ///
-    /// An unmarked list that is a proper prefix of `SUPPORTED` of length
-    /// [`Self::FIRST_PERSISTED_FULL`] or more was complete when written, so it
-    /// is read as every agent — the same shape as a pre-`provider` field list.
-    /// `only` keeps a later subset that happens to match that prefix from
-    /// being upgraded.
-    fn parse_list(raw: &str) -> Option<Vec<Harness>> {
+    /// When `upgrade_legacy_full` is true, an unmarked list that is a proper
+    /// prefix of `SUPPORTED` of length [`Self::FIRST_PERSISTED_FULL`] or more
+    /// was complete when written, so it is read as every agent. That upgrade
+    /// is for persisted preferences only; direct environment overrides are
+    /// explicit selections and stay exact. `only` keeps a newly-stored subset
+    /// from colliding with the legacy persisted form.
+    fn parse_list(raw: &str, upgrade_legacy_full: bool) -> Option<Vec<Harness>> {
         let mut explicit = false;
         let mut parsed = Vec::new();
         for name in raw
@@ -831,7 +833,7 @@ impl AgentSelection {
             return None;
         }
         let resolved = Self::resolve(&parsed);
-        if !explicit && Self::is_legacy_full(&resolved) {
+        if upgrade_legacy_full && !explicit && Self::is_legacy_full(&resolved) {
             Some(Self::SUPPORTED.to_vec())
         } else {
             Some(resolved)
@@ -969,6 +971,19 @@ mod tests {
         assert_eq!(
             AgentSelection::from_args_or_env(&[AgentSelection::Grok]),
             vec![Harness::Grok]
+        );
+    }
+
+    #[test]
+    fn an_explicit_list_matching_a_legacy_full_prefix_stays_exact() {
+        let raw = "claude,codex,grok,agy,opencode,pi";
+        assert_eq!(
+            AgentSelection::parse_list(raw, false),
+            Some(AgentSelection::SUPPORTED[..AgentSelection::FIRST_PERSISTED_FULL].to_vec())
+        );
+        assert_eq!(
+            AgentSelection::parse_list(raw, true),
+            Some(AgentSelection::SUPPORTED.to_vec())
         );
     }
 

--- a/src/configure/herdr.rs
+++ b/src/configure/herdr.rs
@@ -1294,6 +1294,15 @@ mod tests {
     use super::*;
 
     #[test]
+    fn every_supported_harness_has_a_sidebar_style_in_supported_order() {
+        let styles: Vec<Harness> = PROVIDER_STYLES
+            .iter()
+            .map(|(harness, _, _, _)| *harness)
+            .collect();
+        assert_eq!(styles.as_slice(), AgentSelection::SUPPORTED.as_slice());
+    }
+
+    #[test]
     fn extra_native_identity_rows_and_unmarked_legacy_styles_are_preserved() {
         for original in [
             "[ui.sidebar.agents]\nrows = [[\"state_icon\", \"machine\", \"workspace\", \"tab\"], [\"agent\"], [\"agent\"]] # herdr-agent-quota-row\n",
@@ -2141,8 +2150,12 @@ claude = [["state_icon", "agent"]]
             add_quota_row("[ui.sidebar.agents]\nrows = [[\"state_icon\", \"agent\"]]\n").unwrap();
         let removed = remove_quota_row_for(&full, &[Harness::Grok], false).unwrap();
         assert!(!removed.contains("grok ="), "grok survived: {removed}");
-        for kept in ["claude =", "codex =", "agy =", "opencode ="] {
-            assert!(removed.contains(kept), "{kept} was lost: {removed}");
+        for harness in AgentSelection::SUPPORTED {
+            if harness == Harness::Grok {
+                continue;
+            }
+            let kept = format!("{} =", AgentSelection::harness_name(harness));
+            assert!(removed.contains(&kept), "{kept} was lost: {removed}");
         }
         // The shared parts belong to the installation, not to grok.
         assert!(removed.contains("rows = "));

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -272,7 +272,7 @@ impl Settings {
             "configure".to_string(),
             "--apply".to_string(),
             "--agent".to_string(),
-            agent_list(&self.agents()),
+            AgentSelection::as_cli_list(&self.agents()),
             "--quota-percent".to_string(),
             self.percent.as_str().to_string(),
             "--sidebar-layout".to_string(),
@@ -306,27 +306,8 @@ impl Settings {
     }
 }
 
-fn agent_name(harness: Harness) -> &'static str {
-    match harness {
-        Harness::Claude => "claude",
-        Harness::Codex => "codex",
-        Harness::Grok => "grok",
-        Harness::Agy => "agy",
-        Harness::OpenCode => "opencode",
-        Harness::Pi => "pi",
-        Harness::Omp => "omp",
-        Harness::Devin => "devin",
-        Harness::Muse => "muse",
-    }
-}
-
 fn agent_list(agents: &[Harness]) -> String {
-    agents
-        .iter()
-        .copied()
-        .map(agent_name)
-        .collect::<Vec<_>>()
-        .join(",")
+    AgentSelection::names(agents)
 }
 
 fn format_interval(seconds: u64) -> String {
@@ -448,7 +429,10 @@ fn apply(settings: Settings, removed: &[Harness]) -> Result<()> {
     }
     // A Herdr plugin action runs a fixed command line, so the agent selection
     // has to be stored where a later "Install / repair" will find it.
-    prefs::write(prefs::AGENTS, &agent_list(&settings.agents()))?;
+    prefs::write(
+        prefs::AGENTS,
+        &AgentSelection::as_stored_list(&settings.agents()),
+    )?;
     run_self(&executable, &settings.apply_arguments())?;
 
     let herdr = std::env::var("HERDR_BIN_PATH").unwrap_or_else(|_| "herdr".to_string());
@@ -599,7 +583,7 @@ fn render_row(draft: &Settings, applied: Settings, row: Row, selected: bool) -> 
             format!(
                 "{cursor} {changed} {} {}\r\n",
                 checkbox(draft.has_agent(harness)),
-                agent_name(harness)
+                AgentSelection::harness_name(harness)
             )
         }
     }
@@ -721,6 +705,8 @@ mod tests {
 
     /// Applying names every value, so it cannot inherit a stale preference,
     /// and it names the agents so a narrowed selection is what gets installed.
+    /// A complete selection is `all`, so a later provider is included without
+    /// rewriting the preference.
     #[test]
     fn applying_names_every_value_including_the_agent_selection() {
         let mut draft = settings();
@@ -751,6 +737,47 @@ mod tests {
                 "--watch-interval-seconds",
                 "60",
             ]
+        );
+    }
+
+    #[test]
+    fn the_declared_popup_height_fits_every_row() {
+        let manifest = include_str!("../herdr-plugin.toml");
+        let height: usize = manifest
+            .split("[[panes]]")
+            .find(|pane| pane.contains("id = \"settings\""))
+            .unwrap()
+            .lines()
+            .find_map(|line| line.strip_prefix("height = "))
+            .expect("the settings popup declares a height")
+            .trim()
+            .parse()
+            .unwrap();
+        // rows() is every option plus section headers. Reserve the four TUI
+        // chrome lines and Herdr's two-row pane border.
+        let needed = rows().len() + 4 + 2;
+        assert!(
+            height >= needed,
+            "height = {height}, need {needed} after adding a row"
+        );
+    }
+
+    #[test]
+    fn a_complete_selection_is_applied_as_all() {
+        let arguments = settings().apply_arguments();
+        let agent = arguments.iter().position(|flag| flag == "--agent").unwrap();
+        assert_eq!(arguments[agent + 1], "all");
+    }
+
+    #[test]
+    fn turning_the_newest_agent_off_is_an_exact_cli_list() {
+        let mut draft = settings();
+        draft.cycle(Row::Agent(Harness::Muse), 1);
+        let arguments = draft.apply_arguments();
+        let agent = arguments.iter().position(|flag| flag == "--agent").unwrap();
+        assert_eq!(
+            arguments[agent + 1],
+            "claude,codex,grok,agy,opencode,pi,omp,devin"
         );
     }
 

--- a/tests/configure_round_trip.rs
+++ b/tests/configure_round_trip.rs
@@ -1,6 +1,7 @@
 use herdr_agent_quota::cache::CacheStore;
+use herdr_agent_quota::cli::AgentSelection;
 use herdr_agent_quota::configure::herdr::{add_quota_row, remove_quota_row};
-use herdr_agent_quota::model::{Provider, ProviderSnapshot, UsageWindow, WindowKind};
+use herdr_agent_quota::model::{Harness, Provider, ProviderSnapshot, UsageWindow, WindowKind};
 use std::fs;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
@@ -1652,9 +1653,13 @@ fn installing_one_agent_leaves_every_other_agent_untouched() {
     );
 
     let sidebar = homes.sidebar();
-    assert!(sidebar.contains("claude ="), "{sidebar}");
-    for other in ["codex =", "grok =", "agy =", "opencode =", "pi =", "omp ="] {
-        assert!(!sidebar.contains(other), "{other} was written: {sidebar}");
+    assert!(sidebar.contains(&style_row(Harness::Claude)), "{sidebar}");
+    for harness in AgentSelection::SUPPORTED {
+        if harness == Harness::Claude {
+            continue;
+        }
+        let other = style_row(harness);
+        assert!(!sidebar.contains(&other), "{other} was written: {sidebar}");
     }
 
     // Someone who does not use Agy or Grok must end up with nothing of theirs
@@ -1681,16 +1686,13 @@ fn installing_only_pi_adds_only_its_sidebar_style() {
         String::from_utf8_lossy(&output.stderr)
     );
     let sidebar = homes.sidebar();
-    assert!(sidebar.contains("pi ="), "{sidebar}");
-    for other in [
-        "claude =",
-        "codex =",
-        "grok =",
-        "agy =",
-        "opencode =",
-        "omp =",
-    ] {
-        assert!(!sidebar.contains(other), "{other} was written: {sidebar}");
+    assert!(sidebar.contains(&style_row(Harness::Pi)), "{sidebar}");
+    for harness in AgentSelection::SUPPORTED {
+        if harness == Harness::Pi {
+            continue;
+        }
+        let other = style_row(harness);
+        assert!(!sidebar.contains(&other), "{other} was written: {sidebar}");
     }
     assert!(!homes.claude_settings.exists());
     assert!(!homes.agy_settings.exists());
@@ -1712,16 +1714,16 @@ fn uninstalling_one_agent_keeps_the_rest_working() {
     );
 
     let sidebar = homes.sidebar();
-    assert!(!sidebar.contains("grok ="), "grok survived: {sidebar}");
-    for kept in [
-        "claude =",
-        "codex =",
-        "agy =",
-        "opencode =",
-        "pi =",
-        "omp =",
-    ] {
-        assert!(sidebar.contains(kept), "{kept} was lost: {sidebar}");
+    assert!(
+        !sidebar.contains(&style_row(Harness::Grok)),
+        "grok survived: {sidebar}"
+    );
+    for harness in AgentSelection::SUPPORTED {
+        if harness == Harness::Grok {
+            continue;
+        }
+        let kept = style_row(harness);
+        assert!(sidebar.contains(&kept), "{kept} was lost: {sidebar}");
     }
     assert!(
         homes.claude_settings.exists(),
@@ -1786,6 +1788,110 @@ fn an_installer_can_narrow_the_selection_through_the_environment() {
     assert!(!homes.claude_settings.exists());
 }
 
+fn stub_missing_omp_integration(state: &Path) {
+    fs::create_dir_all(state).unwrap();
+    let herdr = state.join("herdr-absent");
+    fs::write(
+        &herdr,
+        r#"#!/bin/sh
+if [ "$1 $2" = "integration status" ]; then
+  printf '%s\n' 'omp: not installed (/home/u/.omp/agent/extensions/herdr-agent-state.ts)'
+  exit 0
+fi
+if [ "$1 $2 $3" = "integration install omp" ]; then
+  printf '%s\n' 'omp extension directory not found at /home/u/.omp/agent/extensions. install omp first' >&2
+  exit 1
+fi
+exit 0
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&herdr).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&herdr, permissions).unwrap();
+}
+
+/// The Herdr configure action has no `--agent` flag, so a list saved before
+/// Muse is what `is_full` sees. Without the upgrade that list is partial,
+/// and a machine without omp dies before any sidebar row is written.
+#[test]
+fn a_saved_pre_muse_full_list_still_configures_when_omp_is_absent() {
+    let root = tempdir().unwrap();
+    let homes = AgentHomes::new(root.path());
+    stub_missing_omp_integration(&homes.state);
+    let config = root.path().join("config");
+    fs::create_dir_all(&config).unwrap();
+    fs::write(
+        config.join("agents"),
+        "claude,codex,grok,agy,opencode,pi,omp,devin\n",
+    )
+    .unwrap();
+
+    let output = homes.configure_with_env(
+        &["--apply"],
+        &[
+            ("HERDR_PLUGIN_CONFIG_DIR", config.to_str().unwrap()),
+            ("HERDR_AGENT_QUOTA_AGENTS", ""),
+        ],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "stderr: {stderr}\nstdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Skipped omp"),
+        "omp should be skipped on a full selection: {stdout}"
+    );
+    let sidebar = homes.sidebar();
+    assert!(
+        sidebar.contains("muse ="),
+        "a once-complete list must include Muse: {sidebar}"
+    );
+    assert!(sidebar.contains("claude ="), "{sidebar}");
+}
+
+#[test]
+fn an_explicit_pre_muse_subset_still_fails_when_omp_is_absent() {
+    let root = tempdir().unwrap();
+    let homes = AgentHomes::new(root.path());
+    stub_missing_omp_integration(&homes.state);
+    let config = root.path().join("config");
+    fs::create_dir_all(&config).unwrap();
+    fs::write(
+        config.join("agents"),
+        "only,claude,codex,grok,agy,opencode,pi,omp,devin\n",
+    )
+    .unwrap();
+
+    let output = homes.configure_with_env(
+        &["--apply"],
+        &[
+            ("HERDR_PLUGIN_CONFIG_DIR", config.to_str().unwrap()),
+            ("HERDR_AGENT_QUOTA_AGENTS", ""),
+        ],
+    );
+    assert!(
+        !output.status.success(),
+        "an explicit omp subset must fail loudly when omp is absent"
+    );
+    let detail = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        detail.contains("omp extension directory not found"),
+        "{detail}"
+    );
+    assert!(
+        !homes.sidebar().contains("muse ="),
+        "a failed configure must not write Muse rows: {}",
+        homes.sidebar()
+    );
+}
+
 #[test]
 fn an_unusable_environment_selection_still_installs_everything() {
     let root = tempdir().unwrap();
@@ -1795,17 +1901,14 @@ fn an_unusable_environment_selection_still_installs_everything() {
         .status
         .success());
     let sidebar = homes.sidebar();
-    for expected in [
-        "claude =",
-        "codex =",
-        "grok =",
-        "agy =",
-        "opencode =",
-        "pi =",
-        "omp =",
-    ] {
-        assert!(sidebar.contains(expected), "{expected} missing: {sidebar}");
+    for harness in AgentSelection::SUPPORTED {
+        let expected = style_row(harness);
+        assert!(sidebar.contains(&expected), "{expected} missing: {sidebar}");
     }
+}
+
+fn style_row(harness: Harness) -> String {
+    format!("{} =", AgentSelection::harness_name(harness))
 }
 
 #[test]

--- a/tests/install_upgrade.rs
+++ b/tests/install_upgrade.rs
@@ -82,3 +82,71 @@ esac
         "300\n"
     );
 }
+
+#[test]
+fn an_explicit_install_agent_list_is_stored_as_a_subset() {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = dir.path().join("bin");
+    let config = dir.path().join("config");
+    let plugin = dir.path().join("plugin/target/release");
+    for path in [&bin, &config, &plugin] {
+        fs::create_dir_all(path).unwrap();
+    }
+    let log = dir.path().join("calls");
+    let manifest: toml::Value = toml::from_str(include_str!("../herdr-plugin.toml")).unwrap();
+    let configure = manifest["actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|action| action["id"].as_str() == Some("configure"))
+        .unwrap()["command"][2]
+        .as_str()
+        .unwrap();
+    for (path, script) in [
+        (bin.join("cargo"), "#!/bin/sh\nexit 0\n"),
+        (
+            plugin.join("herdr-agent-quota"),
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$TEST_LOG\"\n",
+        ),
+        (
+            bin.join("herdr"),
+            r#"#!/bin/sh
+case "$1 $2" in
+  'plugin link') exit 0 ;;
+  'plugin config-dir') printf '%s\n' "$TEST_CONFIG" ;;
+  'plugin action')
+    HERDR_PLUGIN_ROOT="$TEST_PLUGIN" sh -c "$TEST_ACTION" || exit 1
+    printf '%s\n' '{"log_id":"upgrade-test","status":"succeeded"}' ;;
+  'plugin log') printf '%s\n' '{"log_id":"upgrade-test","status":"succeeded"}' ;;
+  'server reload-config') printf '%s\n' reload-config >> "$TEST_LOG" ;;
+  *) exit 2 ;;
+esac
+"#,
+        ),
+    ] {
+        fs::write(&path, script).unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let output = Command::new("bash")
+        .arg(concat!(env!("CARGO_MANIFEST_DIR"), "/install.sh"))
+        .args(["--agent", "claude,codex,grok,agy,opencode,pi,omp,devin"])
+        .env(
+            "PATH",
+            format!("{}:{}", bin.display(), std::env::var("PATH").unwrap()),
+        )
+        .env("TEST_CONFIG", &config)
+        .env("TEST_PLUGIN", dir.path().join("plugin"))
+        .env("TEST_ACTION", configure)
+        .env("TEST_LOG", &log)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(config.join("agents")).unwrap(),
+        "only,claude,codex,grok,agy,opencode,pi,omp,devin\n"
+    );
+}

--- a/tests/plugin_manifest.rs
+++ b/tests/plugin_manifest.rs
@@ -66,9 +66,19 @@ fn the_settings_popup_is_tall_enough_for_every_option() {
         .trim()
         .parse()
         .unwrap();
-    // Three section headers, seven choices, seven fields, nine agents, four
+    // Three section headers, seven choices, every field, every agent, four
     // lines of TUI chrome, and the two rows consumed by Herdr's pane border.
-    assert!(height >= 3 + 7 + 7 + 9 + 4 + 2, "height = {height}");
+    // Walk the live lists so adding a harness or field without growing the
+    // popup is a test failure, not a row below the fold.
+    assert!(
+        height
+            >= 3 + 7
+                + herdr_agent_quota::cli::SidebarField::ALL.len()
+                + herdr_agent_quota::cli::AgentSelection::SUPPORTED.len()
+                + 4
+                + 2,
+        "height = {height}"
+    );
 }
 
 /// Herdr accepts a plugin-owned agent view only from `plugin:<manifest id>`

--- a/tests/watch_handoff.rs
+++ b/tests/watch_handoff.rs
@@ -1,5 +1,6 @@
 #![cfg(unix)]
 
+use herdr_agent_quota::cli::AgentSelection;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::process::{Command, Stdio};
@@ -96,9 +97,8 @@ printf '%s\n' '{"result":{"agents":[]}}'
 
 #[test]
 fn every_supported_working_harness_keeps_the_watcher_alive() {
-    for harness in [
-        "codex", "grok", "claude", "agy", "devin", "pi", "omp", "opencode",
-    ] {
+    for harness in AgentSelection::SUPPORTED {
+        let harness = AgentSelection::harness_name(harness);
         let dir = tempfile::tempdir().unwrap();
         let herdr = dir.path().join("herdr");
         fs::write(&herdr, format!("#!/bin/sh\ntouch \"$TEST_INVENTORY\"\nprintf '%s\\n' '{{\"result\":{{\"agents\":[{{\"pane_id\":\"w1:p1\",\"agent\":\"{harness}\",\"agent_status\":\"working\"}}]}}}}'\n")).unwrap();

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -75,7 +75,7 @@ select_agents() {
     AGENTS_PREF_EXISTED=1
   fi
   trap restore_agents_pref EXIT
-  printf '%s\n' "$AGENTS" > "$AGENTS_PREF"
+  printf '%s\n' "$(agents_pref_value "$AGENTS")" > "$AGENTS_PREF"
 }
 
 if herdr plugin list 2>/dev/null | grep -q 'herdr-agent-quota'; then


### PR DESCRIPTION
Closes #81.

Same shape as #76: a saved "everything on" list written before a new item existed must still mean everything on after that item ships.

## What this changes

Adding a harness to `AgentSelection::SUPPORTED` (Muse in #79) turned every previously-saved complete agent list into a partial one. `is_full` then returned false, and `ensure_omp`'s skip became a hard failure — so `configure` aborted on machines without omp, even though the user had never asked for omp-only behavior.

`parse_list` now reads an unmarked prefix of `SUPPORTED` of length ≥ 6 as every agent (6 is the first complete list the settings pane persisted). Settings and `install.sh --agent` write `all` when complete and `only,<names>` for a subset, so turning the newest agent off is not mistaken for that legacy list. `SUPPORTED` stays append-only.

Also:

- Settings popup `height` follows the live row count (was one short after provider became a field).
- Tests that named agents walk `SUPPORTED` instead of a copied list.
- `AGENTS.md` records the add-harness checklist so the next provider does not skip this.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features --locked`
- [x] A parser change comes with a fixture in `tests/fixtures/` and a test
- [x] No new network call, background process, or credential write

Parser coverage is unit + caller-path tests (`parse_list` / prefs / `configure --apply` with a failing omp install), not a `tests/fixtures/` file — there is no on-disk payload to fixture.

## Provider impact

Configure path for every harness. The failure was omp's install skip becoming fatal when a once-complete saved list was judged partial. Live-checked on Herdr 0.9.0: a saved `claude,codex,grok,agy,opencode,pi,omp` list configured successfully and gained Devin/Muse sidebar rows.

Explicit `--agent omp` (or `only,...` including omp) still fails loudly when omp is absent.